### PR TITLE
Update Install_qFlipper_macOS for macOS14

### DIFF
--- a/assets/resources/badusb/Install_qFlipper_macOS.txt
+++ b/assets/resources/badusb/Install_qFlipper_macOS.txt
@@ -5,7 +5,7 @@ REM Author: 47LeCoste
 REM Version 1.0 (Flipper Ducky)
 REM Target: macOS
 DELAY 3000
-F4
+GUI SPACE
 DELAY 2500
 STRING Terminal
 DELAY 2500


### PR DESCRIPTION
Updated to call spotlight by using CMD+SPACE, instead on F4. F4 does not open spotlight on newer versions of macOS

# What's new

- Changed F4 to "GUI SPACE" to actually call spotlight

# Verification 

- Simply run the updated script on a Mac, or watch this quick demonstration of the updated script working. https://youtu.be/nibd5X2_sqs

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
