### PR TITLE
[NFC]: Ultralight C. Attempt of authentication with default key

### DIFF
--- a/applications/settings/notification_settings/notification_settings_app.c
+++ b/applications/settings/notification_settings/notification_settings_app.c
@@ -556,7 +556,7 @@ static void night_shift_changed(VariableItem* item) {
 
     // force demo night_shift brightness to rgb backlight and stock backlight
     notification_message(app->notification, &sequence_display_backlight_on);
-    
+
     for(int i = 4; i < 6; i++) {
         VariableItem* t_item = variable_item_list_get(app->variable_item_list, i);
         if(index == 0) {

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.h
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.h
@@ -82,6 +82,19 @@ MfUltralightError mf_ultralight_poller_auth_pwd(
     MfUltralightPollerAuthContext* data);
 
 /**
+ * @brief Perform 3DES authentication with key.
+ *
+ * Must ONLY be used inside the callback function.
+ *
+ * @param[in, out] instance pointer to the instance to be used in the transaction.
+ * @param[in, out] data pointer to the authentication context.
+ * @return MfUltralightErrorNone on success, an error code on failure.
+ */
+MfUltralightError mf_ultralight_poller_auth_tdes(
+    MfUltralightPoller* instance,
+    MfUltralightPollerAuthContext* data);
+
+/**
  * @brief Start authentication procedure.
  *
  * Must ONLY be used inside the callback function.

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller_i.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller_i.c
@@ -1,6 +1,7 @@
 #include "mf_ultralight_poller_i.h"
 
 #include <furi.h>
+#include <furi_hal.h>
 
 #define TAG "MfUltralightPoller"
 
@@ -58,6 +59,38 @@ MfUltralightError mf_ultralight_poller_auth_pwd(
         }
         bit_buffer_write_bytes(instance->rx_buffer, data->pack.data, MF_ULTRALIGHT_AUTH_PACK_SIZE);
     } while(false);
+
+    return ret;
+}
+
+MfUltralightError mf_ultralight_poller_auth_tdes(
+    MfUltralightPoller* instance,
+    MfUltralightPollerAuthContext* data) {
+    furi_check(instance);
+    furi_check(data);
+
+    MfUltralightError ret = MfUltralightErrorNone;
+
+    uint8_t output[MF_ULTRALIGHT_C_AUTH_DATA_SIZE];
+    uint8_t RndA[MF_ULTRALIGHT_C_AUTH_RND_BLOCK_SIZE] = {0};
+    furi_hal_random_fill_buf(RndA, sizeof(RndA));
+
+    ret = mf_ultralight_poller_authenticate_start(instance, RndA, output);
+
+    if(ret != MfUltralightErrorNone) {
+        return ret;
+    }
+
+    uint8_t decoded_shifted_RndA[MF_ULTRALIGHT_C_AUTH_RND_BLOCK_SIZE] = {0};
+    const uint8_t* RndB = output + MF_ULTRALIGHT_C_AUTH_RND_B_BLOCK_OFFSET;
+    ret = mf_ultralight_poller_authenticate_end(instance, RndB, output, decoded_shifted_RndA);
+
+    if(ret != MfUltralightErrorNone) {
+        return ret;
+    }
+
+    mf_ultralight_3des_shift_data(RndA);
+    data->auth_success = (memcmp(RndA, decoded_shifted_RndA, sizeof(decoded_shifted_RndA)) == 0);
 
     return ret;
 }

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller_i.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller_i.c
@@ -167,7 +167,7 @@ MfUltralightError mf_ultralight_poller_authenticate_start(
         uint8_t* RndB = output + MF_ULTRALIGHT_C_AUTH_RND_B_BLOCK_OFFSET;
         mf_ultralight_3des_decrypt(
             &instance->des_context,
-            instance->mfu_event.data->auth_context.tdes_key.data,
+            instance->auth_context.tdes_key.data,
             iv,
             encRndB,
             sizeof(encRndB),
@@ -178,7 +178,7 @@ MfUltralightError mf_ultralight_poller_authenticate_start(
 
         mf_ultralight_3des_encrypt(
             &instance->des_context,
-            instance->mfu_event.data->auth_context.tdes_key.data,
+            instance->auth_context.tdes_key.data,
             encRndB,
             output,
             MF_ULTRALIGHT_C_AUTH_DATA_SIZE,
@@ -212,7 +212,7 @@ MfUltralightError mf_ultralight_poller_authenticate_end(
 
         mf_ultralight_3des_decrypt(
             &instance->des_context,
-            instance->mfu_event.data->auth_context.tdes_key.data,
+            instance->auth_context.tdes_key.data,
             RndB,
             bit_buffer_get_data(instance->rx_buffer) + 1,
             MF_ULTRALIGHT_C_AUTH_RND_BLOCK_SIZE,

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller_i.h
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller_i.h
@@ -59,6 +59,7 @@ typedef enum {
     MfUltralightPollerStateAuthMfulC,
     MfUltralightPollerStateReadPages,
     MfUltralightPollerStateTryDefaultPass,
+    MfUltralightPollerStateTryDefaultMfulCKey,
     MfUltralightPollerStateCheckMfulCAuthStatus,
     MfUltralightPollerStateReadFailed,
     MfUltralightPollerStateReadSuccess,

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,86.2,,
+Version,+,86.0,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,86.0,,
+Version,+,86.2,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -2741,6 +2741,7 @@ Function,+,mf_ultralight_is_equal,_Bool,"const MfUltralightData*, const MfUltral
 Function,+,mf_ultralight_is_page_pwd_or_pack,_Bool,"MfUltralightType, uint16_t"
 Function,+,mf_ultralight_load,_Bool,"MfUltralightData*, FlipperFormat*, uint32_t"
 Function,+,mf_ultralight_poller_auth_pwd,MfUltralightError,"MfUltralightPoller*, MfUltralightPollerAuthContext*"
+Function,+,mf_ultralight_poller_auth_tdes,MfUltralightError,"MfUltralightPoller*, MfUltralightPollerAuthContext*"
 Function,+,mf_ultralight_poller_authenticate_end,MfUltralightError,"MfUltralightPoller*, const uint8_t*, const uint8_t*, uint8_t*"
 Function,+,mf_ultralight_poller_authenticate_start,MfUltralightError,"MfUltralightPoller*, const uint8_t*, uint8_t*"
 Function,+,mf_ultralight_poller_read_counter,MfUltralightError,"MfUltralightPoller*, uint8_t, MfUltralightCounter*"


### PR DESCRIPTION
# What's new

- Attempt to authenticate to UL-C with default key
- UL-C authentication was extracted to helper method
- Fixed logical bug where UL-C auth stages used `instance->mfu_event.data->auth_context.tdes_key.data` instead of `instance->auth_context.tdes_key.data`

# Verification 

**New feature:**
- Take UL-C with default PWD and not changed auth conditions. Then try to read via NFC. 48/48 should be read

**Regression**
- Use UL-C with non-default PWD. Read. 44/48 should be read (with default auth conditions)
- Unlock and enter password manually. After unlock 48/48 should be read

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix