### PR TITLE
Flip slashes for Windows builds (Backslash -> Forward Slash)

### DIFF
--- a/documentation/HowToBuild.md
+++ b/documentation/HowToBuild.md
@@ -53,13 +53,13 @@ Check out `documentation/fbt.md` for details on building and flashing firmware.
 ### Compile everything for development
 
 ```sh
-.\fbt.cmd FIRMWARE_APP_SET=debug_pack updater_package
+./fbt.cmd FIRMWARE_APP_SET=debug_pack updater_package
 ```
 
 ### Compile everything for release + get updater package to update from microSD card
 
 ```sh
-.\fbt.cmd COMPACT=1 DEBUG=0 updater_package
+./fbt.cmd COMPACT=1 DEBUG=0 updater_package
 ```
 
 Check `dist/` for build outputs.


### PR DESCRIPTION
Tried building this myself using these directions, kept getting errors.

Flipped the backslash to a forward slash, and got a successful build. 🤷‍♂️

# What's new

- Flipped the backslash to a forward slash for Windows build instructions.

# Verification 

- Run in Git Bash.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
