### PR TITLE
Containerized build and flash

### DIFF
--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:20.04
+
+# Update/Dependency
+RUN apt-get update; \
+	apt-get install -y \
+		git \
+		curl \
+		wget
+
+# Create non-root user: "builder"
+RUN useradd -m builder && \
+    adduser builder dialout
+USER builder
+WORKDIR /home/builder 
+
+# Clone flipper firmware from GitHub
+RUN git clone --recurse-submodules https://github.com/DarkFlippers/unleashed-firmware.git
+WORKDIR unleashed-firmware
+
+USER root
+RUN apt-get install -y vim
+USER builder

--- a/docker_build/Makefile
+++ b/docker_build/Makefile
@@ -1,0 +1,23 @@
+IMG=local/unleashed_firmware
+CUSTOM_FLIPPER_NAME=myflipper
+PORT=/dev/$(shell ls -l /dev/serial/by-id/ | grep 'Flipper' | grep -o 'tty.*')
+
+.PHONY: all
+all: .image_build
+
+build: .image_build
+	docker run --device $(PORT):$(PORT) --env CUSTOM_FLIPPER_NAME="${CUSTOM_FLIPPER_NAME}" ${IMG} ./fbt COMPACT=1 DEBUG=0 FORCE=1 flash_usb_full
+
+dev:
+	docker run --device $(PORT):$(PORT) -it ${IMG} bash
+
+# Build Docker image
+.image_build: Dockerfile
+	docker build --tag ${IMG} .
+	touch .image_build
+	docker images
+
+clean:
+	rm -f .image_build
+	if docker images | grep -q "${IMG}" ; then docker image rm ${IMG}; fi
+	docker images

--- a/docker_build/Makefile
+++ b/docker_build/Makefile
@@ -2,22 +2,29 @@ IMG=local/unleashed_firmware
 CUSTOM_FLIPPER_NAME=myflipper
 PORT=/dev/$(shell ls -l /dev/serial/by-id/ | grep 'Flipper' | grep -o 'tty.*')
 
-.PHONY: all
-all: .image_build
-
-build: .image_build
-	docker run --device $(PORT):$(PORT) --env CUSTOM_FLIPPER_NAME="${CUSTOM_FLIPPER_NAME}" ${IMG} ./fbt COMPACT=1 DEBUG=0 FORCE=1 flash_usb_full
-
-dev:
-	docker run --device $(PORT):$(PORT) -it ${IMG} bash
-
 # Build Docker image
+img: .image_build
 .image_build: Dockerfile
 	docker build --tag ${IMG} .
 	touch .image_build
 	docker images
 
+# Build and flash flipper
+flash: img
+	docker run --device $(PORT):$(PORT) --env CUSTOM_FLIPPER_NAME="${CUSTOM_FLIPPER_NAME}" ${IMG} ./fbt COMPACT=1 DEBUG=0 FORCE=1 flash_usb_full
+
+bash: img
+	docker run --device $(PORT):$(PORT) -it ${IMG} bash
+
 clean:
 	rm -f .image_build
 	if docker images | grep -q "${IMG}" ; then docker image rm ${IMG}; fi
 	docker images
+
+help:
+	@echo "make [all|build|dev|clean|help]"
+	@echo "    img  : Create docker image"
+	@echo "    flash: Build and flash flipper"
+	@echo "    bash : Launch shell in unleashed_firmware contianer"
+	@echo "    clean: Remove docker image"
+	@echo "    help : Print this help menu"

--- a/docker_build/Makefile
+++ b/docker_build/Makefile
@@ -9,8 +9,12 @@ img: .image_build
 	touch .image_build
 	docker images
 
+check_port:
+	@echo "Checking if flipper device is connected somewhere in /dev ...."
+	[ -f $(PORT) ]
+
 # Build and flash flipper
-flash: img
+flash: img check_port
 	docker run --device $(PORT):$(PORT) --env CUSTOM_FLIPPER_NAME="${CUSTOM_FLIPPER_NAME}" ${IMG} ./fbt COMPACT=1 DEBUG=0 FORCE=1 flash_usb_full
 
 bash: img

--- a/docker_build/Makefile
+++ b/docker_build/Makefile
@@ -11,7 +11,7 @@ img: .image_build
 
 check_port:
 	@echo "Checking if flipper device is connected somewhere in /dev ...."
-	[ -f $(PORT) ]
+	[ -c $(PORT) ] && echo "Flipper Connected!"
 
 # Build and flash flipper
 flash: img check_port

--- a/docker_build/ReadMe.md
+++ b/docker_build/ReadMe.md
@@ -1,0 +1,16 @@
+# Docker Build
+Build and flash your flipper in docker. Simply use the makefile rules to build the docker image and flash your flipper device. The makefile automatically detects and mounts your fliper into the docker container.
+
+## Quick build: 
+1. Connect your flipper over USB
+2. Run the command: `make flash`
+
+## Help Menu
+```text
+make [all|build|dev|clean|help]
+    img  : Create docker image
+    flash: Build and flash flipper
+    bash : Launch shell in unleashed_firmware contianer
+    clean: Remove docker image
+    help : Print this help menu
+```


### PR DESCRIPTION
# What's new

- Added `docker_build` directory containing a Dockerfile and Makefile that simplify the build and flash process

# Verification 

1. Checkout/pull my fork
2. cd to `docker_build`
3. Physically connect a flipper device you wish to flash
4. Execute the command: `make flash`

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
