### PR TITLE
Fixed bug with UL reading

### DIFF
--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
@@ -508,7 +508,7 @@ static NfcCommand mf_ultralight_poller_handler_read_pages(MfUltralightPoller* in
     if(instance->error == MfUltralightErrorNone) {
 		if (start_page < instance->pages_total) {
 			FURI_LOG_D(TAG, "Read page %d success", start_page);
-			instance->data->page[start_page] = data.page[start_page];
+			instance->data->page[start_page] = data.page[0];
 			instance->pages_read++;
 			instance->data->pages_read = instance->pages_read;
 		}


### PR DESCRIPTION
# What's new

- In #825 there was a bug with addressing read data, which has 4 MFUL pages (4 byte per page), we always read by one, so need only first 4 bytes

# Verification 

- Read MFUL tag (no matter pwd locked or not). Validate correctness of data, comparing to PM3 result

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
