### PR TITLE
Allow zero-delay fuzzing

### DIFF
--- a/applications/external/flipfrid/scene/flipfrid_scene_run_attack.c
+++ b/applications/external/flipfrid/scene/flipfrid_scene_run_attack.c
@@ -78,7 +78,7 @@ uint8_t id_list_h[14][3] = {
 };
 
 void flipfrid_scene_run_attack_on_enter(FlipFridState* context) {
-    context->time_between_cards = 10;
+    context->time_between_cards = 2;
     context->attack_step = 0;
     context->attack_stop_called = false;
     context->dict = protocol_dict_alloc(lfrfid_protocols, LFRFIDProtocolMax);
@@ -516,7 +516,7 @@ void flipfrid_scene_run_attack_on_event(FlipFridEvent event, FlipFridState* cont
                 break;
             case InputKeyLeft:
                 if(!context->is_attacking) {
-                    if(context->time_between_cards > 5) {
+                    if(context->time_between_cards > 0) {
                         context->time_between_cards--;
                     }
                 }
@@ -568,7 +568,7 @@ void flipfrid_scene_run_attack_on_event(FlipFridEvent event, FlipFridState* cont
             case InputKeyLeft:
                 if(!context->is_attacking) {
                     if(context->time_between_cards > 0) {
-                        if((context->time_between_cards - 10) > 5) {
+                        if((context->time_between_cards - 10) > 0) {
                             context->time_between_cards -= 10;
                         }
                     }


### PR DESCRIPTION
One of the most overlooked features of the LF RFID Fuzzer is the ability to overflow / glitch readers.
If the delay between attempts is low enough, certain readers glitch to open.

# What's new

Reduces the minimum delay between tries to zero.
This allows glitching of lower-end access control systems (specifically, but not restricted to - https://aliexpress.com/item/4000586090511.html )

![flipfrid](https://github.com/quantum-x/unleashed-firmware/assets/2514540/5b85906b-603f-40d3-bcd5-d3262e4edc51)

By setting the delay to 0 or 1, the reader glitches and instantly opens.
Slower delays do not produce this behaviour.

Very useful for pentesters esp in the APAC or US regions.

# Verification 

- Load app
- Check minimum can be reduced to 0
- Default delay 2

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
