### PR TITLE
Allow the RFID protocol menu to wrap

### DIFF
--- a/applications/plugins/flipfrid/scene/flipfrid_scene_entrypoint.c
+++ b/applications/plugins/flipfrid/scene/flipfrid_scene_entrypoint.c
@@ -116,11 +116,15 @@ void flipfrid_scene_entrypoint_on_event(FlipFridEvent event, FlipFridState* cont
             case InputKeyLeft:
                 if(context->menu_proto_index > EM4100) {
                     context->menu_proto_index--;
+                } else if(context->menu_proto_index == EM4100) {
+                    context->menu_proto_index = H10301;
                 }
                 break;
             case InputKeyRight:
                 if(context->menu_proto_index < H10301) {
                     context->menu_proto_index++;
+                } else if(context->menu_proto_index == H10301) {
+                    context->menu_proto_index = EM4100;
                 }
                 break;
             case InputKeyOk:


### PR DESCRIPTION
# What's new

Allow the RFID protocol menu to wrap.

# Verification 

- Open the RFID Fuzzer
- Hit the Right and Left keys to verify the protocol menu wraps around; from last to first, and first to last

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
