### PR TITLE
Fix CAME 12bit pilot bit

### DIFF
--- a/lib/subghz/protocols/came.c
+++ b/lib/subghz/protocols/came.c
@@ -120,10 +120,9 @@ static bool subghz_protocol_encoder_came_get_upload(SubGhzProtocolEncoderCame* i
     instance->encoder.upload[index++] = level_duration_make(
         false,
         (((instance->generic.data_count_bit == CAME_24_COUNT_BIT) ||
-          (instance->generic.data_count_bit ==
-           subghz_protocol_came_const.min_count_bit_for_found)) ?
+          (instance->generic.data_count_bit == PRASTEL_COUNT_BIT)) ?
              (uint32_t)subghz_protocol_came_const.te_short * 76 :
-             (uint32_t)subghz_protocol_came_const.te_short * 39));
+             (uint32_t)subghz_protocol_came_const.te_short * 36));
     //Send start bit
     instance->encoder.upload[index++] =
         level_duration_make(true, (uint32_t)subghz_protocol_came_const.te_short);


### PR DESCRIPTION

# What's new
This commit fixes a regression on the CAME 12bit protocol, header encoding and fix #280 .

I sent this PR also upstream since the file it involves it's coming from there.
# Verification 
To try the fix I tested it on my gate, that wasn't working before

