### PR TITLE
Fix Sub-GHz Remote folder name

### DIFF
--- a/applications/main/subghz_remote/application.fam
+++ b/applications/main/subghz_remote/application.fam
@@ -13,5 +13,5 @@ App(
     fap_libs=["assets",],
     fap_icon="icon.png",
     fap_description="SubGhz Remote, uses up to 5 .sub files",
-    fap_category="Sub-Ghz",
+    fap_category="Sub-GHz",
 )


### PR DESCRIPTION
# What's new

- Default folder for sub-ghz apps is `Sub-GHz` but "Sub-GHz Remote" fap category is `Sub-Ghz` - lowercased `h` that produces 2 folders in `resources.tar` - ` Sub-GHz` and `Sub-Ghz`

![image](https://github.com/DarkFlippers/unleashed-firmware/assets/13971093/7fcb92d4-cdd1-42e4-a5f5-cec118210b83)

# Verification 

- Build update package, open `resources.tar` and verify that there is `Sub-GHz` folder, not `Sub-Ghz`

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
