### PR TITLE
Change tar format to pax for better compatibility

### DIFF
--- a/scripts/update.py
+++ b/scripts/update.py
@@ -20,7 +20,7 @@ class Main(App):
 
     #  No compression, plain tar
     RESOURCE_TAR_MODE = "w:"
-    RESOURCE_TAR_FORMAT = tarfile.USTAR_FORMAT
+    RESOURCE_TAR_FORMAT = tarfile.PAX_FORMAT
     RESOURCE_FILE_NAME = "resources.tar"
 
     WHITELISTED_STACK_TYPES = set(


### PR DESCRIPTION
# What's new

- This pull request fixes building firmware via fbt on modern MacOS computers

# Verification 

On MacOS 12.6 Monterey with Python 3.10:

- Run `./fbt COMPACT=1 DEBUG=0 updater_package copro_dist` on fresh `dev`
- An error will pop up:

```
...

  File "flipperzero-firmware/toolchain/x86_64-darwin/python/lib/python3.9/tarfile.py", line 946, in _create_header
    itn(info.get("uid", 0), 8, format),
  File "flipperzero-firmware/toolchain/x86_64-darwin/python/lib/python3.9/tarfile.py", line 217, in itn
    raise ValueError("overflow in number field")
ValueError: overflow in number field
scons: *** [dist_updater_package] Error 1
********** ERRORS **********
Failed building dist_updater_package: Error 1
```

- Run `./fbt COMPACT=1 DEBUG=0 updater_package copro_dist` on this branch
- There must be no errors



# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
