### PR TITLE
add support for Favorite App - Ok Long

### DIFF
--- a/applications/services/desktop/desktop_settings.h
+++ b/applications/services/desktop/desktop_settings.h
@@ -14,6 +14,7 @@ typedef enum {
     FavoriteAppLeftLong,
     FavoriteAppRightShort,
     FavoriteAppRightLong,
+    FavoriteAppOkLong,
 
     FavoriteAppNumber,
 } FavoriteAppShortcut;

--- a/applications/services/desktop/scenes/desktop_scene_main.c
+++ b/applications/services/desktop/scenes/desktop_scene_main.c
@@ -174,6 +174,11 @@ bool desktop_scene_main_on_event(void* context, SceneManagerEvent event) {
                 desktop, &desktop->settings.favorite_apps[FavoriteAppRightLong]);
             consumed = true;
             break;
+        case DesktopMainEventOpenFavoriteOkLong:
+            desktop_scene_main_start_favorite(
+                desktop, &desktop->settings.favorite_apps[FavoriteAppOkLong]);
+            consumed = true;
+            break;
 
         case DesktopAnimationEventCheckAnimation:
             animation_manager_check_blocking_process(desktop->animation_manager);

--- a/applications/services/desktop/views/desktop_events.h
+++ b/applications/services/desktop/views/desktop_events.h
@@ -8,6 +8,7 @@ typedef enum {
     DesktopMainEventOpenFavoriteLeftLong,
     DesktopMainEventOpenFavoriteRightShort,
     DesktopMainEventOpenFavoriteRightLong,
+    DesktopMainEventOpenFavoriteOkLong,
     DesktopMainEventOpenMenu,
     DesktopMainEventOpenDebug,
     DesktopMainEventOpenPowerOff,

--- a/applications/services/desktop/views/desktop_view_main.c
+++ b/applications/services/desktop/views/desktop_view_main.c
@@ -74,6 +74,7 @@ bool desktop_main_input_callback(InputEvent* event, void* context) {
                 if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) {
                     main_view->callback(DesktopAnimationEventNewIdleAnimation, main_view->context);
                 }
+                main_view->callback(DesktopMainEventOpenFavoriteOkLong, main_view->context);
             }
         }
     } else {

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -182,6 +182,7 @@ void desktop_settings_scene_start_on_enter(void* context) {
     variable_item_list_add(variable_item_list, "Favorite App - Left Long", 1, NULL, NULL);
     variable_item_list_add(variable_item_list, "Favorite App - Right Short", 1, NULL, NULL);
     variable_item_list_add(variable_item_list, "Favorite App - Right Long", 1, NULL, NULL);
+    variable_item_list_add(variable_item_list, "Favorite App - Ok Long", 1, NULL, NULL);
 
     variable_item_list_add(variable_item_list, "DummyMode - Left", 1, NULL, NULL);
     variable_item_list_add(variable_item_list, "DummyMode - Left Long", 1, NULL, NULL);

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -18,6 +18,7 @@ typedef enum {
     DesktopSettingsFavoriteLeftLong,
     DesktopSettingsFavoriteRightShort,
     DesktopSettingsFavoriteRightLong,
+    DesktopSettingsFavoriteOkLong,
     DesktopSettingsDummyLeft,
     DesktopSettingsDummyLeftLong,
     DesktopSettingsDummyRight,
@@ -245,6 +246,13 @@ bool desktop_settings_scene_start_on_event(void* context, SceneManagerEvent even
                 app->scene_manager,
                 DesktopSettingsAppSceneFavorite,
                 SCENE_STATE_SET_FAVORITE_APP | FavoriteAppRightLong);
+            scene_manager_next_scene(app->scene_manager, DesktopSettingsAppSceneFavorite);
+            break;
+        case DesktopSettingsFavoriteOkLong:
+            scene_manager_set_scene_state(
+                app->scene_manager,
+                DesktopSettingsAppSceneFavorite,
+                SCENE_STATE_SET_FAVORITE_APP | FavoriteAppOkLong);
             scene_manager_next_scene(app->scene_manager, DesktopSettingsAppSceneFavorite);
             break;
 


### PR DESCRIPTION
# What's new

- Settings option to set favorite app under `Ok Long`
- Handle opening `Favorite App - Ok Long` from desktop

# Verification 

- Set favorite app in `Settings -> Desktop -> Favorite App - Ok Long`
- Exit `Settings`
- Long press `Ok` button on `Desktop`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
