### PR TITLE
feat[freq-analzer]: add stealth modes for frequency analyzer

### DIFF
--- a/applications/subghz/views/subghz_frequency_analyzer.c
+++ b/applications/subghz/views/subghz_frequency_analyzer.c
@@ -53,6 +53,7 @@ typedef struct {
     float rssi;
     float rssi_last;
     float trigger;
+    uint8_t feedback_level;
 } SubGhzFrequencyAnalyzerModel;
 
 void subghz_frequency_analyzer_set_callback(
@@ -142,6 +143,21 @@ void subghz_frequency_analyzer_draw(Canvas* canvas, SubGhzFrequencyAnalyzerModel
     }
     canvas_draw_str(canvas, 9, 42, buffer);
 
+    switch(model->feedback_level) {
+    case 2:
+        canvas_draw_icon(canvas, 128 - 8 - 1, 1, &I_Volup_8x6);
+        break;
+    case 1:
+        canvas_draw_icon(canvas, 128 - 8 - 1, 1, &I_Voldwn_6x6);
+        break;
+    case 0:
+        canvas_draw_icon(canvas, 128 - 8 - 1, 1, &I_Voldwn_6x6);
+        canvas_set_color(canvas, ColorWhite);
+        canvas_draw_box(canvas, 128 - 2 - 1 - 2, 1, 2, 6);
+        canvas_set_color(canvas, ColorBlack);
+        break;
+    }
+
     // Buttons hint
     elements_button_left(canvas, "T-");
     elements_button_right(canvas, "T+");
@@ -175,7 +191,7 @@ bool subghz_frequency_analyzer_input(InputEvent* event, void* context) {
         need_redraw = true;
     }
 
-    if(event->type == InputTypePress && event->key == InputKeyUp) {
+    if(event->type == InputTypePress && event->key == InputKeyDown) {
         if(instance->feedback_level == 0) {
             instance->feedback_level = 2;
         } else {
@@ -187,12 +203,13 @@ bool subghz_frequency_analyzer_input(InputEvent* event, void* context) {
 
     if(need_redraw) {
         SubGhzFrequencyAnalyzer* instance = context;
-        instance->view with_view_model(
+        with_view_model(
             instance->view, (SubGhzFrequencyAnalyzerModel * model) {
                 model->rssi_last = instance->rssi_last;
                 model->frequency_last = instance->frequency_last;
                 model->trigger =
                     subghz_frequency_analyzer_worker_get_trigger_level(instance->worker);
+                model->feedback_level = instance->feedback_level;
                 return true;
             });
     }
@@ -258,6 +275,7 @@ void subghz_frequency_analyzer_pair_callback(void* context, uint32_t frequency, 
             model->frequency = frequency;
             model->frequency_last = instance->frequency_last_vis;
             model->trigger = subghz_frequency_analyzer_worker_get_trigger_level(instance->worker);
+            model->feedback_level = instance->feedback_level;
             return true;
         });
 }


### PR DESCRIPTION
# What's new

Sometimes you don't want the Flipper to make a sound and/or vibrate when it finds a signal. 
This PR allows you to select one of the 3 feedback modes by pressing the <kbd>DOWN</kbd> button:

* `0` - no feedback
* `1` - vibro only
* `2` - vibro and beep (**DEFAULT**)

https://user-images.githubusercontent.com/71837281/186597228-af2cc805-6e76-483c-b3af-bae00c5c01f4.mov

# Verification 

- Open `SubGhz` -> `Frequency Analyzer`
- Press <kbd>DOWN</kbd> ̉ verify that the feedback mode changes (the speaker icon in the top right should change)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
