### PR TITLE
Consistancy Check, As mentioned in Discord

### DIFF
--- a/documentation/CustomFlipperName.md
+++ b/documentation/CustomFlipperName.md
@@ -6,7 +6,7 @@
 3. Run release build to verify all is ok - `./fbt COMPACT=1 DEBUG=0 updater_package`
 4. Clear build files - `./fbt COMPACT=1 DEBUG=0 updater_package -c`
 5. Run command with extra environment var before `./fbt` that variable should contain your custom name in alphanumeric characters - max length 8 chars
- `CUSTOM_FLIPPER_NAME=Name ./fbt COMPACT=1 DEBUG=0 updater_package` - where `Name` write your custom name
+ `./fbt CUSTOM_FLIPPER_NAME=Name COMPACT=1 DEBUG=0 updater_package` - where `Name` write your custom name
 6. Copy `dist/f7-C/f7-update-local` folder to microSD `update/myfw/` and run `update` file on flipper from file manager app (Archive)
 7. Flash from microSD card only!!!! .dfu update from qFlipper will not work properly since name and serial number will be changed
 8. Done, you will have custom name, serial number and bluetooth mac address


### PR DESCRIPTION
You can put arguments / options after ./fbt apparently, fun.

# What's new

- Move argument / option to _after_ command (./fbt) for consistency. 

# Verification 

- Run in git-bash.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
