### PR TITLE
Autolock disarm by active USB connection instead of USB charging connection.

### DIFF
--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -17,11 +17,6 @@
 
 #define TAG "Desktop"
 
-// dublicate constants from desktop_setting_scene_start.c
-#define USB_INHIBIT_AUTOLOCK_OFF 0
-#define USB_INHIBIT_AUTOLOCK_ON  1
-#define USB_INHIBIT_AUTOLOCK_RPC 2
-
 static void desktop_auto_lock_arm(Desktop*);
 static void desktop_auto_lock_inhibit(Desktop*);
 static void desktop_start_auto_lock_timer(Desktop*);
@@ -150,15 +145,11 @@ static bool desktop_custom_event_callback(void* context, uint32_t event) {
 
     } else if(event == DesktopGlobalAutoLock) {
         if(!desktop->app_running && !desktop->locked) {
-            // if usb_inhibit_autolock enabled and device charging or device charged but still connected to USB then break desktop locking.
-            if((desktop->settings.usb_inhibit_auto_lock == USB_INHIBIT_AUTOLOCK_ON) &&
-               ((furi_hal_power_is_charging()) || (furi_hal_power_is_charging_done()))) {
+            // Disable AutoLock if usb_inhibit_autolock option enabled and device have active USB connection.
+            if((desktop->settings.usb_inhibit_auto_lock) && (furi_hal_usb_is_locked())) {
                 return (0);
             }
-            // if usb_inhibit_autolock set to RPC and we have F0 connected to phone or PC app then break desktop locking.
-            if(desktop->settings.usb_inhibit_auto_lock == USB_INHIBIT_AUTOLOCK_RPC) {
-                return (0);
-            }
+            
             desktop_lock(desktop);
         }
     } else if(event == DesktopGlobalSaveSettings) {

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -45,22 +45,14 @@ const char* const auto_lock_delay_text[AUTO_LOCK_DELAY_COUNT] = {
 const uint32_t auto_lock_delay_value[AUTO_LOCK_DELAY_COUNT] =
     {0, 10000, 15000, 30000, 60000, 90000, 120000, 300000, 600000};
 
-#define USB_INHIBIT_AUTO_LOCK_DELAY_COUNT 3
-#define USB_INHIBIT_AUTOLOCK_OFF          0
-#define USB_INHIBIT_AUTOLOCK_ON           1
-#define USB_INHIBIT_AUTOLOCK_RPC          2
+#define USB_INHIBIT_AUTO_LOCK_DELAY_COUNT 2
 
 const char* const usb_inhibit_auto_lock_delay_text[USB_INHIBIT_AUTO_LOCK_DELAY_COUNT] = {
     "OFF",
     "ON",
-    "RPC",
 };
 
-const uint32_t usb_inhibit_auto_lock_delay_value[USB_INHIBIT_AUTO_LOCK_DELAY_COUNT] = {
-    USB_INHIBIT_AUTOLOCK_OFF,
-    USB_INHIBIT_AUTOLOCK_ON,
-    USB_INHIBIT_AUTOLOCK_RPC,
-};
+const uint32_t usb_inhibit_auto_lock_delay_value[USB_INHIBIT_AUTO_LOCK_DELAY_COUNT] = {0,1};
 
 #define CLOCK_ENABLE_COUNT 2
 const char* const clock_enable_text[CLOCK_ENABLE_COUNT] = {
@@ -144,7 +136,7 @@ void desktop_settings_scene_start_on_enter(void* context) {
     // USB connection Inhibit autolock OFF|ON|with opened RPC session
     item = variable_item_list_add(
         variable_item_list,
-        "USB disarm Auto Lock",
+        "Auto Lock disarm by active USB connection",
         USB_INHIBIT_AUTO_LOCK_DELAY_COUNT,
         desktop_settings_scene_start_usb_inhibit_auto_lock_delay_changed,
         app);


### PR DESCRIPTION
Autolock disarm by active USB connection instead of USB charging connection.