### PR TITLE
Fix link to "TOTP (Authenticator) config description"

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -135,7 +135,7 @@ Games:
 
 ## [- Configure Sub-GHz Remote App](https://github.com/DarkFlippers/unleashed-firmware/blob/dev/documentation/SubGHzRemotePlugin.md)
 
-## [- TOTP (Authenticator) config description](https://github.com/akopachov/flipper-zero_authenticator/blob/master/.github/conf-file_description.md)
+## [- TOTP (Authenticator) config description](https://github.com/akopachov/flipper-zero_authenticator/blob/master/docs/conf-file_description.md)
 
 ## [- Barcode Generator](https://github.com/DarkFlippers/unleashed-firmware/blob/dev/documentation/BarcodeGenerator.md)
 


### PR DESCRIPTION
# What's new

- Fix link to "TOTP (Authenticator) config description" in Readme

# Verification 

- Click new link (<https://github.com/akopachov/flipper-zero_authenticator/blob/master/docs/conf-file_description.md>)

# Checklist (For Reviewer)

- [-] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [-] I've built this code, uploaded it to the device and verified feature/bugfix
