### PR TITLE
Toniebox menu spelling fix

### DIFF
--- a/applications/main/nfc/scenes/nfc_scene_slix_unlock_menu.c
+++ b/applications/main/nfc/scenes/nfc_scene_slix_unlock_menu.c
@@ -25,7 +25,7 @@ void nfc_scene_slix_unlock_menu_on_enter(void* context) {
         instance);
     submenu_add_item(
         submenu,
-        "Auth As TommyBox",
+        "Auth As TonieBox",
         SubmenuIndexSlixUnlockMenuTonieBox,
         nfc_scene_slix_unlock_menu_submenu_callback,
         instance);


### PR DESCRIPTION
# What's new

- TommyBox should be TonieBox 

# Verification 

- open unlock slix menu
- verify TonieBox spelling is correct 

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
