### PR TITLE
Power: remove % sign from desktop and center numbers

### DIFF
--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -12,10 +12,8 @@ void power_draw_battery_callback(Canvas* canvas, void* context) {
     canvas_draw_icon(canvas, 0, 0, &I_Battery_26x8);
 
     if(power->info.gauge_is_ok) {
-        char batteryPercentile[5];
+        char batteryPercentile[4];
         snprintf(batteryPercentile, sizeof(batteryPercentile), "%d", power->info.charge);
-        strcat(batteryPercentile, "%");
-
         if((power->displayBatteryPercentage == 1) &&
            (power->state !=
             PowerStateCharging)) { //if display battery percentage, black background white text
@@ -23,14 +21,14 @@ void power_draw_battery_callback(Canvas* canvas, void* context) {
             canvas_set_color(canvas, ColorBlack);
             canvas_draw_box(canvas, 1, 1, 22, 6);
             canvas_set_color(canvas, ColorWhite);
-            canvas_draw_str_aligned(canvas, 12, 4, AlignCenter, AlignCenter, batteryPercentile);
+            canvas_draw_str_aligned(canvas, 11, 4, AlignCenter, AlignCenter, batteryPercentile);
         } else if(
             (power->displayBatteryPercentage == 2) &&
             (power->state !=
              PowerStateCharging)) { //if display inverted percentage, white background black text
             canvas_set_font(canvas, FontBatteryPercent);
             canvas_set_color(canvas, ColorBlack);
-            canvas_draw_str_aligned(canvas, 12, 4, AlignCenter, AlignCenter, batteryPercentile);
+            canvas_draw_str_aligned(canvas, 11, 4, AlignCenter, AlignCenter, batteryPercentile);
         } else if(
             (power->displayBatteryPercentage == 3) &&
             (power->state != PowerStateCharging)) { //Retro style segmented display, 3 parts


### PR DESCRIPTION
# What's new

- show battery percentage without % on desktop

# Verification 

- settings -> desktop -> Battery view to % or Inv. %

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
