### PR TITLE
Wifi marauder BT menus option

### DIFF
--- a/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_start.c
+++ b/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_start.c
@@ -58,7 +58,7 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
      FOCUS_CONSOLE_END,
      SHOW_STOPSCAN_TIP},
     {"Sniff",
-     {"beacon", "deauth", "esp", "pmkid", "probe", "pwn", "raw", "bt", "cc"},
+     {"beacon", "deauth", "esp", "pmkid", "probe", "pwn", "raw", "bt", "skim"},
      9,
      {"sniffbeacon", "sniffdeauth", "sniffesp", "sniffpmkid", "sniffprobe", "sniffpwn", "sniffraw", "sniffbt", "sniffskim"},
      NO_ARGS,

--- a/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_start.c
+++ b/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_start.c
@@ -1,3 +1,5 @@
+//** Includes sniffbt and sniffskim for compatible ESP32-WROOM hardware.
+//wifi_marauder_app_i.h also changed **//
 #include "../wifi_marauder_app_i.h"
 
 // For each command, define whether additional arguments are needed
@@ -10,7 +12,7 @@ typedef enum { FOCUS_CONSOLE_END = 0, FOCUS_CONSOLE_START, FOCUS_CONSOLE_TOGGLE 
 #define SHOW_STOPSCAN_TIP (true)
 #define NO_TIP (false)
 
-#define MAX_OPTIONS (7)
+#define MAX_OPTIONS (9)
 typedef struct {
     const char* item_string;
     const char* options_menu[MAX_OPTIONS];
@@ -56,9 +58,9 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
      FOCUS_CONSOLE_END,
      SHOW_STOPSCAN_TIP},
     {"Sniff",
-     {"beacon", "deauth", "esp", "pmkid", "probe", "pwn", "raw"},
-     7,
-     {"sniffbeacon", "sniffdeauth", "sniffesp", "sniffpmkid", "sniffprobe", "sniffpwn", "sniffraw"},
+     {"beacon", "deauth", "esp", "pmkid", "probe", "pwn", "raw", "bt", "cc"},
+     9,
+     {"sniffbeacon", "sniffdeauth", "sniffesp", "sniffpmkid", "sniffprobe", "sniffpwn", "sniffraw", "sniffbt", "sniffskim"},
      NO_ARGS,
      FOCUS_CONSOLE_END,
      SHOW_STOPSCAN_TIP},

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
@@ -1,3 +1,5 @@
+//** Includes sniffbt and sniffskim for compatible ESP32-WROOM hardware.
+// wifi_marauder_scene_start.c also changed **//
 #pragma once
 
 #include "wifi_marauder_app.h"


### PR DESCRIPTION
# What's new

- Added sniffbt and sniffskim as menu option as sniff -> bt and sniff -> cc

# Verification 

- You can see them in the menu and test functionality with ESP32-WROOM flashed via SkeletonMan03's FZEasyMarauderFlash

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
