### PR TITLE
Use default UL/UL-C pwd/key as default value for key input

### DIFF
--- a/applications/main/nfc/helpers/mf_ultralight_auth.c
+++ b/applications/main/nfc/helpers/mf_ultralight_auth.c
@@ -18,9 +18,11 @@ void mf_ultralight_auth_free(MfUltralightAuth* instance) {
 void mf_ultralight_auth_reset(MfUltralightAuth* instance) {
     furi_assert(instance);
 
+    uint32_t default_password = MF_ULTRALIGHT_DEFAULT_PASSWORD;
+
     instance->type = MfUltralightAuthTypeNone;
-    memset(&instance->password, 0, sizeof(MfUltralightAuthPassword));
-    memset(&instance->tdes_key, 0, sizeof(MfUltralightC3DesAuthKey));
+    memcpy(&instance->password, &default_password, sizeof(MfUltralightAuthPassword));
+    memcpy(&instance->tdes_key, MF_ULTRALIGHT_C_DEFAULT_KEY, sizeof(MfUltralightC3DesAuthKey));
     memset(&instance->pack, 0, sizeof(MfUltralightAuthPack));
 }
 

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.h
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.h
@@ -38,6 +38,7 @@ extern "C" {
 #define MF_ULTRALIGHT_TEARING_FLAG_NUM   (3)
 #define MF_ULTRALIGHT_AUTH_PASSWORD_SIZE (4)
 #define MF_ULTRALIGHT_AUTH_PACK_SIZE     (2)
+#define MF_ULTRALIGHT_DEFAULT_PASSWORD   (0xffffffffUL)
 
 #define MF_ULTRALIGHT_C_AUTH_RESPONSE_SIZE      (9)
 #define MF_ULTRALIGHT_C_AUTH_DES_KEY_SIZE       (16)
@@ -47,6 +48,11 @@ extern "C" {
 #define MF_ULTRALIGHT_C_AUTH_RND_A_BLOCK_OFFSET (0)
 #define MF_ULTRALIGHT_C_AUTH_RND_B_BLOCK_OFFSET (8)
 #define MF_ULTRALIGHT_C_ENCRYPTED_PACK_SIZE     (MF_ULTRALIGHT_C_AUTH_DATA_SIZE + 1)
+#define MF_ULTRALIGHT_C_DEFAULT_KEY                                                               \
+    (uint8_t[]) {                                                                                 \
+        0x49, 0x45, 0x4D, 0x4B, 0x41, 0x45, 0x52, 0x42, 0x21, 0x4E, 0x41, 0x43, 0x55, 0x4F, 0x59, \
+            0x46                                                                                  \
+    }
 
 typedef enum {
     MfUltralightErrorNone,

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller_i.h
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller_i.h
@@ -11,8 +11,6 @@ extern "C" {
 #define MF_ULTRALIGHT_POLLER_STANDARD_FWT_FC (60000)
 #define MF_ULTRALIGHT_MAX_BUFF_SIZE          (64)
 
-#define MF_ULTRALIGHT_DEFAULT_PASSWORD (0xffffffffUL)
-
 #define MF_ULTRALIGHT_IS_NTAG_I2C(type)                                                \
     (((type) == MfUltralightTypeNTAGI2C1K) || ((type) == MfUltralightTypeNTAGI2C2K) || \
      ((type) == MfUltralightTypeNTAGI2CPlus1K) || ((type) == MfUltralightTypeNTAGI2CPlus2K))


### PR DESCRIPTION
# What's new

For simplification of unlocking UL11/UL21/NTAGs (where pwd is applicable) and UL C we are prepopulating input with default transport key for that chip type.

It's crucial for Ultralight C, where key size is 16 bytes

# Verification 

- Read tag of corresponding type with locked pages
- Chose unlock with manual input
- Validate a value in input
- (Optional) If you tag has default pwd - proceed with pre-populated value

Regression validation:
- Ensure input accepts manually entered value and tries to unlock using it

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
