### PR TITLE
SubGhz: Enable backlight on new signal

### DIFF
--- a/applications/main/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver.c
@@ -6,13 +6,17 @@
 const NotificationSequence subghz_sequence_rx = {
     &message_green_255,
 
+    &message_display_backlight_on,
+
     &message_vibro_on,
     &message_note_c6,
     &message_delay_50,
     &message_sound_off,
     &message_vibro_off,
 
-    &message_delay_50,
+    &message_delay_1000,
+
+    &message_display_backlight_off,    
     NULL,
 };
 

--- a/applications/main/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver.c
@@ -13,17 +13,12 @@ const NotificationSequence subghz_sequence_rx = {
     &message_delay_50,
     &message_sound_off,
     &message_vibro_off,
-
-    &message_delay_1000,
-
-    &message_display_backlight_off,    
+    
     NULL,
 };
 
 const NotificationSequence subghz_sequence_rx_locked = {
     &message_green_255,
-
-    &message_display_backlight_on,
 
     &message_vibro_on,
     &message_note_c6,
@@ -31,9 +26,6 @@ const NotificationSequence subghz_sequence_rx_locked = {
     &message_sound_off,
     &message_vibro_off,
 
-    &message_delay_500,
-
-    &message_display_backlight_off,
     NULL,
 };
 

--- a/applications/main/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver.c
@@ -13,12 +13,15 @@ const NotificationSequence subghz_sequence_rx = {
     &message_delay_50,
     &message_sound_off,
     &message_vibro_off,
-    
+
+    &message_delay_50,
     NULL,
 };
 
 const NotificationSequence subghz_sequence_rx_locked = {
     &message_green_255,
+
+    &message_display_backlight_on,
 
     &message_vibro_on,
     &message_note_c6,
@@ -26,6 +29,9 @@ const NotificationSequence subghz_sequence_rx_locked = {
     &message_sound_off,
     &message_vibro_off,
 
+    &message_delay_500,
+
+    &message_display_backlight_off,
     NULL,
 };
 


### PR DESCRIPTION
# What's new

- Turn on backlight when new signal is received, uses system backlight timer

# Verification 

- open subghz > read, wait till display turns off, receive a signal, the display will turn on for a period which was set in system settings

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
