### PR TITLE
Increase pilars line width to improve visibility

### DIFF
--- a/applications/plugins/flappy_bird/flappy_bird.c
+++ b/applications/plugins/flappy_bird/flappy_bird.c
@@ -182,10 +182,34 @@ static void flappy_game_render_callback(Canvas* const canvas, void* ctx) {
                     canvas, pilar->point.x, pilar->point.y, FLAPPY_GAB_WIDTH, pilar->height);
 
                 canvas_draw_frame(
+                    canvas, pilar->point.x + 1, pilar->point.y, FLAPPY_GAB_WIDTH, pilar->height);
+
+                canvas_draw_frame(
+                    canvas,
+                    pilar->point.x + 2,
+                    pilar->point.y,
+                    FLAPPY_GAB_WIDTH - 1,
+                    pilar->height);
+
+                canvas_draw_frame(
                     canvas,
                     pilar->point.x,
                     pilar->point.y + pilar->height + FLAPPY_GAB_HEIGHT,
                     FLAPPY_GAB_WIDTH,
+                    FLIPPER_LCD_HEIGHT - pilar->height - FLAPPY_GAB_HEIGHT);
+
+                canvas_draw_frame(
+                    canvas,
+                    pilar->point.x + 1,
+                    pilar->point.y + pilar->height + FLAPPY_GAB_HEIGHT,
+                    FLAPPY_GAB_WIDTH - 1,
+                    FLIPPER_LCD_HEIGHT - pilar->height - FLAPPY_GAB_HEIGHT);
+
+                canvas_draw_frame(
+                    canvas,
+                    pilar->point.x + 2,
+                    pilar->point.y + pilar->height + FLAPPY_GAB_HEIGHT,
+                    FLAPPY_GAB_WIDTH - 1,
                     FLIPPER_LCD_HEIGHT - pilar->height - FLAPPY_GAB_HEIGHT);
             }
         }


### PR DESCRIPTION
# What's new

- Pilars on Flappy Bird have wider vertical lines to improve visibility on actual hardware

# Verification 

- Open Flappy Bird
- Vertical lines of pilars should be more visible on an actual Flipper Zero

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
