### PR TITLE
Wifi Marauder: make "add random" not overlap > symbol

### DIFF
--- a/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_start.c
+++ b/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_start.c
@@ -26,7 +26,7 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
     {"View Log from", {"start", "end"}, 2, {"", ""}, NO_ARGS, FOCUS_CONSOLE_TOGGLE, NO_TIP},
     {"Scan AP", {""}, 1, {"scanap"}, NO_ARGS, FOCUS_CONSOLE_END, SHOW_STOPSCAN_TIP},
     {"SSID",
-     {"add random", "add name", "remove"},
+     {"add rand", "add name", "remove"},
      3,
      {"ssid -a -g", "ssid -a -n", "ssid -r"},
      INPUT_ARGS,


### PR DESCRIPTION
# What's new

- use "add rand" instead of "add random" to not overlap > symbol

# Verification 

- open wifi marauder, ssid add random was overlapped by > symbol, this made the m look ugly

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
