### PR TITLE
add EAN-13 support

### DIFF
--- a/applications/plugins/barcode_generator/barcode_generator.h
+++ b/applications/plugins/barcode_generator/barcode_generator.h
@@ -1,7 +1,8 @@
 #define BARCODE_HEIGHT 50
 #define BARCODE_Y_START 3
 #define BARCODE_TEXT_OFFSET 9
-#define NUMBER_OF_BARCODE_TYPES 2
+#define BARCODE_MAX_LENS 13
+#define NUMBER_OF_BARCODE_TYPES 3
 #define MENU_INDEX_VIEW 0
 #define MENU_INDEX_EDIT 1
 #define MENU_INDEX_PARITY 2
@@ -23,14 +24,27 @@ typedef enum {
     MenuMode,
 } Mode;
 
+typedef enum {
+    BarEncodingTypeLeft,
+    BarEncodingTypeRight,
+    BarEncodingTypeG,
+} BarEncodingType;
+
+typedef enum {
+    BarTypeEAN8,
+    BarTypeUPCA,
+    BarTypeEAN13,
+} BarType;
+
 typedef struct {
     char* name;
     int numberOfDigits;
     int startPos;
+    BarType bartype;
 } BarcodeType;
 
 typedef struct {
-    int barcodeNumeral[12]; //The current barcode number
+    int barcodeNumeral[BARCODE_MAX_LENS]; //The current barcode number
     int editingIndex; //The index of the editing symbol
     int menuIndex; //The index of the menu cursor
     Mode mode; //View, edit or menu
@@ -49,4 +63,17 @@ static const int DIGITS[10][4] = {
     {1, 3, 1, 2},
     {1, 2, 1, 3},
     {3, 1, 1, 2},
+};
+
+static const uint8_t EAN13ENCODE[10] = {
+    0b000000,
+    0b110100,
+    0b101100,
+    0b011100,
+    0b110010,
+    0b100110,
+    0b001110,
+    0b101010,
+    0b011010,
+    0b010110,
 };


### PR DESCRIPTION
# What's new

Barcode generator: add EAN-13 support
Issues:[230](https://github.com/DarkFlippers/unleashed-firmware/issues/230)

# Verification 

Run barcode generator. 
In menu, set type EAN-13. 
Use the edit function to set the first digit other than 0. 
Scan the barcode.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
