### PR TITLE
(Hopefully) last filebrowser fixes

### DIFF
--- a/applications/main/archive/helpers/archive_browser.c
+++ b/applications/main/archive/helpers/archive_browser.c
@@ -74,7 +74,9 @@ static void archive_list_item_cb(
             browser->view,
             ArchiveBrowserViewModel * model,
             {
-                files_array_sort(model->files);
+                if(model->item_cnt <= BROWSER_SORT_THRESHOLD) {
+                    files_array_sort(model->files);
+                }
                 model->list_loading = false;
             },
             true);

--- a/applications/main/archive/views/archive_browser_view.c
+++ b/applications/main/archive/views/archive_browser_view.c
@@ -398,15 +398,20 @@ static bool archive_view_input(InputEvent* event, void* context) {
 
     bool in_menu;
     bool move_fav_mode;
+    bool is_loading;
     with_view_model(
         browser->view,
         ArchiveBrowserViewModel * model,
         {
             in_menu = model->menu;
             move_fav_mode = model->move_fav;
+            is_loading = model->folder_loading || model->list_loading;
         },
         false);
 
+    if(is_loading) {
+        return false;
+    }
     if(in_menu) {
         if(event->type != InputTypeShort) {
             return true; // RETURN

--- a/applications/services/gui/modules/file_browser.c
+++ b/applications/services/gui/modules/file_browser.c
@@ -646,7 +646,10 @@ static bool file_browser_view_input_callback(InputEvent* event, void* context) {
     bool is_loading = false;
 
     with_view_model(
-        browser->view, FileBrowserModel * model, { is_loading = model->folder_loading; }, false);
+        browser->view,
+        FileBrowserModel * model,
+        { is_loading = model->folder_loading || model->list_loading; },
+        false);
 
     if(is_loading) {
         return false;

--- a/applications/services/gui/modules/file_browser.c
+++ b/applications/services/gui/modules/file_browser.c
@@ -478,7 +478,7 @@ static void browser_list_item_cb(
             browser->view,
             FileBrowserModel * model,
             {
-                if(model->item_cnt < 430) {
+                if(model->item_cnt <= BROWSER_SORT_THRESHOLD) {
                     FuriString* selected = NULL;
                     if(model->item_idx > 0) {
                         selected = furi_string_alloc_set(

--- a/applications/services/gui/modules/file_browser_worker.c
+++ b/applications/services/gui/modules/file_browser_worker.c
@@ -418,7 +418,7 @@ static int32_t browser_worker(void* context) {
         if(flags & WorkerEvtLoad) {
             FURI_LOG_D(
                 TAG, "Load offset: %lu cnt: %lu", browser->load_offset, browser->load_count);
-            if(items_cnt > 430) {
+            if(items_cnt > BROWSER_SORT_THRESHOLD) {
                 browser_folder_load_chunked(
                     browser, path, browser->load_offset, browser->load_count);
             } else {

--- a/applications/services/gui/modules/file_browser_worker.h
+++ b/applications/services/gui/modules/file_browser_worker.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+#define BROWSER_SORT_THRESHOLD 400
+
 typedef struct BrowserWorker BrowserWorker;
 typedef void (*BrowserWorkerFolderOpenCallback)(
     void* context,


### PR DESCRIPTION
# What's new

- Skip inputs while loading / sorting is in progress to prevent cursor / focus shift
- Fix archive sorting, now respects chunked load threshold

# Verification 

- Open a folder and go up / down before sorting is finished, no longer shifts cursor
- Scroll a big folder in archive, no longer has sort bug

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
