### PR TITLE
Fix for solitaire card placement bug

### DIFF
--- a/applications/plugins/solitaire/solitaire.c
+++ b/applications/plugins/solitaire/solitaire.c
@@ -255,6 +255,10 @@ bool place_on_top(Card* where, Card what) {
         int8_t b_letter = (int8_t)what.character;
         if(a_letter == 12) a_letter = -1;
         if(b_letter == 12) b_letter = -1;
+
+        if(where->disabled && b_letter != -1)
+            return false;
+
         if((a_letter + 1) == b_letter) {
             where->disabled = what.disabled;
             where->pip = what.pip;


### PR DESCRIPTION
# What's new

- fixed card logic to not allow placing ♠3 on an empty place at the top.

# Verification 

- Try to place ♠3 on one of the empty cells at the top. Originally the game allowed to place this card there.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
