### PR TITLE
lfrfid: Add support for ELECTRA access systems (extra data)

### DIFF
--- a/applications/main/lfrfid/lfrfid.c
+++ b/applications/main/lfrfid/lfrfid.c
@@ -255,7 +255,8 @@ bool lfrfid_load_raw_key_from_file_select(LfRfid* app) {
     furi_assert(app);
 
     DialogsFileBrowserOptions browser_options;
-    dialog_file_browser_set_basic_options(&browser_options, ".raw", &I_125_10px);
+    dialog_file_browser_set_basic_options(
+        &browser_options, LFRFID_APP_RAW_ASK_EXTENSION, &I_125_10px);
     browser_options.base_path = LFRFID_APP_FOLDER;
 
     // Input events and views are managed by file_browser
@@ -263,14 +264,13 @@ bool lfrfid_load_raw_key_from_file_select(LfRfid* app) {
         dialog_file_browser_show(app->dialogs, app->file_path, app->file_path, &browser_options);
 
     if(result) {
-        // Extract .raw
+        // Extract .raw and then .ask
         path_extract_filename(app->file_path, app->file_name, true);
-        //path_extract_filename(app->file_name, app->file_name, true);
+        path_extract_filename(app->file_name, app->file_name, true);
     }
 
     return result;
 }
-
 bool lfrfid_delete_key(LfRfid* app) {
     furi_assert(app);
 


### PR DESCRIPTION
# What's new

-Added support for ELECTRA access fobs EM410X that contain "security" data. As per issue: https://forum.flipper.net/t/electra-intercom/6368/54

# Verification 

- I tried the code, READ, WROTE and EMULATED an ELECTRA ACCES CARD. I am new at coding, no ideea what to write here :(

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
