### PR TITLE
Loader: Fix misplaced ApplicationBeforeLoad events

### DIFF
--- a/applications/services/loader/loader.c
+++ b/applications/services/loader/loader.c
@@ -654,10 +654,6 @@ static LoaderMessageLoaderStatusResult loader_do_start_by_name(
     status.value = loader_make_success_status(error_message);
     status.error = LoaderStatusErrorUnknown;
 
-    LoaderEvent event;
-    event.type = LoaderEventTypeApplicationBeforeLoad;
-    furi_pubsub_publish(loader->pubsub, &event);
-
     do {
         // check lock
         if(loader_do_is_locked(loader)) {
@@ -677,6 +673,17 @@ static LoaderMessageLoaderStatusResult loader_do_start_by_name(
             break;
         }
 
+        // check Applications
+        if(strcmp(name, LOADER_APPLICATIONS_NAME) == 0) {
+            loader_do_applications_show(loader);
+            status.value = loader_make_success_status(error_message);
+            break;
+        }
+
+        LoaderEvent event;
+        event.type = LoaderEventTypeApplicationBeforeLoad;
+        furi_pubsub_publish(loader->pubsub, &event);
+
         // check internal apps
         {
             const FlipperInternalApplication* app = loader_find_application_by_name(name);
@@ -685,13 +692,6 @@ static LoaderMessageLoaderStatusResult loader_do_start_by_name(
                 status.value = loader_make_success_status(error_message);
                 break;
             }
-        }
-
-        // check Applications
-        if(strcmp(name, LOADER_APPLICATIONS_NAME) == 0) {
-            loader_do_applications_show(loader);
-            status.value = loader_make_success_status(error_message);
-            break;
         }
 
         // check External Applications

--- a/applications/services/loader/loader_applications.c
+++ b/applications/services/loader/loader_applications.c
@@ -141,6 +141,7 @@ static void
     }
 
     furi_pubsub_unsubscribe(loader_get_pubsub(app->loader), subscription);
+    furi_thread_flags_clear(APPLICATION_STOP_EVENT);
 }
 
 static int32_t loader_applications_thread(void* p) {

--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -487,9 +487,7 @@ static void power_loader_callback(const void* message, void* context) {
         power->app_running = true;
         power_auto_poweroff_disarm(power);
         // arm timer if some apps was not loaded or was stoped
-    } else if(
-        event->type == LoaderEventTypeApplicationLoadFailed ||
-        event->type == LoaderEventTypeApplicationStopped) {
+    } else if(event->type == LoaderEventTypeNoMoreAppsInQueue) {
         power->app_running = false;
         power_auto_poweroff_arm(power);
     }


### PR DESCRIPTION
# What's new

- fixes animation freeze after opening apps picker
- due to refactoring in ofw, `ApplicationBeforeLoad` event is sent when opening apps picker, and when attempting to open a second app while another app is open, which are never followed by `ApplicationLoadFailed`/`ApplicationStopped`/`NoMoreAppsInQueue` events, causing code handling `ApplicationBeforeLoad` to misbehave; these events shouldn't be sent

# Verification 

- open and close apps picker
- animation is not frozen

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
