### PR TITLE
Fix unirf freeze (protocol deserialize status ok)

### DIFF
--- a/applications/main/unirfremix/unirfremix_app.c
+++ b/applications/main/unirfremix/unirfremix_app.c
@@ -402,7 +402,9 @@ bool unirfremix_key_load(
         preset->decoder = subghz_receiver_search_decoder_base_by_name(
             receiver, furi_string_get_cstr(preset->protocol));
         if(preset->decoder) {
-            if(!subghz_protocol_decoder_base_deserialize(preset->decoder, fff_data)) {
+            SubGhzProtocolStatus status = subghz_protocol_decoder_base_deserialize(preset->decoder, fff_data);
+            if(status != SubGhzProtocolStatusOk) {
+                FURI_LOG_E(TAG, "Protocol deserialize failed, status = %d", status);
                 break;
             }
         } else {


### PR DESCRIPTION
# What's new

- Protocol deserialize checks for status not truthiness
- Fixes unirf freeze on any file

# Verification 

- Can actually use subghz remote

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
