### PR TITLE
Added lfrfid protocol EM4100/40/RAW

### DIFF
--- a/documentation/LFRFID_EM4100_RAW.md
+++ b/documentation/LFRFID_EM4100_RAW.md
@@ -1,0 +1,48 @@
+# LFRFIDProtocolEM4100_RAW
+
+The LFRFIDProtocolEM4100_RAW protocol allows for emulating 8 bytes (64 bits) of data as entered directly by the user.
+It uses a 40cs/bit bit rate, and ASK/Manchester. It is useful for emulating cards that are not yet supported, such as SecuraKey.
+
+As of now, this protocol is meant purely for easily emulating arbitrary 64bit ASK data at a 40cs/bit-rate. As such, the read function is not useful with this protocol.
+
+## SecuraKey RKKT-01 Example:
+SecuraKey provides little information about the encoding on their basic 26-bit wiegand formatted cards.
+One variant it is known to use for its black puck keyfobs is ASK/Manchester encoded, has a bit-rate of 40, and has an unusual "wiegand" structure, whose parity bits it ignores. Let's look at an example:
+
+We receive (a Black Securakey)[https://securakeystore.com/store/securakey-rkkt-01-prox-key-tag.html], (archived)[https://web.archive.org/web/20231211065716/https://securakeystore.com/store/securakey-rkkt-01-prox-key-tag.html] with a random number of 2421258 which sends the following 8 bytes on repeat at a bit-rate of 40:
+
+Hex     FF 80 00 00 01 23 C8 14
+Binary  11111111 10000000 00000000 00000000 00000001 00100011 11001000 00010100
+
+How did it get this value? It works like this:
+
+The first two bytes are a primitive header (taken from the EM4100): FF 80
+
+The second two bytes are zero: 00 00
+
+The last four bytes are where the data is encoded / the madness happens.
+To sort through it we take the keyfob number (2421258), and convert is to hex, and binary:
+
+Dec     2421258
+Hex     24 f2 0a
+Bin     00100100 11110010 00001010
+
+Now, insert an extra zero-bit after each byte:
+
+Bin     00100100 0 11110010 0 00001010 0
+                 ^          ^          ^
+                 |          |          |
+                These are the three inserted zero-bits.
+
+The new value in binary is 00000001 00100011 11001000 00010100.
+So, our original three-byte fob number now has four bytes. This new, extended number in decimal, hex, and binary is:
+
+Dec     19122196
+Hex     01 23 c8 14
+Bin     00000001 00100011 11001000 00010100
+
+Putting the two header bytes, two zero-bytes, and the four recently calculated data bytes together gives the previously mentioned value:
+
+Dec     18410715276709709844
+Hex     ff 80 00 00 01 23 c8 14
+Bin     11111111 10000000 00000000 00000000 00000001 00100011 11001000 00010100

--- a/lib/lfrfid/protocols/lfrfid_protocols.c
+++ b/lib/lfrfid/protocols/lfrfid_protocols.c
@@ -20,6 +20,7 @@
 
 const ProtocolBase* lfrfid_protocols[] = {
     [LFRFIDProtocolEM4100] = &protocol_em4100,
+    [LFRFIDProtocolEM4100_RAW] = &protocol_em4100_raw,
     [LFRFIDProtocolEM4100_32] = &protocol_em4100_32,
     [LFRFIDProtocolEM4100_16] = &protocol_em4100_16,
     [LFRFIDProtocolH10301] = &protocol_h10301,

--- a/lib/lfrfid/protocols/lfrfid_protocols.h
+++ b/lib/lfrfid/protocols/lfrfid_protocols.h
@@ -9,6 +9,7 @@ typedef enum {
 
 typedef enum {
     LFRFIDProtocolEM4100,
+    LFRFIDProtocolEM4100_RAW,
     LFRFIDProtocolEM4100_32,
     LFRFIDProtocolEM4100_16,
     LFRFIDProtocolH10301,

--- a/lib/lfrfid/protocols/protocol_em4100.h
+++ b/lib/lfrfid/protocols/protocol_em4100.h
@@ -3,6 +3,8 @@
 
 extern const ProtocolBase protocol_em4100;
 
+extern const ProtocolBase protocol_em4100_raw;
+
 extern const ProtocolBase protocol_em4100_32;
 
 extern const ProtocolBase protocol_em4100_16;


### PR DESCRIPTION
This protocol allows users to send 8 bytes (64 bits) of data directly without any encoding.

Added documentation/LFRFID_EM4100_RAW.md

# What's new

Sometimes it is useful to send eight bytes of your choosing over, and over again using ASK at 40cs/bit-rate.

# Verification 
A device such as a proxmark3 should be able to demodulate data as em4100. Try emulating FF80000001234567 while reading with a device like proxmark3.

# Checklist (For Reviewer)

- [X] PR has description of feature/bug
- [X] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
