### PR TITLE
change update the Battery info

### DIFF
--- a/applications/desktop/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/desktop/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -41,6 +41,7 @@ const uint32_t displayBatteryPercentage_value[BATTERY_VIEW_COUNT] = {0, 1, 2, 3,
 static void desktop_settings_scene_start_var_list_enter_callback(void* context, uint32_t index) {
     DesktopSettingsApp* app = context;
     view_dispatcher_send_custom_event(app->view_dispatcher, index);
+
 }
 
 static void desktop_settings_scene_start_battery_view_changed(VariableItem* item) {

--- a/applications/power/power_service/power.c
+++ b/applications/power/power_service/power.c
@@ -171,11 +171,6 @@ static void power_check_charging_state(Power* power) {
 
 static bool power_update_info(Power* power) {
     PowerInfo info;
-	
-    DesktopSettings* settings = malloc(sizeof(DesktopSettings));
-    LOAD_DESKTOP_SETTINGS(settings);
-    power->displayBatteryPercentage = settings->displayBatteryPercentage;
-    free(settings);
 
     info.gauge_is_ok = furi_hal_power_gauge_is_ok();
     info.charge = furi_hal_power_get_pct();
@@ -256,6 +251,11 @@ int32_t power_srv(void* p) {
     Power* power = power_alloc();
     power_update_info(power);
     furi_record_create(RECORD_POWER, power);
+	
+    DesktopSettings* settings = malloc(sizeof(DesktopSettings));
+    LOAD_DESKTOP_SETTINGS(settings);
+    power->displayBatteryPercentage = settings->displayBatteryPercentage;
+    free(settings);
 
     while(1) {
         // Update data from gauge and charger
@@ -271,7 +271,13 @@ int32_t power_srv(void* p) {
         power_check_battery_level_change(power);
 
         // Update battery view port
-        if(need_refresh) view_port_update(power->battery_view_port);
+        if(need_refresh) {
+            DesktopSettings* settings = malloc(sizeof(DesktopSettings));
+            LOAD_DESKTOP_SETTINGS(settings);
+            power->displayBatteryPercentage = settings->displayBatteryPercentage;
+            free(settings);
+            view_port_update(power->battery_view_port);
+        }
 
         // Check OTG status and disable it in case of fault
         if(furi_hal_power_is_otg_enabled()) {


### PR DESCRIPTION
# What's new

- Updated to check desktop settings when a refresh is needed or boot; instead of constantly. Changing battery type should now require a restart to take effect immediately - Maybe we can make some "Save" function into the settings to trigger the the update? 
# Verification 

- [ Describe how to verify changes ]

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
