### PR TITLE
Add "Autosave RAW" setting to sub-ghz app.

### DIFF
--- a/applications/main/subghz/application.fam
+++ b/applications/main/subghz/application.fam
@@ -1,7 +1,7 @@
 App(
     appid="subghz",
     name="Sub-GHz",
-    apptype=FlipperAppType.APP,
+    apptype=FlipperAppType.EXTERNAL,
     targets=["f7"],
     cdefines=["APP_SUBGHZ"],
     entry_point="subghz_app",

--- a/applications/main/subghz/helpers/subghz_txrx.c
+++ b/applications/main/subghz/helpers/subghz_txrx.c
@@ -512,6 +512,16 @@ SubGhzSpeakerState subghz_txrx_speaker_get_state(SubGhzTxRx* instance) {
     return instance->speaker_state;
 }
 
+void subghz_txrx_autosave_set_state(SubGhzTxRx* instance, SubGhzAutosaveState state) {
+    furi_assert(instance);
+    instance->autosave_state = state;
+}
+
+SubGhzAutosaveState subghz_txrx_autosave_get_state(SubGhzTxRx* instance) {
+    furi_assert(instance);
+    return instance->autosave_state;
+}
+
 bool subghz_txrx_load_decoder_by_name_protocol(SubGhzTxRx* instance, const char* name_protocol) {
     furi_assert(instance);
     furi_assert(name_protocol);

--- a/applications/main/subghz/helpers/subghz_txrx.h
+++ b/applications/main/subghz/helpers/subghz_txrx.h
@@ -199,6 +199,22 @@ void subghz_txrx_speaker_set_state(SubGhzTxRx* instance, SubGhzSpeakerState stat
 SubGhzSpeakerState subghz_txrx_speaker_get_state(SubGhzTxRx* instance);
 
 /**
+ * Set state autosave
+ * 
+ * @param instance Pointer to a SubGhzTxRx 
+ * @param state State autosave
+ */
+void subghz_txrx_autosave_set_state(SubGhzTxRx* instance, SubGhzAutosaveState state);
+
+/**
+ * Get state autosave
+ * 
+ * @param instance Pointer to a SubGhzTxRx 
+ * @return SubGhzAutosaveState 
+ */
+SubGhzAutosaveState subghz_txrx_autosave_get_state(SubGhzTxRx* instance);
+
+/**
  * load decoder by name protocol
  * 
  * @param instance Pointer to a SubGhzTxRx

--- a/applications/main/subghz/helpers/subghz_txrx_i.h
+++ b/applications/main/subghz/helpers/subghz_txrx_i.h
@@ -24,6 +24,8 @@ struct SubGhzTxRx {
     const SubGhzDevice* radio_device;
     SubGhzRadioDeviceType radio_device_type;
 
+    SubGhzAutosaveState autosave_state;
+
     SubGhzTxRxNeedSaveCallback need_save_callback;
     void* need_save_context;
 

--- a/applications/main/subghz/helpers/subghz_types.h
+++ b/applications/main/subghz/helpers/subghz_types.h
@@ -71,6 +71,12 @@ typedef enum {
     SubGhzLockOn,
 } SubGhzLock;
 
+/** SubGhz RAW Autosave */
+typedef enum {
+    AutosaveOff,
+    AutosaveOn,
+} SubGhzAutosaveState;
+
 typedef enum {
     SubGhzViewIdMenu,
     SubGhzViewIdReceiver,

--- a/applications/main/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver_config.c
@@ -62,6 +62,7 @@ const uint32_t speaker_value[SPEAKER_COUNT] = {
     SubGhzSpeakerStateShutdown,
     SubGhzSpeakerStateEnable,
 };
+
 #define BIN_RAW_COUNT 2
 const char* const bin_raw_text[BIN_RAW_COUNT] = {
     "OFF",
@@ -71,10 +72,21 @@ const uint32_t bin_raw_value[BIN_RAW_COUNT] = {
     SubGhzProtocolFlag_Decodable,
     SubGhzProtocolFlag_Decodable | SubGhzProtocolFlag_BinRAW,
 };
+
 #define PROTOCOL_IGNORE_COUNT 2
 const char* const protocol_ignore_text[PROTOCOL_IGNORE_COUNT] = {
     "OFF",
     "ON",
+};
+
+#define AUTOSAVE_COUNT 2
+const char* const autosave_text[AUTOSAVE_COUNT] = {
+    "OFF",
+    "ON",
+};
+const uint32_t autosave_value[AUTOSAVE_COUNT] = {
+    AutosaveOff,
+    AutosaveOn,
 };
 
 uint8_t subghz_scene_receiver_config_next_frequency(const uint32_t value, void* context) {
@@ -276,6 +288,10 @@ static void subghz_scene_receiver_config_set_magellan(VariableItem* item) {
     subghz_scene_receiver_config_set_ignore_filter(item, SubGhzProtocolFlag_Magelan);
 }
 
+static void subghz_scene_receiver_config_set_autosave(VariableItem* item) {
+    subghz_scene_receiver_config_set_ignore_filter(item, SubGhzProtocolFlag_Autosave);
+}
+
 static void subghz_scene_receiver_config_var_list_enter_callback(void* context, uint32_t index) {
     furi_assert(context);
     SubGhz* subghz = context;
@@ -389,6 +405,18 @@ void subghz_scene_receiver_config_on_enter(void* context) {
             subghz->ignore_filter, SubGhzProtocolFlag_Magelan);
         variable_item_set_current_value_index(item, value_index);
         variable_item_set_current_value_text(item, protocol_ignore_text[value_index]);
+
+        item = variable_item_list_add(
+            subghz->variable_item_list,
+            "Autosave RAW:",
+            AUTOSAVE_COUNT,
+            subghz_scene_receiver_config_set_autosave,
+            subghz);
+
+        value_index = value_index_uint32(
+            subghz_txrx_autosave_get_state(subghz->txrx), autosave_value, AUTOSAVE_COUNT);
+        variable_item_set_current_value_index(item, value_index);
+        variable_item_set_current_value_text(item, autosave_text[value_index]);
     }
 
     // Enable speaker, will send all incoming noises and signals to speaker so you can listen how your remote sounds like :)

--- a/applications/main/subghz/subghz_history.c
+++ b/applications/main/subghz/subghz_history.c
@@ -147,13 +147,14 @@ FlipperFormat* subghz_history_get_raw_data(SubGhzHistory* instance, uint16_t idx
         return NULL;
     }
 }
+
 bool subghz_history_get_text_space_left(SubGhzHistory* instance, FuriString* output) {
     furi_assert(instance);
     if(memmgr_get_free_heap() < SUBGHZ_HISTORY_FREE_HEAP) {
         if(output != NULL) furi_string_printf(output, "    Free heap LOW");
         return true;
     }
-    if(instance->last_index_write == SUBGHZ_HISTORY_MAX) {
+    if(instance->last_index_write == SUBGHZ_HISTORY_MAX && SubGhzProtocolFlag_Autosave) {
         if(output != NULL) furi_string_printf(output, "   Memory is FULL");
         return true;
     }
@@ -165,6 +166,7 @@ bool subghz_history_get_text_space_left(SubGhzHistory* instance, FuriString* out
 uint16_t subghz_history_get_last_index(SubGhzHistory* instance) {
     return instance->last_index_write;
 }
+
 void subghz_history_get_text_item_menu(SubGhzHistory* instance, FuriString* output, uint16_t idx) {
     SubGhzHistoryItem* item = SubGhzHistoryItemArray_get(instance->history->data, idx);
     furi_string_set(output, item->item_str);

--- a/applications/main/subghz/subghz_history.c
+++ b/applications/main/subghz/subghz_history.c
@@ -154,7 +154,7 @@ bool subghz_history_get_text_space_left(SubGhzHistory* instance, FuriString* out
         if(output != NULL) furi_string_printf(output, "    Free heap LOW");
         return true;
     }
-    if(instance->last_index_write == SUBGHZ_HISTORY_MAX && SubGhzProtocolFlag_Autosave) {
+    if(instance->last_index_write == SUBGHZ_HISTORY_MAX) {
         if(output != NULL) furi_string_printf(output, "   Memory is FULL");
         return true;
     }

--- a/applications/main/subghz/subghz_history.h
+++ b/applications/main/subghz/subghz_history.h
@@ -6,6 +6,7 @@
 #include <furi_hal.h>
 #include <lib/flipper_format/flipper_format.h>
 #include <lib/subghz/types.h>
+#include "helpers/subghz_txrx.h"
 
 typedef struct SubGhzHistory SubGhzHistory;
 

--- a/lib/subghz/types.h
+++ b/lib/subghz/types.h
@@ -126,6 +126,7 @@ typedef enum {
     SubGhzProtocolFlag_StarLine = (1 << 11),
     SubGhzProtocolFlag_AutoAlarms = (1 << 12),
     SubGhzProtocolFlag_Magelan = (1 << 13),
+    SubGhzProtocolFlag_Autosave = (1 << 14),
 } SubGhzProtocolFlag;
 
 struct SubGhzProtocol {


### PR DESCRIPTION
Not sure if we should make this a part of unleashed, or the main firmware? Or at all? I'm not even sure if this is even a good idea yet but wanted to get this PR out to get an opinion on it as I tinker with it. Feel free to share thoughts, thanks all.

Edit: Side note, I'm also interested in maybe combining with the below work was well. Maybe as a new app?

https://github.com/flipperdevices/flipperzero-firmware/pull/1667

# What's new

- Autosave sub-ghz RAW data. Intention: bypass 55 capture/heap size max limits.

# Verification 

- In "Sub-GHz" application read & capture RAW, see autosave function.

# Todo

- [x] Add new "Autosave RAW" setting.
- [ ] Autosave captures when setting is "On".
- [ ] Default functionality when setting is "Off".

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
