### PR TITLE
random uid for detect reader each time NFC app exists and comes back

### DIFF
--- a/lib/nfc/helpers/reader_analyzer.c
+++ b/lib/nfc/helpers/reader_analyzer.c
@@ -3,6 +3,7 @@
 #include <lib/nfc/protocols/nfc_util.h>
 #include <lib/nfc/protocols/mifare_classic.h>
 #include <m-array.h>
+#include <furi_hal_random.h>
 
 #include "mfkey32.h"
 #include "nfc_debug_pcap.h"
@@ -38,7 +39,7 @@ struct ReaderAnalyzer {
     NfcDebugPcap* pcap;
 };
 
-const FuriHalNfcDevData reader_analyzer_nfc_data[] = {
+static FuriHalNfcDevData reader_analyzer_nfc_data[] = { //XXX
     [ReaderAnalyzerNfcDataMfClassic] =
         {.sak = 0x08,
          .atqa = {0x44, 0x00},
@@ -99,7 +100,8 @@ int32_t reader_analyzer_thread(void* context) {
 
 ReaderAnalyzer* reader_analyzer_alloc() {
     ReaderAnalyzer* instance = malloc(sizeof(ReaderAnalyzer));
-
+    reader_analyzer_nfc_data[ReaderAnalyzerNfcDataMfClassic].cuid = rand(); //XXX
+    furi_hal_random_fill_buf((uint8_t*) &reader_analyzer_nfc_data[ReaderAnalyzerNfcDataMfClassic].uid, 7);
     instance->nfc_data = reader_analyzer_nfc_data[ReaderAnalyzerNfcDataMfClassic];
     instance->alive = false;
     instance->stream =


### PR DESCRIPTION
# What's new

- UIDs are now random for detect reader. this is useful for evading detection of a flipper as well as getting reader keys that are derived from the UID

# Verification 

- use detect reader on another flipper, proxmark 3 or any other NFC reader and read its UID. every time you exit the NFC app, go back in and use detect reader the UID should be different 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
