### PR TITLE
Fix POCSAG pager RIC: text repetition and overlap

### DIFF
--- a/applications/external/pocsag_pager/protocols/pocsag.c
+++ b/applications/external/pocsag_pager/protocols/pocsag.c
@@ -157,7 +157,7 @@ static bool pocsag_decode_message_word(SubGhzProtocolDecoderPocsag* instance, ui
 // Function called when current message got decoded, but other messages might follow
 static void pocsag_message_done(SubGhzProtocolDecoderPocsag* instance) {
     // append the message to the long-term storage string
-    furi_string_cat_printf(
+    furi_string_printf(
         instance->generic.result_ric, "\e#RIC: %" PRIu32 "\e# | ", instance->ric);
     furi_string_cat_str(instance->generic.result_ric, func_msg[instance->func]);
     if(instance->func != POCSAG_FUNC_ALERT1) {


### PR DESCRIPTION
# What's new

- Original issue raised here: ClaraCrazy/Flipper-Xtreme#172
- Same text was being added to string multiple times erroneously
- Fixed by resetting string when this happens initially

# Verification 

- RIC text isn't duplicated and therefore doesn't overlap other text elements

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
