### PR TITLE
Solitaire and Blackjack now affect Flipper's level

### DIFF
--- a/applications/plugins/blackjack/blackjack.c
+++ b/applications/plugins/blackjack/blackjack.c
@@ -278,6 +278,7 @@ void dealer_tick(GameState* game_state) {
 
     if(dealer_score >= DEALER_MAX) {
         if(dealer_score > 21 || dealer_score < player_score) {
+            DOLPHIN_DEED(DolphinDeedPluginGameWin);
             enqueue(
                 &(game_state->queue_state),
                 game_state,
@@ -570,6 +571,7 @@ int32_t blackjack_app(void* p) {
     gui_add_view_port(gui, view_port, GuiLayerFullscreen);
 
     AppEvent event;
+    DOLPHIN_DEED(DolphinDeedPluginGameStart);
 
     for(bool processing = true; processing;) {
         FuriStatus event_status = furi_message_queue_get(event_queue, &event, 100);

--- a/applications/plugins/solitaire/solitaire.c
+++ b/applications/plugins/solitaire/solitaire.c
@@ -274,6 +274,7 @@ void tick(GameState* game_state, NotificationApp* notification) {
     if(game_state->state == GameStatePlay) {
         if(game_state->top_cards[0].character == 11 && game_state->top_cards[1].character == 11 &&
            game_state->top_cards[2].character == 11 && game_state->top_cards[3].character == 11) {
+            DOLPHIN_DEED(DolphinDeedPluginGameWin);
             game_state->state = GameStateAnimate;
             return;
         }
@@ -487,6 +488,8 @@ int32_t solitaire_app(void* p) {
     gui_add_view_port(gui, view_port, GuiLayerFullscreen);
 
     AppEvent event;
+    DOLPHIN_DEED(DolphinDeedPluginGameStart);
+
     for(bool processing = true; processing;) {
         FuriStatus event_status = furi_message_queue_get(event_queue, &event, 150);
         GameState* localstate = (GameState*)acquire_mutex_block(&state_mutex);


### PR DESCRIPTION
# What's new

- Both games implemented the DOLPHIN_DEED feature

# Verification 

- Take a note on Flipper's current level, play some round in the games, then check the level again.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
