### PR TITLE
battery info temperature shown in C or F based on settings

### DIFF
--- a/applications/settings/power_settings_app/views/battery_info.c
+++ b/applications/settings/power_settings_app/views/battery_info.c
@@ -2,6 +2,7 @@
 #include <furi.h>
 #include <gui/elements.h>
 #include <assets_icons.h>
+#include <locale/locale.h>
 
 #define LOW_CHARGE_THRESHOLD 10
 #define HIGH_DRAIN_CURRENT_THRESHOLD 100
@@ -101,7 +102,15 @@ static void battery_info_draw_callback(Canvas* canvas, void* context) {
     char health[10];
 
     snprintf(batt_level, sizeof(batt_level), "%lu%%", (uint32_t)model->charge);
-    snprintf(temperature, sizeof(temperature), "%lu C", (uint32_t)model->gauge_temperature);
+    if(locale_get_measurement_unit() == LocaleMeasurementUnitsMetric) {
+        snprintf(temperature, sizeof(temperature), "%lu C", (uint32_t)model->gauge_temperature);
+    } else {
+        snprintf(
+            temperature,
+            sizeof(temperature),
+            "%lu F",
+            (uint32_t)locale_celsius_to_fahrenheit(model->gauge_temperature));
+    }
     snprintf(
         voltage,
         sizeof(voltage),


### PR DESCRIPTION
# What's new

- If Setttings->System->Units is set to Imperial, the temperature will be displayed in Fahrenheit instead of Celsius.

# Verification 

- Go to Setttings->System->Units. Set units to Imperial.
- Go to Settings->Power->Battery Info

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
