### PR TITLE
LFRFID: add DEZ 10 display form for EM4100

### DIFF
--- a/lib/lfrfid/protocols/protocol_em4100.c
+++ b/lib/lfrfid/protocols/protocol_em4100.c
@@ -347,11 +347,13 @@ void protocol_em4100_render_data(ProtocolEM4100* protocol, FuriString* result) {
     uint8_t* data = protocol->data;
     furi_string_printf(
         result,
-        "FC: %03u\n"
-        "Card: %05hu (RF/%hhu)",
+        "FC: %03u Card: %05hu CL:%hhu\n"
+        "DEZ 10: %010lu",
         data[2],
         (uint16_t)((data[3] << 8) | (data[4])),
-        protocol->clock_per_bit);
+        protocol->clock_per_bit,
+        (uint32_t)((data[2] << 16) | (data[3] << 8) | (data[4]))
+    );
 };
 
 const ProtocolBase protocol_em4100 = {


### PR DESCRIPTION
# What's new

- Added DEZ 10 display format for EM4100 which is popular in some systems

# Verification 

- Read/display EM4100 tag

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
