### PR TITLE
Fix file browser update issues

### DIFF
--- a/applications/main/archive/helpers/archive_browser.c
+++ b/applications/main/archive/helpers/archive_browser.c
@@ -58,8 +58,9 @@ static void archive_list_load_cb(void* context, uint32_t list_load_offset) {
 }
 
 static void
-    archive_list_item_cb(void* context, FuriString* item_path, bool is_folder, bool is_last) {
+    archive_list_item_cb(void* context, FuriString* item_path, uint32_t idx, bool is_folder, bool is_last) {
     furi_assert(context);
+    UNUSED(idx);
     ArchiveBrowserView* browser = (ArchiveBrowserView*)context;
 
     if(!is_last) {

--- a/applications/main/archive/views/archive_browser_view.c
+++ b/applications/main/archive/views/archive_browser_view.c
@@ -482,7 +482,7 @@ static bool archive_view_input(InputEvent* event, void* context) {
                         model->scroll_counter = 0;
                     }
                 },
-                true);
+                false);
             archive_update_offset(browser);
         }
 

--- a/applications/services/gui/modules/file_browser.c
+++ b/applications/services/gui/modules/file_browser.c
@@ -34,6 +34,7 @@ typedef enum {
 } BrowserItemType;
 
 typedef struct {
+    uint32_t unsorted_idx;
     FuriString* path;
     BrowserItemType type;
     uint8_t* custom_icon_data;
@@ -41,6 +42,7 @@ typedef struct {
 } BrowserItem_t;
 
 static void BrowserItem_t_init(BrowserItem_t* obj) {
+    obj->unsorted_idx = 0;
     obj->type = BrowserItemTypeLoading;
     obj->path = furi_string_alloc();
     obj->display_name = furi_string_alloc();
@@ -48,6 +50,7 @@ static void BrowserItem_t_init(BrowserItem_t* obj) {
 }
 
 static void BrowserItem_t_init_set(BrowserItem_t* obj, const BrowserItem_t* src) {
+    obj->unsorted_idx = src->unsorted_idx;
     obj->type = src->type;
     obj->path = furi_string_alloc_set(src->path);
     obj->display_name = furi_string_alloc_set(src->display_name);
@@ -60,6 +63,7 @@ static void BrowserItem_t_init_set(BrowserItem_t* obj, const BrowserItem_t* src)
 }
 
 static void BrowserItem_t_set(BrowserItem_t* obj, const BrowserItem_t* src) {
+    obj->unsorted_idx = src->unsorted_idx;
     obj->type = src->type;
     furi_string_set(obj->path, src->path);
     furi_string_set(obj->display_name, src->display_name);
@@ -158,7 +162,7 @@ static void
     browser_folder_open_cb(void* context, uint32_t item_cnt, int32_t file_idx, bool is_root);
 static void browser_list_load_cb(void* context, uint32_t list_load_offset);
 static void
-    browser_list_item_cb(void* context, FuriString* item_path, bool is_folder, bool is_last);
+    browser_list_item_cb(void* context, FuriString* item_path, uint32_t idx, bool is_folder, bool is_last);
 static void browser_long_load_cb(void* context);
 
 static void file_browser_scroll_timer_callback(void* context) {
@@ -413,12 +417,13 @@ static void browser_list_load_cb(void* context, uint32_t list_load_offset) {
 }
 
 static void
-    browser_list_item_cb(void* context, FuriString* item_path, bool is_folder, bool is_last) {
+    browser_list_item_cb(void* context, FuriString* item_path, uint32_t idx, bool is_folder, bool is_last) {
     furi_assert(context);
     FileBrowser* browser = (FileBrowser*)context;
 
     BrowserItem_t item;
     item.custom_icon_data = NULL;
+    item.unsorted_idx = idx;
 
     if(!is_last) {
         item.path = furi_string_alloc_set(item_path);
@@ -465,10 +470,23 @@ static void
             browser->view,
             FileBrowserModel * model,
             {
+                FuriString* selected = NULL;
+                if(model->item_idx > 0) {
+                    selected = furi_string_alloc_set(items_array_get(model->items, model->item_idx)->path);
+                }
                 items_array_sort(model->items);
+                if(selected) {
+                    for(uint32_t i = 0; i < model->item_cnt; i++) {
+                        if(!furi_string_cmp(items_array_get(model->items, i)->path, selected)) {
+                            model->item_idx = i;
+                            break;
+                        }
+                    }
+                }
                 model->list_loading = false;
             },
             true);
+        browser_update_offset(browser);
     }
 }
 
@@ -667,10 +685,7 @@ static bool file_browser_view_input_callback(InputEvent* event, void* context) {
                     if(browser_is_item_in_array(model, model->item_idx)) {
                         selected_item =
                             items_array_get(model->items, model->item_idx - model->array_offset);
-                        select_index = model->item_idx;
-                        if((!model->is_root) && (select_index > 0)) {
-                            select_index -= 1;
-                        }
+                        select_index = selected_item->unsorted_idx;
                     }
                 },
                 false);

--- a/applications/services/gui/modules/file_browser.c
+++ b/applications/services/gui/modules/file_browser.c
@@ -351,7 +351,7 @@ static void browser_update_offset(FileBrowser* browser) {
                     CLAMP(model->item_idx - 1, (int32_t)model->item_cnt - bounds, 0);
             }
         },
-        false);
+        true);
 }
 
 static void
@@ -383,7 +383,7 @@ static void
             model->list_loading = true;
             model->folder_loading = false;
         },
-        true);
+        false);
     browser_update_offset(browser);
 
     file_browser_worker_load(browser->worker, load_offset, ITEM_LIST_LEN_MAX);
@@ -459,7 +459,7 @@ static void
                 items_array_push_back(model->items, item);
                 // TODO: calculate if element is visible
             },
-            true);
+            false);
         furi_string_free(item.display_name);
         furi_string_free(item.path);
         if(item.custom_icon_data) {
@@ -485,7 +485,7 @@ static void
                 }
                 model->list_loading = false;
             },
-            true);
+            false);
         browser_update_offset(browser);
     }
 }
@@ -670,7 +670,7 @@ static bool file_browser_view_input_callback(InputEvent* event, void* context) {
                         model->scroll_counter = 0;
                     }
                 },
-                true);
+                false);
             browser_update_offset(browser);
             consumed = true;
         }

--- a/applications/services/gui/modules/file_browser_worker.c
+++ b/applications/services/gui/modules/file_browser_worker.c
@@ -233,8 +233,7 @@ static bool
         // chances are, the new files are higher in the sorted list...
         // so the files keep shifting around while scrolling...
         // now this does something intelligent: loads and sorts all in one go.
-        // might take a few milliseconds longer, but atleast it works :kekw:
-        // and yes skotopes, most definitely a "limitation of fatfs driver" :roflmao:
+        // might take a few milliseconds longer, but atleast it works
         UNUSED(offset);
         UNUSED(count);
         if(browser->list_load_cb) {

--- a/applications/services/gui/modules/file_browser_worker.c
+++ b/applications/services/gui/modules/file_browser_worker.c
@@ -226,13 +226,15 @@ static bool
         //     break;
         // }
 
-        // FLIPPER DEVS MOMENT
-        // this used to load the file list in chunks, and then sort it...
+        // ROGUE MASTER MOMENT
+        // this used to load the file list in chunks, which makes sense
+        // but then RM made it sort the files, still in chunks...
         // so while scrolling, it loads more files and sorts them...
         // chances are, the new files are higher in the sorted list...
         // so the files keep shifting around while scrolling...
-        // now this does something intelligent and loads all in one go.
+        // now this does something intelligent: loads and sorts all in one go.
         // might take a few milliseconds longer, but atleast it works :kekw:
+        // and yes skotopes, most definitely a "limitation of fatfs driver" :roflmao:
         UNUSED(offset);
         UNUSED(count);
         if(browser->list_load_cb) {

--- a/applications/services/gui/modules/file_browser_worker.c
+++ b/applications/services/gui/modules/file_browser_worker.c
@@ -247,13 +247,13 @@ static bool
                 furi_string_printf(name_str, "%s/%s", furi_string_get_cstr(path), name_temp);
                 if(browser->list_item_cb) {
                     browser->list_item_cb(
-                        browser->cb_ctx, name_str, (file_info.flags & FSF_DIRECTORY), false);
+                        browser->cb_ctx, name_str, items_cnt, (file_info.flags & FSF_DIRECTORY), false);
                 }
                 items_cnt++;
             }
         }
         if(browser->list_item_cb) {
-            browser->list_item_cb(browser->cb_ctx, NULL, false, true);
+            browser->list_item_cb(browser->cb_ctx, NULL, 0, false, true);
         }
         ret = true;
     } while(0);

--- a/applications/services/gui/modules/file_browser_worker.h
+++ b/applications/services/gui/modules/file_browser_worker.h
@@ -17,6 +17,7 @@ typedef void (*BrowserWorkerListLoadCallback)(void* context, uint32_t list_load_
 typedef void (*BrowserWorkerListItemCallback)(
     void* context,
     FuriString* item_path,
+    uint32_t idx,
     bool is_folder,
     bool is_last);
 typedef void (*BrowserWorkerLongLoadCallback)(void* context);


### PR DESCRIPTION
# What's new

- Fixes the issues with #327
- In particular backing out of apps and folders will correctly remember and restore the previously selected item
  - I noticed that sadly after opening an app the previous history is cleared, only the last item remains selected on exit
  - Seems like this is unrelated to these PRs and is default behavior
  - This is due to the app, and saved file, selectors being used temporarily to choose a file and closed on app launch
  - The archive is unaffected since it remains open in background while app is launched
- Also made some performance improvements by skipping view dispatcher redraws while indexing
  - Haven't properly tested the gains but it feels snappier to me
  - Mostly affects normal file browsers, the archive seems more optimized by default
- Also updated the explanation comment with proper context, I didn't previously know the full story
# Verification 

- Open apps or folders from file pickers
- Backing out selects correct file
- Might notice a speed-up when first loading folders

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
