### PR TITLE
NFC: add CTAS Andalucia reader

### DIFF
--- a/applications/main/nfc/application.fam
+++ b/applications/main/nfc/application.fam
@@ -147,6 +147,15 @@ App(
 )
 
 App(
+    appid="andalucia_parser",
+    apptype=FlipperAppType.PLUGIN,
+    entry_point="andalucia_plugin_ep",
+    targets=["f7"],
+    requires=["nfc"],
+    sources=["plugins/supported_cards/andalucia.c"],
+)
+
+App(
     appid="aime_parser",
     apptype=FlipperAppType.PLUGIN,
     entry_point="aime_plugin_ep",

--- a/applications/main/nfc/plugins/supported_cards/andalucia.c
+++ b/applications/main/nfc/plugins/supported_cards/andalucia.c
@@ -1,92 +1,133 @@
 #include "nfc_supported_card_plugin.h"
 #include <flipper_application.h>
 
+#include "protocols/mf_classic/mf_classic.h"
 #include <nfc/protocols/mf_classic/mf_classic_poller_sync.h>
 
 #include <bit_lib.h>
 
 #define TAG "Andalucia"
 
-#include <gui/modules/widget.h>
-#include <nfc_worker_i.h>
+static const uint64_t andalucia_key = 0x99100225D83B;
+static const uint8_t andalucia_sector = 9;
 
-#include <furi_hal.h>
+bool andalucia_verify(Nfc* nfc) {
+    bool verified = false;
 
-static const MfClassicAuthContext andalucia_keys[] = {
-    {.sector = 0, .key_a = 0xA0A1A2A3A4A5, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 1, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 2, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 3, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 4, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 5, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 6, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 7, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 8, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 9, .key_a = 0x99100225D83B, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 10, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 11, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 12, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 13, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 14, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
-    {.sector = 15, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    do {
+        uint8_t block_num = mf_classic_get_first_block_num_of_sector(andalucia_sector);
+        FURI_LOG_D(TAG, "Andalucia: Verifying sector %u", andalucia_sector);
+
+        MfClassicKey key = {};
+        bit_lib_num_to_bytes_be(andalucia_key, COUNT_OF(key.data), key.data);
+
+        MfClassicAuthContext auth_ctx = {};
+        MfClassicError error =
+            mf_classic_poller_sync_auth(nfc, block_num, &key, MfClassicKeyTypeA, &auth_ctx);
+
+        if(error != MfClassicErrorNone) {
+            FURI_LOG_D(TAG, "Andalucia: Failed to read block %u: %d", block_num, error);
+            break;
+        }
+
+        verified = true;
+    } while(false);
+
+    return verified;
+}
+
+static bool andalucia_read(Nfc* nfc, NfcDevice* device) {
+    furi_assert(nfc);
+    furi_assert(device);
+
+    bool is_read = false;
+
+    MfClassicData* data = mf_classic_alloc();
+    nfc_device_copy_data(device, NfcProtocolMfClassic, data);
+
+    do {
+        MfClassicType type = MfClassicType1k;
+        MfClassicError error = mf_classic_poller_sync_detect_type(nfc, &type);
+        if(error != MfClassicErrorNone) break;
+
+        data->type = type;
+        if(type != MfClassicType1k) break;
+
+        MfClassicDeviceKeys keys = {};
+        for(size_t i = 0; i < mf_classic_get_total_sectors_num(data->type); i++) {
+            bit_lib_num_to_bytes_be(andalucia_key, sizeof(MfClassicKey), keys.key_a[i].data);
+            FURI_BIT_SET(keys.key_a_mask, i);
+            bit_lib_num_to_bytes_be(andalucia_key, sizeof(MfClassicKey), keys.key_b[i].data);
+            FURI_BIT_SET(keys.key_b_mask, i);
+        }
+
+        error = mf_classic_poller_sync_read(nfc, &keys, data);
+        if(error == MfClassicErrorNotPresent) {
+            FURI_LOG_W(TAG, "Andalucia: Failed to read data");
+            break;
+        }
+
+        nfc_device_set_data(device, NfcProtocolMfClassic, data);
+
+        is_read = (error == MfClassicErrorNone);
+    } while(false);
+
+    mf_classic_free(data);
+
+    return is_read;
+}
+
+static bool andalucia_parse(const NfcDevice* device, FuriString* parsed_data) {
+    furi_assert(device);
+    furi_assert(parsed_data);
+
+    const MfClassicData* data = nfc_device_get_data(device, NfcProtocolMfClassic);
+
+    bool parsed = false;
+
+    do {
+        // Verify key
+        MfClassicSectorTrailer* sec_tr = mf_classic_get_sector_trailer_by_sector(data, andalucia_sector);
+        uint64_t key = bit_lib_bytes_to_num_be(sec_tr->key_a.data, 6);
+        if(key != andalucia_key) return false;
+
+        // Verify card type
+        if(data->type != MfClassicType1k) return false;
+
+        // Point to sector 9, block 1, value 0
+        const uint8_t* temp_ptr = &data->block[andalucia_sector * 4 + 1].data[0];
+        // Read first 4 bytes of block 0 of sector 4 from last to first and convert them to uint32_t
+        // 38 18 00 00 becomes 00 00 18 38, and equals to 6200 decimal
+        uint32_t balance =
+            ((temp_ptr[3] << 24) | (temp_ptr[2] << 16) | (temp_ptr[1] << 8) | temp_ptr[0]);
+
+        double eur = (balance / 2) / 100.0f;
+
+        furi_string_printf(
+            parsed_data, "\e#Andalucia\nBalance: %.2f euros.", eur);
+
+        parsed = true;
+    } while(false);
+
+    return parsed;
+}
+
+/* Actual implementation of app<>plugin interface */
+static const NfcSupportedCardsPlugin andalucia_plugin = {
+    .protocol = NfcProtocolMfClassic,
+    .verify = andalucia_verify,
+    .read = andalucia_read,
+    .parse = andalucia_parse,
 };
 
-bool andalucia_parser_verify(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
-    furi_assert(nfc_worker);
-    UNUSED(nfc_worker);
+/* Plugin descriptor to comply with basic plugin specification */
+static const FlipperAppPluginDescriptor andalucia_plugin_descriptor = {
+    .appid = NFC_SUPPORTED_CARD_PLUGIN_APP_ID,
+    .ep_api_version = NFC_SUPPORTED_CARD_PLUGIN_API_VERSION,
+    .entry_point = &andalucia_plugin,
+};
 
-    if(nfc_worker->dev_data->mf_classic_data.type != MfClassicType1k) {
-        return false;
-    }
-
-    uint8_t sector = 9;
-    uint8_t block = mf_classic_get_sector_trailer_block_num_by_sector(sector);
-    FURI_LOG_D("Andalucia", "Verifying sector %d", sector);
-    if(mf_classic_authenticate(tx_rx, block, 0x99100225D83B, MfClassicKeyA)) {
-        FURI_LOG_D("Andalucia", "Sector %d verified", sector);
-        return true;
-    }
-    return false;
-}
-
-bool andalucia_parser_read(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
-    furi_assert(nfc_worker);
-
-    MfClassicReader reader = {};
-    FuriHalNfcDevData* nfc_data = &nfc_worker->dev_data->nfc_data;
-    reader.type = mf_classic_get_classic_type(nfc_data->atqa[0], nfc_data->atqa[1], nfc_data->sak);
-
-    for(size_t i = 0; i < COUNT_OF(andalucia_keys); i++) {
-        mf_classic_reader_add_sector(
-            &reader, andalucia_keys[i].sector, andalucia_keys[i].key_a, andalucia_keys[i].key_b);
-        FURI_LOG_T("Andalucia", "Added sector %d", andalucia_keys[i].sector);
-    }
-
-    return mf_classic_read_card(tx_rx, &reader, &nfc_worker->dev_data->mf_classic_data) == 16;
-}
-
-bool andalucia_parser_parse(NfcDeviceData* dev_data) {
-    MfClassicData* data = &dev_data->mf_classic_data;
-
-    // Verify key
-    MfClassicSectorTrailer* sec_tr = mf_classic_get_sector_trailer_by_sector(data, 9);
-    uint64_t key = nfc_util_bytes2num(sec_tr->key_a, 6);
-    if(key != andalucia_keys[9].key_a) return false;
-
-    // Verify card type
-    if(data->type != MfClassicType1k) return false;
-
-    // Point to block 1 of sector 9, value 0
-    uint8_t* temp_ptr = &data->block[9 * 4 + 1].value[0];
-    // Read first 4 bytes of block 0 of sector 4 from last to first and convert them to uint32_t
-    // 38 18 00 00 becomes 00 00 18 38, and equals to 6200 decimal
-    uint32_t balance =
-        ((temp_ptr[3] << 24) | (temp_ptr[2] << 16) | (temp_ptr[1] << 8) | temp_ptr[0]);
-
-    double eur = (balance / 2) / 100.0f;
-
-    furi_string_printf(
-        dev_data->parsed_data, "\e#Andalucia\nBalance: %.2f euros.", eur);
-
-    return true;
+/* Plugin entry point - must return a pointer to const descriptor  */
+const FlipperAppPluginDescriptor* andalucia_plugin_ep(void) {
+    return &andalucia_plugin_descriptor;
 }

--- a/applications/main/nfc/plugins/supported_cards/andalucia.c
+++ b/applications/main/nfc/plugins/supported_cards/andalucia.c
@@ -1,0 +1,92 @@
+#include "nfc_supported_card_plugin.h"
+#include <flipper_application.h>
+
+#include <nfc/protocols/mf_classic/mf_classic_poller_sync.h>
+
+#include <bit_lib.h>
+
+#define TAG "Andalucia"
+
+#include <gui/modules/widget.h>
+#include <nfc_worker_i.h>
+
+#include <furi_hal.h>
+
+static const MfClassicAuthContext andalucia_keys[] = {
+    {.sector = 0, .key_a = 0xA0A1A2A3A4A5, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 1, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 2, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 3, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 4, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 5, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 6, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 7, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 8, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 9, .key_a = 0x99100225D83B, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 10, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 11, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 12, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 13, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 14, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+    {.sector = 15, .key_a = 0xFFFFFFFFFFFF, .key_b = 0xFFFFFFFFFFFF},
+};
+
+bool andalucia_parser_verify(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
+    furi_assert(nfc_worker);
+    UNUSED(nfc_worker);
+
+    if(nfc_worker->dev_data->mf_classic_data.type != MfClassicType1k) {
+        return false;
+    }
+
+    uint8_t sector = 9;
+    uint8_t block = mf_classic_get_sector_trailer_block_num_by_sector(sector);
+    FURI_LOG_D("Andalucia", "Verifying sector %d", sector);
+    if(mf_classic_authenticate(tx_rx, block, 0x99100225D83B, MfClassicKeyA)) {
+        FURI_LOG_D("Andalucia", "Sector %d verified", sector);
+        return true;
+    }
+    return false;
+}
+
+bool andalucia_parser_read(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
+    furi_assert(nfc_worker);
+
+    MfClassicReader reader = {};
+    FuriHalNfcDevData* nfc_data = &nfc_worker->dev_data->nfc_data;
+    reader.type = mf_classic_get_classic_type(nfc_data->atqa[0], nfc_data->atqa[1], nfc_data->sak);
+
+    for(size_t i = 0; i < COUNT_OF(andalucia_keys); i++) {
+        mf_classic_reader_add_sector(
+            &reader, andalucia_keys[i].sector, andalucia_keys[i].key_a, andalucia_keys[i].key_b);
+        FURI_LOG_T("Andalucia", "Added sector %d", andalucia_keys[i].sector);
+    }
+
+    return mf_classic_read_card(tx_rx, &reader, &nfc_worker->dev_data->mf_classic_data) == 16;
+}
+
+bool andalucia_parser_parse(NfcDeviceData* dev_data) {
+    MfClassicData* data = &dev_data->mf_classic_data;
+
+    // Verify key
+    MfClassicSectorTrailer* sec_tr = mf_classic_get_sector_trailer_by_sector(data, 9);
+    uint64_t key = nfc_util_bytes2num(sec_tr->key_a, 6);
+    if(key != andalucia_keys[9].key_a) return false;
+
+    // Verify card type
+    if(data->type != MfClassicType1k) return false;
+
+    // Point to block 1 of sector 9, value 0
+    uint8_t* temp_ptr = &data->block[9 * 4 + 1].value[0];
+    // Read first 4 bytes of block 0 of sector 4 from last to first and convert them to uint32_t
+    // 38 18 00 00 becomes 00 00 18 38, and equals to 6200 decimal
+    uint32_t balance =
+        ((temp_ptr[3] << 24) | (temp_ptr[2] << 16) | (temp_ptr[1] << 8) | temp_ptr[0]);
+
+    double eur = (balance / 2) / 100.0f;
+
+    furi_string_printf(
+        dev_data->parsed_data, "\e#Andalucia\nBalance: %.2f euros.", eur);
+
+    return true;
+}


### PR DESCRIPTION
# What's new

- Read balance available for NFC transport card, based in https://github.com/Alejandro12120/flipperzero-firmware/commit/7d9ff0431a9ba35b0662582a2f548f0e5f302fef

# Verification 

- I have read a card and validated the plugin display works.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
