### PR TITLE
SubGhz: Allow setting RSSI trigger to beggining

### DIFF
--- a/applications/main/subghz/views/subghz_frequency_analyzer.c
+++ b/applications/main/subghz/views/subghz_frequency_analyzer.c
@@ -169,7 +169,7 @@ void subghz_frequency_analyzer_draw(Canvas* canvas, SubGhzFrequencyAnalyzerModel
     // RSSI
     canvas_draw_str(canvas, 33, 62, "RSSI");
     subghz_frequency_analyzer_draw_rssi(
-        canvas, model->rssi, model->rssi_last, model->trigger, 57, 58);
+        canvas, model->rssi, model->rssi_last, model->trigger, 56, 57);
 
     // Last detected frequency
     subghz_frequency_analyzer_history_frequency_draw(canvas, model);


### PR DESCRIPTION
# What's new

- allow setting RSSI trigger to beggining in Frequency analyzer

# Verification 

- move trigger to the left and it will be perfectly at start

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
