### PR TITLE
SubGhz: fix assert failure during signal openning

### DIFF
--- a/applications/main/subghz/helpers/subghz_txrx.c
+++ b/applications/main/subghz/helpers/subghz_txrx.c
@@ -634,19 +634,6 @@ bool subghz_txrx_radio_device_is_frequecy_valid(SubGhzTxRx* instance, uint32_t f
     return subghz_devices_is_frequency_valid(instance->radio_device, frequency);
 }
 
-bool subghz_txrx_radio_device_is_tx_alowed(SubGhzTxRx* instance, uint32_t frequency) {
-    furi_assert(instance);
-    furi_assert(instance->txrx_state != SubGhzTxRxStateSleep);
-
-    subghz_devices_idle(instance->radio_device);
-    subghz_devices_set_frequency(instance->radio_device, frequency);
-
-    bool ret = subghz_devices_set_tx(instance->radio_device);
-    subghz_devices_idle(instance->radio_device);
-
-    return ret;
-}
-
 void subghz_txrx_set_debug_pin_state(SubGhzTxRx* instance, bool state) {
     furi_assert(instance);
     instance->debug_pin_state = state;

--- a/applications/main/subghz/helpers/subghz_txrx.h
+++ b/applications/main/subghz/helpers/subghz_txrx.h
@@ -336,8 +336,6 @@ const char* subghz_txrx_radio_device_get_name(SubGhzTxRx* instance);
 */
 bool subghz_txrx_radio_device_is_frequecy_valid(SubGhzTxRx* instance, uint32_t frequency);
 
-bool subghz_txrx_radio_device_is_tx_alowed(SubGhzTxRx* instance, uint32_t frequency);
-
 void subghz_txrx_set_debug_pin_state(SubGhzTxRx* instance, bool state);
 bool subghz_txrx_get_debug_pin_state(SubGhzTxRx* instance);
 

--- a/applications/main/subghz/subghz_i.c
+++ b/applications/main/subghz/subghz_i.c
@@ -121,12 +121,6 @@ bool subghz_key_load(SubGhz* subghz, const char* file_path, bool show_dialog) {
             break;
         }
 
-        if(!subghz_txrx_radio_device_is_tx_alowed(subghz->txrx, temp_data32)) {
-            FURI_LOG_E(TAG, "This frequency can only be used for RX on chosen radio module");
-            load_key_state = SubGhzLoadKeyStateOnlyRx;
-            break;
-        }
-
         //Load preset
         if(!flipper_format_read_string(fff_data_file, "Preset", temp_str)) {
             FURI_LOG_E(TAG, "Missing Preset");

--- a/applications/main/subghz_remote/helpers/txrx/subghz_txrx.c
+++ b/applications/main/subghz_remote/helpers/txrx/subghz_txrx.c
@@ -634,19 +634,6 @@ bool subghz_txrx_radio_device_is_frequecy_valid(SubGhzTxRx* instance, uint32_t f
     return subghz_devices_is_frequency_valid(instance->radio_device, frequency);
 }
 
-bool subghz_txrx_radio_device_is_tx_alowed(SubGhzTxRx* instance, uint32_t frequency) {
-    furi_assert(instance);
-    furi_assert(instance->txrx_state != SubGhzTxRxStateSleep);
-
-    subghz_devices_idle(instance->radio_device);
-    subghz_devices_set_frequency(instance->radio_device, frequency);
-
-    bool ret = subghz_devices_set_tx(instance->radio_device);
-    subghz_devices_idle(instance->radio_device);
-
-    return ret;
-}
-
 void subghz_txrx_set_debug_pin_state(SubGhzTxRx* instance, bool state) {
     furi_assert(instance);
     instance->debug_pin_state = state;

--- a/applications/main/subghz_remote/helpers/txrx/subghz_txrx.h
+++ b/applications/main/subghz_remote/helpers/txrx/subghz_txrx.h
@@ -365,8 +365,6 @@ const char* subghz_txrx_radio_device_get_name(SubGhzTxRx* instance);
 */
 bool subghz_txrx_radio_device_is_frequecy_valid(SubGhzTxRx* instance, uint32_t frequency);
 
-bool subghz_txrx_radio_device_is_tx_alowed(SubGhzTxRx* instance, uint32_t frequency);
-
 void subghz_txrx_set_debug_pin_state(SubGhzTxRx* instance, bool state);
 bool subghz_txrx_get_debug_pin_state(SubGhzTxRx* instance);
 


### PR DESCRIPTION
# What's new
Assert failed during open SubGhz signal
```
bool subghz_txrx_radio_device_is_tx_alowed(SubGhzTxRx* instance, uint32_t frequency) {
    furi_assert(instance->txrx_state != SubGhzTxRxStateSleep);
```

# Verification 

Open saved subghz signal

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
