### PR TITLE
Add a Precise mode

### DIFF
--- a/applications/external/spectrum_analyzer/spectrum_analyzer.c
+++ b/applications/external/spectrum_analyzer/spectrum_analyzer.c
@@ -52,39 +52,55 @@ void spectrum_analyzer_draw_scale(Canvas* canvas, const SpectrumAnalyzerModel* m
     }
 
     // Draw scale tags
-    uint16_t tag_left;
-    uint16_t tag_center;
-    uint16_t tag_right;
+    uint32_t tag_left = 0;
+    uint32_t tag_center = 0;
+    uint32_t tag_right = 0;
     char temp_str[18];
 
     tag_center = model->center_freq;
 
     switch(model->width) {
     case NARROW:
-        tag_left = model->center_freq - 2;
-        tag_right = model->center_freq + 2;
+        tag_left = model->center_freq - 2000;
+        tag_right = model->center_freq + 2000;
         break;
     case ULTRANARROW:
-        tag_left = model->center_freq - 1;
-        tag_right = model->center_freq + 1;
+        tag_left = model->center_freq - 1000;
+        tag_right = model->center_freq + 1000;
+        break;
+    case PRECISE:
+        tag_left = model->center_freq - 200;
+        tag_right = model->center_freq + 200;
         break;
     case ULTRAWIDE:
-        tag_left = model->center_freq - 40;
-        tag_right = model->center_freq + 40;
+        tag_left = model->center_freq - 40000;
+        tag_right = model->center_freq + 40000;
         break;
     default:
-        tag_left = model->center_freq - 10;
-        tag_right = model->center_freq + 10;
+        tag_left = model->center_freq - 10000;
+        tag_right = model->center_freq + 10000;
     }
 
     canvas_set_font(canvas, FontSecondary);
-    snprintf(temp_str, 18, "%u", tag_left);
-    canvas_draw_str_aligned(canvas, FREQ_START_X, 63, AlignCenter, AlignBottom, temp_str);
-    snprintf(temp_str, 18, "%u", tag_center);
-    canvas_draw_str_aligned(canvas, 128 / 2, 63, AlignCenter, AlignBottom, temp_str);
-    snprintf(temp_str, 18, "%u", tag_right);
-    canvas_draw_str_aligned(
-        canvas, FREQ_START_X + FREQ_LENGTH_X - 1, 63, AlignCenter, AlignBottom, temp_str);
+    switch(model->width) {
+    case PRECISE:
+        snprintf(temp_str, 18, "%.1f", ((double)tag_left)/1000);
+        canvas_draw_str_aligned(canvas, FREQ_START_X, 63, AlignCenter, AlignBottom, temp_str);
+        snprintf(temp_str, 18, "%.1f", ((double)tag_center)/1000);
+        canvas_draw_str_aligned(canvas, 128 / 2, 63, AlignCenter, AlignBottom, temp_str);
+        snprintf(temp_str, 18, "%.1f", ((double)tag_right)/1000);
+        canvas_draw_str_aligned(
+            canvas, FREQ_START_X + FREQ_LENGTH_X - 1, 63, AlignCenter, AlignBottom, temp_str);
+        break;
+    default:
+        snprintf(temp_str, 18, "%lu", tag_left/1000);
+        canvas_draw_str_aligned(canvas, FREQ_START_X, 63, AlignCenter, AlignBottom, temp_str);
+        snprintf(temp_str, 18, "%lu", tag_center/1000);
+        canvas_draw_str_aligned(canvas, 128 / 2, 63, AlignCenter, AlignBottom, temp_str);
+        snprintf(temp_str, 18, "%lu", tag_right/1000);
+        canvas_draw_str_aligned(
+            canvas, FREQ_START_X + FREQ_LENGTH_X - 1, 63, AlignCenter, AlignBottom, temp_str);
+    }
 }
 
 static void spectrum_analyzer_render_callback(Canvas* const canvas, void* ctx) {
@@ -113,6 +129,9 @@ static void spectrum_analyzer_render_callback(Canvas* const canvas, void* ctx) {
             break;
         case ULTRANARROW:
             strncpy(temp_mode_str, "ULTRANARROW", 12);
+            break;
+        case PRECISE:
+            strncpy(temp_mode_str, "PRECISE", 12);
             break;
         case ULTRAWIDE:
             strncpy(temp_mode_str, "ULTRAWIDE", 12);
@@ -206,12 +225,12 @@ void spectrum_analyzer_calculate_frequencies(SpectrumAnalyzerModel* model) {
     uint8_t new_band;
     uint32_t min_hz;
     uint32_t max_hz;
-    uint8_t margin;
-    uint8_t step;
-    uint16_t upper_limit;
-    uint16_t lower_limit;
-    uint16_t next_up;
-    uint16_t next_down;
+    uint32_t margin;
+    uint32_t step;
+    uint32_t upper_limit;
+    uint32_t lower_limit;
+    uint32_t next_up;
+    uint32_t next_down;
     uint8_t next_band_up;
     uint8_t next_band_down;
 
@@ -226,19 +245,24 @@ void spectrum_analyzer_calculate_frequencies(SpectrumAnalyzerModel* model) {
         step = ULTRANARROW_STEP;
         model->spacing = ULTRANARROW_SPACING;
         break;
+    case PRECISE:
+        margin = PRECISE_MARGIN;
+        step = PRECISE_STEP;
+        model->spacing = PRECISE_SPACING;
+        break;
     case ULTRAWIDE:
         margin = ULTRAWIDE_MARGIN;
         step = ULTRAWIDE_STEP;
         model->spacing = ULTRAWIDE_SPACING;
         /* nearest 20 MHz step */
-        model->center_freq = ((model->center_freq + 10) / 20) * 20;
+        model->center_freq = ((model->center_freq + 10000) / 20000) * 20000;
         break;
     default:
         margin = WIDE_MARGIN;
         step = WIDE_STEP;
         model->spacing = WIDE_SPACING;
         /* nearest 5 MHz step */
-        model->center_freq = ((model->center_freq + 2) / 5) * 5;
+        model->center_freq = ((model->center_freq + 2000) / 5000) * 5000;
         break;
     }
 
@@ -287,21 +311,21 @@ void spectrum_analyzer_calculate_frequencies(SpectrumAnalyzerModel* model) {
     /* doing everything in Hz from here on */
     switch(model->band) {
     case BAND_400:
-        min_hz = MIN_400 * 1000000;
-        max_hz = MAX_400 * 1000000;
+        min_hz = MIN_400 * 1000;
+        max_hz = MAX_400 * 1000;
         break;
     case BAND_300:
-        min_hz = MIN_300 * 1000000;
-        max_hz = MAX_300 * 1000000;
+        min_hz = MIN_300 * 1000;
+        max_hz = MAX_300 * 1000;
         break;
     default:
-        min_hz = MIN_900 * 1000000;
-        max_hz = MAX_900 * 1000000;
+        min_hz = MIN_900 * 1000;
+        max_hz = MAX_900 * 1000;
         break;
     }
 
     model->channel0_frequency =
-        model->center_freq * 1000000 - (model->spacing * ((NUM_CHANNELS / 2) + 1));
+        model->center_freq * 1000 - (model->spacing * ((NUM_CHANNELS / 2) + 1));
 
     // /* calibrate upper channels */
     // hz = model->center_freq * 1000000;
@@ -327,7 +351,7 @@ void spectrum_analyzer_calculate_frequencies(SpectrumAnalyzerModel* model) {
     model->max_rssi_dec = 0;
 
     FURI_LOG_D("Spectrum", "setup_frequencies - max_hz: %lu - min_hz: %lu", max_hz, min_hz);
-    FURI_LOG_D("Spectrum", "center_freq: %u", model->center_freq);
+    FURI_LOG_D("Spectrum", "center_freq: %lu", model->center_freq);
     FURI_LOG_D(
         "Spectrum",
         "ch[0]: %lu - ch[%u]: %lu",
@@ -464,7 +488,7 @@ int32_t spectrum_analyzer_app(void* p) {
             break;
         case InputKeyRight:
             model->center_freq += hstep;
-            FURI_LOG_D("Spectrum", "center_freq: %u", model->center_freq);
+            FURI_LOG_D("Spectrum", "center_freq: %lu", model->center_freq);
             spectrum_analyzer_calculate_frequencies(model);
             spectrum_analyzer_worker_set_frequencies(
                 spectrum_analyzer->worker, model->channel0_frequency, model->spacing, model->width);
@@ -474,7 +498,7 @@ int32_t spectrum_analyzer_app(void* p) {
             spectrum_analyzer_calculate_frequencies(model);
             spectrum_analyzer_worker_set_frequencies(
                 spectrum_analyzer->worker, model->channel0_frequency, model->spacing, model->width);
-            FURI_LOG_D("Spectrum", "center_freq: %u", model->center_freq);
+            FURI_LOG_D("Spectrum", "center_freq: %lu", model->center_freq);
             break;
         case InputKeyOk: {
             switch(model->width) {
@@ -485,6 +509,9 @@ int32_t spectrum_analyzer_app(void* p) {
                 model->width = ULTRANARROW;
                 break;
             case ULTRANARROW:
+                model->width = PRECISE;
+                break;
+            case PRECISE:
                 model->width = ULTRAWIDE;
                 break;
             case ULTRAWIDE:

--- a/applications/external/spectrum_analyzer/spectrum_analyzer.h
+++ b/applications/external/spectrum_analyzer/spectrum_analyzer.h
@@ -15,17 +15,20 @@
  * wide mode (default): 20 MHz on screen, 196 kHz per channel
  * narrow mode: 4 MHz on screen, 39 kHz per channel
  * ultranarrow mode: 2 MHz on screen, 19 kHz per channel
+ * pricse mode: 400 KHz on screen, 3.92 kHz per channel
  */
 #define WIDE 0
 #define NARROW 1
 #define ULTRAWIDE 2
 #define ULTRANARROW 3
+#define PRECISE 4
 
 /* channel spacing in Hz */
 #define WIDE_SPACING 196078
 #define NARROW_SPACING 39215
 #define ULTRAWIDE_SPACING 784313
 #define ULTRANARROW_SPACING 19607
+#define PRECISE_SPACING 3921
 
 /* vertical scrolling */
 #define VERTICAL_SHORT_STEP 16
@@ -33,36 +36,40 @@
 #define MIN_VSCROLL 0
 #define DEFAULT_VSCROLL 48
 
-/* frequencies in MHz */
-#define DEFAULT_FREQ 440
-#define WIDE_STEP 5
-#define NARROW_STEP 1
-#define ULTRAWIDE_STEP 20
-#define ULTRANARROW_STEP 1
-#define WIDE_MARGIN 13
-#define NARROW_MARGIN 3
-#define ULTRAWIDE_MARGIN 42
-#define ULTRANARROW_MARGIN 1
+/* frequencies in KHz */
+#define DEFAULT_FREQ 440000
+#define WIDE_STEP 5000
+#define NARROW_STEP 1000
+#define ULTRAWIDE_STEP 20000
+#define ULTRANARROW_STEP 1000
+#define PRECISE_STEP 100
+
+/* margin in KHz */
+#define WIDE_MARGIN 13000
+#define NARROW_MARGIN 3000
+#define ULTRAWIDE_MARGIN 42000
+#define ULTRANARROW_MARGIN 1000
+#define PRECISE_MARGIN 200
 
 /* frequency bands supported by device */
 #define BAND_300 0
 #define BAND_400 1
 #define BAND_900 2
 
-/* band limits in MHz */
-#define MIN_300 281
-#define CEN_300 315
-#define MAX_300 361
-#define MIN_400 378
-#define CEN_400 435
-#define MAX_400 481
-#define MIN_900 749
-#define CEN_900 855
-#define MAX_900 962
+/* band limits in KHz */
+#define MIN_300 281000
+#define CEN_300 315000
+#define MAX_300 361000
+#define MIN_400 378000
+#define CEN_400 435000
+#define MAX_400 481000
+#define MIN_900 749000
+#define CEN_900 855000
+#define MAX_900 962000
 
-/* band transition points in MHz */
-#define EDGE_400 369
-#define EDGE_900 615
+/* band transition points in KHz */
+#define EDGE_400 369000
+#define EDGE_900 615000
 
 /* VCO transition points in Hz */
 #define MID_300 318000000


### PR DESCRIPTION
# What's new

- Added a Precise mode with 400 KHz on-screen with 3.92 kHz per channel
- Changed many uints to unit32_t to allow for KHz increments

# Verification 

- Find a signal and see the high precision in Precise mode

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
