### PR TITLE
Added 10s Display Timeout

### DIFF
--- a/applications/notification/notification_settings_app.c
+++ b/applications/notification/notification_settings_app.c
@@ -46,17 +46,18 @@ const char* const volume_text[VOLUME_COUNT] = {
 };
 const float volume_value[VOLUME_COUNT] = {0.0f, 0.25f, 0.5f, 0.75f, 1.0f};
 
-#define DELAY_COUNT 7
+#define DELAY_COUNT 8
 const char* const delay_text[DELAY_COUNT] = {
     "1s",
     "5s",
+    "10s",
     "15s",
     "30s",
     "60s",
     "90s",
     "120s",
 };
-const uint32_t delay_value[DELAY_COUNT] = {1000, 5000, 15000, 30000, 60000, 90000, 120000};
+const uint32_t delay_value[DELAY_COUNT] = {1000, 5000, 10000, 15000, 30000, 60000, 90000, 120000};
 
 #define VIBRO_COUNT 2
 const char* const vibro_text[VIBRO_COUNT] = {


### PR DESCRIPTION
# What's new

- added 10 Seconds Display Timeout

# Verification 

- Settings > LCD and Notifications > Backlight Time (10s added)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
