### PR TITLE
SubGhz: Fix Sd: being inside the Send button

### DIFF
--- a/lib/subghz/protocols/faac_slh.c
+++ b/lib/subghz/protocols/faac_slh.c
@@ -492,7 +492,7 @@ void subghz_protocol_decoder_faac_slh_get_string(void* context, string_t output)
         "Key:%lX%08lX\r\n"
         "Fix:%08lX    Cnt:%05X\r\n"
         "Hop:%08lX    Btn:%lX\r\n"
-        "Sn:%07lX Sd:%08lX",
+        "Sn:%07lX\nSd:%08lX",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),

--- a/lib/subghz/protocols/keeloq.c
+++ b/lib/subghz/protocols/keeloq.c
@@ -940,7 +940,7 @@ void subghz_protocol_decoder_keeloq_get_string(void* context, string_t output) {
         "Key:%08lX%08lX\r\n"
         "Fix:0x%08lX    Cnt:%04X\r\n"
         "Hop:0x%08lX    Btn:%01lX\r\n"
-        "MF:%s Sd:0x%08lX\r\n",
+        "MF:%s\nSd:0x%08lX\r\n",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         code_found_hi,


### PR DESCRIPTION
# What's new

- This commit fixes Sd:"code" text being inside the Send button

# Verification 

- add manually or record any Keeloq or Faac signal and check send menu

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
