### PR TITLE
Minesweeper: Set cursor to initial position on death

### DIFF
--- a/applications/plugins/minesweeper/minesweeper.c
+++ b/applications/plugins/minesweeper/minesweeper.c
@@ -217,6 +217,10 @@ static bool game_lost(Minesweeper* minesweeper_state) {
 
     dialog_message_set_icon(message, NULL, 0, 10);
 
+    // Set cursor to initial position
+    minesweeper_state->cursor_x = 0;
+    minesweeper_state->cursor_y = 0;
+
     NotificationApp* notifications = furi_record_open(RECORD_NOTIFICATION);
     notification_message(notifications, &sequence_set_vibro_on);
     furi_record_close(RECORD_NOTIFICATION);


### PR DESCRIPTION
# What's new

- after dying in minesweeper and restarting the cursor was kept on the death position, this pr always sets cursor to 0,0 on death

# Verification 

- die in random place in Minesweeper and you will respawn at default postion

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
