### PR TITLE
Fix CTRL-SHIFT in mousejacker

### DIFF
--- a/applications/plugins/mousejacker/mousejacker_ducky.c
+++ b/applications/plugins/mousejacker/mousejacker_ducky.c
@@ -291,7 +291,7 @@ static bool mj_process_ducky_line(
         strncmp(line_tmp, "CONTROL-SHIFT", strlen("CONTROL-SHIFT")) == 0) {
         line_tmp = &line_tmp[mj_ducky_get_command_len(line_tmp) + 1];
         if(!mj_get_ducky_key(line_tmp, strlen(line_tmp), &dk)) return false;
-        send_hid_packet(handle, addr, addr_size, rate, dk.mod | 4 | 2, dk.hid, plugin_state);
+        send_hid_packet(handle, addr, addr_size, rate, dk.mod | 1 | 2, dk.hid, plugin_state);
         return true;
     } else if(
         strncmp(line_tmp, "CTRL", strlen("CTRL")) == 0 ||


### PR DESCRIPTION
# What's new

- [ Describe changes here ]
Fixed a tiny bug in the nrf24 mousejacker that made CTRL-SHIFT behave as ALT-SHIFT.

# Verification 

- [ Describe how to verify changes ]
Try to do `CTRL-SHIFT i` in the browser using this and the previous version
# Checklist (For Reviewer)

- [*] PR has description of feature/bug
- [*] Description contains actions to verify feature/bugfix
- [*] I've built this code, uploaded it to the device and verified feature/bugfix
