### PR TITLE
feat[infrared]: allow disabling automatic signal decoding

### DIFF
--- a/applications/main/infrared/scenes/infrared_scene_start.c
+++ b/applications/main/infrared/scenes/infrared_scene_start.c
@@ -3,6 +3,7 @@
 enum SubmenuIndex {
     SubmenuIndexUniversalRemotes,
     SubmenuIndexLearnNewRemote,
+    SubmenuIndexLearnNewRemoteRaw,
     SubmenuIndexSavedRemotes,
     SubmenuIndexDebug
 };
@@ -38,6 +39,12 @@ void infrared_scene_start_on_enter(void* context) {
 
     if(infrared->app_state.is_debug_enabled) {
         submenu_add_item(
+            submenu,
+            "Learn New Remote RAW",
+            SubmenuIndexLearnNewRemoteRaw,
+            infrared_scene_start_submenu_callback,
+            infrared);
+        submenu_add_item(
             submenu, "Debug", SubmenuIndexDebug, infrared_scene_start_submenu_callback, infrared);
     }
 
@@ -61,7 +68,15 @@ bool infrared_scene_start_on_event(void* context, SceneManagerEvent event) {
         if(submenu_index == SubmenuIndexUniversalRemotes) {
             scene_manager_next_scene(scene_manager, InfraredSceneUniversal);
             consumed = true;
-        } else if(submenu_index == SubmenuIndexLearnNewRemote) {
+        } else if(
+            submenu_index == SubmenuIndexLearnNewRemote ||
+            submenu_index == SubmenuIndexLearnNewRemoteRaw) {
+
+            // enable automatic signal decoding if "Learn New Remote"
+            // disable automatic signal decoding if "Learn New Remote (RAW)"
+            infrared_worker_rx_enable_signal_decoding(
+                infrared->worker, submenu_index == SubmenuIndexLearnNewRemote);
+
             infrared->app_state.is_learning_new_remote = true;
             scene_manager_next_scene(scene_manager, InfraredSceneLearn);
             consumed = true;


### PR DESCRIPTION
# What's new

Adds a new menu item `Lean New Remote RAW` in the Infrared App, which is only visible when the debug mode is enabled in the settings. When used, automatic decoding of signals is prevented -> you always get a raw capture.

https://user-images.githubusercontent.com/71837281/211199190-d4621c9a-4258-43e9-a181-a61327746d47.mov

# Verification 

- Verify that debug mode is disabled (`Settings -> System -> Debug -> OFF`)
- Open the `Infrared` app
- `Learn New Remote RAW` should be missing
- Verify that debug mode is enabled (`Settings -> System -> Debug -> ON`)
- Open the `Infrared` app
- `Learn New Remote RAW` should be available
- Use `Learn New Remote` and verify that signals are decoded
- Use `Learn New Remote RAW` and verify that signals are not decoded

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
