### PR TITLE
Switch off autolock and autopoweroff when USB cable connected.

### DIFF
--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -12,6 +12,7 @@
 
 #include "scenes/desktop_scene.h"
 #include "scenes/desktop_scene_locked.h"
+#include "furi_hal_power.h"
 
 #define TAG "Desktop"
 
@@ -154,10 +155,18 @@ static bool desktop_custom_event_callback(void* context, uint32_t event) {
 
     } else if(event == DesktopGlobalAutoLock) {
         if(!desktop->app_running && !desktop->locked) {
+            // if restrict_autolock_autopoweroff enabled and device charging or device charged but still connected to USB then break desktop locking.
+            if ((desktop->settings.restrict_autolock_autopoweroff) && ((furi_hal_power_is_charging()) || (furi_hal_power_is_charging_done()))){
+            return(0);
+            } 
             desktop_lock(desktop);
         }
-    } else if(event == DesktopGlobalAutoPowerOff) {
+    } else if(event == DesktopGlobalAutoPowerOff) {      
         if(!desktop->app_running) {
+            // if restrict_autolock_autopoweroff enabled and device charging or device charged but still connected to USB then break poweoff.
+            if ((desktop->settings.restrict_autolock_autopoweroff) && ((furi_hal_power_is_charging()) || (furi_hal_power_is_charging_done()))){
+            return(0);
+            }    
             Power* power = furi_record_open(RECORD_POWER);
             power_off(power);
         }

--- a/applications/services/desktop/desktop_settings.c
+++ b/applications/services/desktop/desktop_settings.c
@@ -6,20 +6,21 @@
 
 #define TAG "DesktopSettings"
 
-#define DESKTOP_SETTINGS_VER_14 (14)
-#define DESKTOP_SETTINGS_VER    (15)
+#define DESKTOP_SETTINGS_VER_15 (15)
+#define DESKTOP_SETTINGS_VER    (16)
 
 #define DESKTOP_SETTINGS_PATH  INT_PATH(DESKTOP_SETTINGS_FILE_NAME)
 #define DESKTOP_SETTINGS_MAGIC (0x17)
 
 typedef struct {
     uint32_t auto_lock_delay_ms;
+    uint32_t auto_poweroff_delay_ms;  //--- auto_power_off_timer
     uint8_t displayBatteryPercentage;
     uint8_t dummy_mode;
     uint8_t display_clock;
     FavoriteApp favorite_apps[FavoriteAppNumber];
     FavoriteApp dummy_apps[DummyAppNumber];
-} DesktopSettingsV14;
+} DesktopSettingsV15;
 
 // Actual size of DesktopSettings v13
 //static_assert(sizeof(DesktopSettingsV13) == 1234);
@@ -41,31 +42,32 @@ void desktop_settings_load(DesktopSettings* settings) {
                 DESKTOP_SETTINGS_MAGIC,
                 DESKTOP_SETTINGS_VER);
 
-        } else if(version == DESKTOP_SETTINGS_VER_14) {
-            DesktopSettingsV14* settings_v14 = malloc(sizeof(DesktopSettingsV14));
+        } else if(version == DESKTOP_SETTINGS_VER_15) {
+            DesktopSettingsV15* settings_v15 = malloc(sizeof(DesktopSettingsV15));
 
             success = saved_struct_load(
                 DESKTOP_SETTINGS_PATH,
-                settings_v14,
-                sizeof(DesktopSettingsV14),
+                settings_v15,
+                sizeof(DesktopSettingsV15),
                 DESKTOP_SETTINGS_MAGIC,
-                DESKTOP_SETTINGS_VER_14);
+                DESKTOP_SETTINGS_VER_15);
 
             if(success) {
-                settings->auto_lock_delay_ms = settings_v14->auto_lock_delay_ms;
-                settings->auto_poweroff_delay_ms = 0;
-                settings->displayBatteryPercentage = settings_v14->displayBatteryPercentage;
-                settings->dummy_mode = settings_v14->dummy_mode;
-                settings->display_clock = settings_v14->display_clock;
+                settings->auto_lock_delay_ms = settings_v15->auto_lock_delay_ms;
+                settings->auto_poweroff_delay_ms = settings_v15->auto_poweroff_delay_ms;
+                settings->restrict_autolock_autopoweroff=0;
+                settings->displayBatteryPercentage = settings_v15->displayBatteryPercentage;
+                settings->dummy_mode = settings_v15->dummy_mode;
+                settings->display_clock = settings_v15->display_clock;
                 memcpy(
                     settings->favorite_apps,
-                    settings_v14->favorite_apps,
+                    settings_v15->favorite_apps,
                     sizeof(settings->favorite_apps));
                 memcpy(
-                    settings->dummy_apps, settings_v14->dummy_apps, sizeof(settings->dummy_apps));
+                    settings->dummy_apps, settings_v15->dummy_apps, sizeof(settings->dummy_apps));
             }
 
-            free(settings_v14);
+            free(settings_v15);
         }
 
     } while(false);

--- a/applications/services/desktop/desktop_settings.h
+++ b/applications/services/desktop/desktop_settings.h
@@ -38,9 +38,8 @@ typedef struct {
 
 typedef struct {
     uint32_t auto_lock_delay_ms;
-    //--- auto_power_off_timer
-    uint32_t auto_poweroff_delay_ms;
-    //---
+    uint32_t auto_poweroff_delay_ms;  //--- auto_power_off_timer
+    uint8_t restrict_autolock_autopoweroff;  //--- restrict_autolock_autopoweroff (on|off)
     uint8_t displayBatteryPercentage;
     uint8_t dummy_mode;
     uint8_t display_clock;

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -10,6 +10,7 @@ typedef enum {
     DesktopSettingsPinSetup = 0,
     DesktopSettingsAutoLockDelay,
     DesktopSettingsAutoPowerOff,
+    DesktopSettingsRestrictAutoLockAutoPowerOff,
     DesktopSettingsBatteryDisplay,
     DesktopSettingsClockDisplay,
     DesktopSettingsChangeName,
@@ -62,6 +63,16 @@ const char* const clock_enable_text[CLOCK_ENABLE_COUNT] = {
 
 const uint32_t clock_enable_value[CLOCK_ENABLE_COUNT] = {0, 1};
 
+//--- Menu options for restrict_autolock_autopoweroff
+#define RESTRICT_AUTOLOCK_AUTOPOWEROFF_COUNT 2
+const char* const restrict_autolock_autopoweroff_text[RESTRICT_AUTOLOCK_AUTOPOWEROFF_COUNT] = {
+    "OFF",
+    "ON",
+};
+
+const uint32_t restrict_autolock_autopoweroff_value[RESTRICT_AUTOLOCK_AUTOPOWEROFF_COUNT] = {0, 1};
+//---
+
 #define BATTERY_VIEW_COUNT 6
 
 const char* const battery_view_count_text[BATTERY_VIEW_COUNT] =
@@ -113,7 +124,15 @@ static void desktop_settings_scene_start_auto_lock_delay_changed(VariableItem* i
     variable_item_set_current_value_text(item, auto_lock_delay_text[index]);
     app->settings.auto_lock_delay_ms = auto_lock_delay_value[index];
 }
+//--- restrict_autolock_autopoweroff
+static void desktop_settings_scene_start_restrict_autolock_autopoweroff_changed(VariableItem* item) {
+    DesktopSettingsApp* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
 
+    variable_item_set_current_value_text(item, restrict_autolock_autopoweroff_text[index]);
+    app->settings.restrict_autolock_autopoweroff = restrict_autolock_autopoweroff_value[index];
+}
+//---
 void desktop_settings_scene_start_on_enter(void* context) {
     DesktopSettingsApp* app = context;
     VariableItemList* variable_item_list = app->variable_item_list;
@@ -149,6 +168,22 @@ void desktop_settings_scene_start_on_enter(void* context) {
         AUTO_POWEROFF_DELAY_COUNT);
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, auto_poweroff_delay_text[value_index]);
+    // ---
+ 
+    // --- Add menu line for restrict_autolock_autopoweroff
+    item = variable_item_list_add(
+        variable_item_list,
+        "USB restrict AutoLock/AutoPowerOff",
+        RESTRICT_AUTOLOCK_AUTOPOWEROFF_COUNT,
+        desktop_settings_scene_start_restrict_autolock_autopoweroff_changed,
+        app);
+
+    value_index = value_index_uint32(
+        app->settings.restrict_autolock_autopoweroff,
+        restrict_autolock_autopoweroff_value,
+        RESTRICT_AUTOLOCK_AUTOPOWEROFF_COUNT);
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, restrict_autolock_autopoweroff_text[value_index]);
     // ---
 
     item = variable_item_list_add(


### PR DESCRIPTION
# What's new

Added desktop setting option who restrict autolock and autopoweoff when USB cable connected. (Flipper Zero will be not autolocked and cant autopoweroff if USB cable connected to device).

According to https://github.com/DarkFlippers/unleashed-firmware/issues/850