### PR TITLE
Add furi_hal_version_uid_default (Fix TOTP)

### DIFF
--- a/applications/external/totp/services/crypto/crypto.c
+++ b/applications/external/totp/services/crypto/crypto.c
@@ -90,7 +90,7 @@ CryptoSeedIVResult
             max_i = uid_size;
         }
 
-        const uint8_t* uid = furi_hal_version_uid();
+        const uint8_t* uid = furi_hal_version_uid_default();
         for(uint8_t i = 0; i < max_i; i++) {
             plugin_state->iv[i] = plugin_state->iv[i] ^ uid[i];
         }

--- a/applications/external/totp/services/crypto/crypto.c
+++ b/applications/external/totp/services/crypto/crypto.c
@@ -90,7 +90,7 @@ CryptoSeedIVResult
             max_i = uid_size;
         }
 
-        const uint8_t* uid = furi_hal_version_uid_default();
+        const uint8_t* uid = furi_hal_version_uid();
         for(uint8_t i = 0; i < max_i; i++) {
             plugin_state->iv[i] = plugin_state->iv[i] ^ uid[i];
         }

--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,28.2,,
+Version,+,28.3,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -1481,6 +1481,7 @@ Function,+,furi_hal_version_get_otp_version,FuriHalVersionOtpVersion,
 Function,-,furi_hal_version_init,void,
 Function,-,furi_hal_version_set_name,void,const char*
 Function,+,furi_hal_version_uid,const uint8_t*,
+Function,+,furi_hal_version_uid_default,const uint8_t*,
 Function,+,furi_hal_version_uid_size,size_t,
 Function,-,furi_hal_vibro_init,void,
 Function,+,furi_hal_vibro_on,void,_Bool

--- a/firmware/targets/f7/furi_hal/furi_hal_version.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_version.c
@@ -314,6 +314,10 @@ size_t furi_hal_version_uid_size() {
     return 64 / 8;
 }
 
+const uint8_t* furi_hal_version_uid_default() {
+    return (const uint8_t*)UID64_BASE;
+}
+
 const uint8_t* furi_hal_version_uid() {
     if(version_get_custom_name(NULL) != NULL) {
         return (const uint8_t*)&(*((uint32_t*)version_get_custom_name(NULL)));

--- a/firmware/targets/furi_hal_include/furi_hal_version.h
+++ b/firmware/targets/furi_hal_include/furi_hal_version.h
@@ -204,6 +204,8 @@ size_t furi_hal_version_uid_size();
  */
 const uint8_t* furi_hal_version_uid();
 
+const uint8_t* furi_hal_version_uid_default();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# What's new

- Added new API route `furi_hal_version_uid_default` (Fixes TOTP)

# Verification 

- Open Authenticator (TOTP) app without namespoof on current version
- Use namespoof, observe "Digital signature verification - failed"
- Change `ext/totp/services/crypto.c#L93` to use new API route, observe working even with namespoof

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
