### PR TITLE
NFC: Fix Mifare DESFire reading

### DIFF
--- a/lib/nfc/helpers/iso14443_4_layer.c
+++ b/lib/nfc/helpers/iso14443_4_layer.c
@@ -68,7 +68,9 @@ bool iso14443_4_layer_decode_block(
 
     // TODO: Fix properly! this is a very big kostyl na velosipede
     // (bit_buffer_copy_right are called to copy bigger buffer into smaller buffer causing crash on furi check) issue comes iso14443_4a_poller_send_block at line 109
-    if(bit_buffer_get_size_bytes(output_data) < bit_buffer_get_size_bytes(output_data) - 1)
+    // Mimicks furi_check()s in bit_buffer_copy_right(): buf=output_data other=block_data start_index=1
+    if(!(bit_buffer_get_size_bytes(block_data) > 1)) return ret;
+    if(!(bit_buffer_get_capacity_bytes(output_data) >= bit_buffer_get_size_bytes(block_data) - 1))
         return ret;
 
     do {


### PR DESCRIPTION
# What's new

- Previous fix for EMV read crash in 75ece9b697d1e3b66a75f2d423e51f369bc387f1 caused DESFire to never read
- Was comparing sizes of same buffer, and also logic should have compared size and capacity, destination buffer is always empty in beginning so size is 0
- Changed check to use same parameters as the furi_check()s that cause the crash in this original bugfix from 75ece9b697d1e3b66a75f2d423e51f369bc387f1
- Fixes #756 

# Verification 

- Read any Mifare DESFire card
- Read EMV cards that used to cause crashes before 75ece9b697d1e3b66a75f2d423e51f369bc387f1

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
