### PR TITLE
Implements an array for baudrates on GPS UART app

### DIFF
--- a/applications/external/gps_nmea_uart/gps.c
+++ b/applications/external/gps_nmea_uart/gps.c
@@ -139,20 +139,14 @@ int32_t gps_app(void* p) {
                     switch(event.input.key) {
                     case InputKeyUp:
                         gps_uart_deinit_thread(gps_uart);
-                        switch(gps_uart->baudrate) {
-                        case GPS_BAUDRATE_9k:
-                            gps_uart->baudrate = GPS_BAUDRATE_57k;
-                            break;
-                        case GPS_BAUDRATE_57k:
-                            gps_uart->baudrate = GPS_BAUDRATE_115k;
-                            break;
-                        case GPS_BAUDRATE_115k:
-                            gps_uart->baudrate = GPS_BAUDRATE_9k;
-                            break;
-
-                        default:
-                            break;
+                        const int baudrate_length =
+                            sizeof(gps_baudrates) / sizeof(gps_baudrates[0]);
+                        current_gps_baudrate++;
+                        if(current_gps_baudrate >= baudrate_length) {
+                            current_gps_baudrate = 0;
                         }
+                        gps_uart->baudrate = gps_baudrates[current_gps_baudrate];
+
                         gps_uart_init_thread(gps_uart);
                         gps_uart->changing_baudrate = true;
                         view_port_update(view_port);

--- a/applications/external/gps_nmea_uart/gps_uart.c
+++ b/applications/external/gps_nmea_uart/gps_uart.c
@@ -169,7 +169,7 @@ GpsUart* gps_uart_enable() {
 
     gps_uart->notifications = furi_record_open(RECORD_NOTIFICATION);
 
-    gps_uart->baudrate = GPS_BAUDRATE_57k;
+    gps_uart->baudrate = gps_baudrates[current_gps_baudrate];
 
     gps_uart_init_thread(gps_uart);
 

--- a/applications/external/gps_nmea_uart/gps_uart.h
+++ b/applications/external/gps_nmea_uart/gps_uart.h
@@ -3,10 +3,10 @@
 #include <furi_hal.h>
 #include <notification/notification_messages.h>
 
-#define GPS_BAUDRATE_9k 9600
-#define GPS_BAUDRATE_57k 57600
-#define GPS_BAUDRATE_115k 115200
 #define RX_BUF_SIZE 1024
+
+static const int gps_baudrates[5] = {9600, 19200, 38400, 57600, 115200};
+static int current_gps_baudrate = 3;
 
 typedef struct {
     bool valid;


### PR DESCRIPTION
# What's new

- Implements an array for GPS UART app
My GPS is 19200, and I was patching this manually before. With the changes introduces, I decided to turn the baudrates into an array for easier configuration in the code.

# Verification 

It should behave exactly the same, except it has 19200 as an option

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
