### PR TITLE
Arkanoid: rand_range, remove temp number

### DIFF
--- a/applications/arkanoid/arkanoid_game.c
+++ b/applications/arkanoid/arkanoid_game.c
@@ -67,8 +67,7 @@ static const NotificationSequence sequence_short_sound = {
 
 // generate number in range [min,max)
 int rand_range(int min, int max) {
-    int number = min + rand() % (max - min);
-    return number;
+    return min + rand() % (max - min);
 }
 
 void move_ball(Canvas* canvas, ArkanoidState* st) {


### PR DESCRIPTION
# What's new

- int rand_range used int number to generate and store the random number and then return it
- remove int number and return a generated random number directly

# Verification 

- check code

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
