### PR TITLE
Fix clipper date timestamp

### DIFF
--- a/applications/main/nfc/plugins/supported_cards/clipper.c
+++ b/applications/main/nfc/plugins/supported_cards/clipper.c
@@ -548,7 +548,7 @@ static void furi_string_cat_timestamp(
     const char* time_hdr,
     uint32_t tmst_1900) {
     DateTime tm;
-
+    tmst_1900 -= 2208988800; // Clipper uses epoch from 1900, not 1970.
     datetime_timestamp_to_datetime(tmst_1900, &tm);
 
     FuriString* date_str = furi_string_alloc();


### PR DESCRIPTION
# What's new

- Fixed the clipper date timestamp. As the epoch for clipper is 1900, not 1970.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
