### PR TITLE
Features mousejacker

### DIFF
--- a/applications/plugins/mousejacker/mousejacker_ducky.c
+++ b/applications/plugins/mousejacker/mousejacker_ducky.c
@@ -344,7 +344,11 @@ static bool mj_process_ducky_line(
         if(!mj_get_ducky_key("SPACE", 5, &dk)) return false;
         send_hid_packet(handle, addr, addr_size, rate, dk.mod, dk.hid, plugin_state);
         return true;
-    }
+    } else if(strncmp(line_tmp, "TAB", strlen("TAB")) == 0) {
+        if(!mj_get_ducky_key("TAB", 3, &dk)) return false;
+        send_hid_packet(handle, addr, addr_size, rate, dk.mod, dk.hid, plugin_state);
+        return true;
+    } 
 
     return false;
 }

--- a/applications/plugins/mousejacker/mousejacker_ducky.c
+++ b/applications/plugins/mousejacker/mousejacker_ducky.c
@@ -97,7 +97,7 @@ static uint32_t mj_ducky_get_command_len(const char* line) {
 static bool mj_get_ducky_key(char* key, size_t keylen, MJDuckyKey* dk) {
     //FURI_LOG_D(TAG, "looking up key %s with length %d", key, keylen);
     for(uint i = 0; i < sizeof(mj_ducky_keys) / sizeof(MJDuckyKey); i++) {
-        if(strncmp(mj_ducky_keys[i].name, key, keylen) == 0) {
+        if(strlen(mj_ducky_keys[i].name) == keylen && !strncmp(mj_ducky_keys[i].name, key, keylen)) {
             memcpy(dk, &mj_ducky_keys[i], sizeof(MJDuckyKey));
             return true;
         }

--- a/applications/plugins/mousejacker/mousejacker_ducky.c
+++ b/applications/plugins/mousejacker/mousejacker_ducky.c
@@ -210,6 +210,10 @@ static void send_hid_packet(
     furi_delay_ms(12);
 }
 
+static bool ducky_end_line(const char chr) {
+    return ((chr == ' ') || (chr == '\0') || (chr == '\r') || (chr == '\n'));
+}
+
 // returns false if there was an error processing script line
 static bool mj_process_ducky_line(
     FuriHalSpiBusHandle* handle,
@@ -307,7 +311,7 @@ static bool mj_process_ducky_line(
             holding_alt = false;
             release_key(handle, addr, addr_size, rate, plugin_state);
         }
-        
+
         return true;
     } else if(strncmp(line_tmp, ducky_cmd_repeat, strlen(ducky_cmd_repeat)) == 0) {
         // REPEAT

--- a/applications/plugins/mousejacker/mousejacker_ducky.c
+++ b/applications/plugins/mousejacker/mousejacker_ducky.c
@@ -89,7 +89,7 @@ static uint32_t mj_ducky_get_command_len(const char* line) {
 static bool mj_get_ducky_key(char* key, size_t keylen, MJDuckyKey* dk) {
     //FURI_LOG_D(TAG, "looking up key %s with length %d", key, keylen);
     for(uint i = 0; i < sizeof(mj_ducky_keys) / sizeof(MJDuckyKey); i++) {
-        if(!strncmp(mj_ducky_keys[i].name, key, keylen)) {
+        if(strncmp(mj_ducky_keys[i].name, key, keylen) == 0) {
             memcpy(dk, &mj_ducky_keys[i], sizeof(MJDuckyKey));
             return true;
         }


### PR DESCRIPTION
# What's new

- Correcting bug when using DEL pressing DELETE
- Adding TAB support
- Adding ALTSTRING support for non qwerty keyboards

# Verification 

### For ALTSTRING
- Inside a MouseJacker Payload, write : 
```
DELAY 200

ALTSTRING Testing !
```
- Then execute this Payload on an OS supporting ALT codes (Windows for example)
- It should write the correct string

### For TAB
- Inside a MouseJacker Payload, write : 
```
DELAY 200

TAB
```
- Then execute the Payload
- It should press TAB key

### For Bug Fixes
- Inside a MouseJacker Payload, write : 
```
DELAY 200

CTRL-ALT DEL
```
- Then execute the Payload
- It should press CTRL + ALT + DEL shortcut

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
