### PR TITLE
Discord in README open in new tab

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,7 +16,7 @@ Please help us implement emulation for all subghz dynamic (rolling code) protoco
 <br>
 Our Discord Community:
 <br>
-<a href="https://discord.unleashedflip.com"><img src="https://discordapp.com/api/guilds/937479784148115456/widget.png?style=banner4" alt="Unofficial Discord Community"></a>
+<a href="https://discord.unleashedflip.com"><img src="https://discordapp.com/api/guilds/937479784148115456/widget.png?style=banner4" alt="Unofficial Discord Community" target="_blank"></a>
 
 <br>
 <br>


### PR DESCRIPTION
Changes the discord link in the readme to open in a new tab instead of overwrite the current tab

# What's new

- Changed README
- 
# Verification 

- Click the discord link in the readme

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
