### PR TITLE
Move Misc apps to Tools

### DIFF
--- a/applications/debug/uart_echo/application.fam
+++ b/applications/debug/uart_echo/application.fam
@@ -8,5 +8,5 @@ App(
     stack_size=2 * 1024,
     order=70,
     fap_icon="uart_10px.png",
-    fap_category="Misc",
+    fap_category="Tools",
 )

--- a/applications/plugins/barcode_generator/application.fam
+++ b/applications/plugins/barcode_generator/application.fam
@@ -11,5 +11,5 @@ App(
     stack_size=1 * 1024,
     order=50,
     fap_icon="barcode_10px.png",
-    fap_category="Misc",
+    fap_category="Tools",
 )

--- a/applications/plugins/multi_converter/application.fam
+++ b/applications/plugins/multi_converter/application.fam
@@ -8,5 +8,5 @@ App(
     stack_size=1 * 1024,
     order=19,
     fap_icon="converter_10px.png",
-    fap_category="Misc",
+    fap_category="Tools",
 )

--- a/applications/plugins/totp/application.fam
+++ b/applications/plugins/totp/application.fam
@@ -14,6 +14,6 @@ App(
     ],
     stack_size=2 * 1024,
     order=20,
-    fap_category="Misc",
+    fap_category="Tools",
     fap_icon="totp_10px.png"
 )

--- a/applications/plugins/usbkeyboard/application.fam
+++ b/applications/plugins/usbkeyboard/application.fam
@@ -10,5 +10,5 @@ App(
     ],
     order=60,
     fap_icon="usb_keyboard_10px.png",
-    fap_category="Misc",
+    fap_category="Tools",
 )


### PR DESCRIPTION
# What's new

- Moved USB Keyboard, Multi Converter, Barcode Generator, and UART Echo apps from Misc folder to Tools for better organization

# Verification 

- Apps are located in the correct directory after installation and run properly

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
