### PR TITLE
[FAP] htu21d falsely reading temp as humidity

### DIFF
--- a/applications/plugins/htu21d_temp_sensor/temperature_sensor.c
+++ b/applications/plugins/htu21d_temp_sensor/temperature_sensor.c
@@ -113,7 +113,7 @@ static bool temperature_sensor_fetch_data(double* temperature, double* humidity)
         *temperature = (float)(adc_raw * 175.72 / 65536.00) - 46.85;
 
         // Fetch humidity
-        ret = temperature_sensor_cmd((uint8_t)HTU21D_CMD_TEMPERATURE, buffer, 2);
+        ret = temperature_sensor_cmd((uint8_t)HTU21D_CMD_HUMIDITY, buffer, 2);
 
         if(ret) {
             // Calculate humidity


### PR DESCRIPTION
compiled and tested by blowing onto the sensor.

fixes #174

# What's new

- reading htu21d humidity correctly

# Verification 

- run htu21d fap with sensor attached to i2c and blow onto the sensor to see humidity rising

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
