### PR TITLE
bugfix t5577_write_with_pass

### DIFF
--- a/lib/lfrfid/tools/t5577.c
+++ b/lib/lfrfid/tools/t5577.c
@@ -110,7 +110,7 @@ void t5577_write_with_pass(LFRFIDT5577* data, uint32_t password) {
     t5577_start();
     FURI_CRITICAL_ENTER();
     for(size_t i = 0; i < data->blocks_to_write; i++) {
-        t5577_write_block_pass(0, false, data->block[i], true, password);
+        t5577_write_block_pass(i, false, data->block[i], true, password);
     }
     t5577_write_reset();
     FURI_CRITICAL_EXIT();


### PR DESCRIPTION
# What's new

- bugfix in T5577 write function with password `void t5577_write_with_pass(LFRFIDT5577* data, uint32_t password)`
- This PR https://github.com/DarkFlippers/unleashed-firmware/pull/493 added the original code, but I believe it contains a bug.
- There is no implementation that triggers the bug yet, so this improvement is just for future proofing.

# Verification 

- Code review by comparing with `t5577_write(LFRFIDT5577* data)` in the same file `t5577.c`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
