### PR TITLE
Update setting_user

### DIFF
--- a/assets/resources/subghz/assets/setting_user
+++ b/assets/resources/subghz/assets/setting_user
@@ -44,6 +44,7 @@ Frequency: 464000000
 Frequency: 779000000
 Frequency: 868350000
 Frequency: 868400000
+Frequency: 868950000
 Frequency: 906400000
 Frequency: 915000000
 Frequency: 925000000


### PR DESCRIPTION
Adding the 868.95 frequency for the Sommer device, the `Sommer(fsk476)` protocol was recently added but Flipper could not read it until now.

# What's new

- Added 868.95 frequency for Sommer devices

# Verification 

- x

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
