### PR TITLE
Feature: lock device with pin by long pressing up button

### DIFF
--- a/applications/services/desktop/scenes/desktop_scene_main.c
+++ b/applications/services/desktop/scenes/desktop_scene_main.c
@@ -9,6 +9,7 @@
 #include "../views/desktop_view_main.h"
 #include "desktop_scene.h"
 #include "desktop_scene_i.h"
+#include "../helpers/pin_lock.h"
 
 #define TAG "DesktopSrv"
 
@@ -93,6 +94,18 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
 
         case DesktopMainEventOpenDebug:
             scene_manager_next_scene(desktop->scene_manager, DesktopSceneDebug);
+            consumed = true;
+            break;
+
+        case DesktopMainEventLock:
+            if(desktop->settings.pin_code.length > 0) {
+                scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 1);
+                desktop_pin_lock(&desktop->settings);
+                desktop_lock(desktop);
+            } else {
+                scene_manager_set_scene_state(desktop->scene_manager, DesktopSceneLockMenu, 0);
+                desktop_lock(desktop);
+            }
             consumed = true;
             break;
 

--- a/applications/services/desktop/views/desktop_events.h
+++ b/applications/services/desktop/views/desktop_events.h
@@ -9,6 +9,7 @@ typedef enum {
     DesktopMainEventOpenDebug,
     DesktopMainEventOpenPassport,
     DesktopMainEventOpenPowerOff,
+    DesktopMainEventLock,
 
     DesktopMainEventOpenGameMenu,
 

--- a/applications/services/desktop/views/desktop_view_main.c
+++ b/applications/services/desktop/views/desktop_view_main.c
@@ -67,6 +67,8 @@ bool desktop_main_input_callback(InputEvent* event, void* context) {
                 main_view->callback(DesktopMainEventOpenDebug, main_view->context);
             } else if(event->key == InputKeyLeft) {
                 main_view->callback(DesktopMainEventOpenFavoriteSecondary, main_view->context);
+            } else if(event->key == InputKeyUp) {
+                main_view->callback(DesktopMainEventLock, main_view->context);
             }
         }
     } else {


### PR DESCRIPTION
# What's new

New device lock shortcut - long press up button on desktop to: lock device with PIN if enabled, simple lock otherwise.

# Verification 

- Set PIN
- Return to main screen
- Press and hold UP button
- Device must lock with pin
- Remove PIN
- Return to main screen
- Press and hold UP button
-  Device must lock with simple lock

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
