### PR TITLE
[SubGHz] [Fix] Restore the original byte order of values in the GenData struct

### DIFF
--- a/applications/main/subghz/scenes/subghz_scene_set_counter.c
+++ b/applications/main/subghz/scenes/subghz_scene_set_counter.c
@@ -92,9 +92,7 @@ bool subghz_scene_set_counter_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == SubGhzCustomEventByteInputDone) {
-            GenInfo gen_info = *subghz->gen_info;
-
-            switch(gen_info.type) {
+            switch(subghz->gen_info->type) {
             case GenFaacSLH:
             case GenKeeloqBFT:
                 scene_manager_next_scene(subghz->scene_manager, SubGhzSceneSetSeed);
@@ -102,65 +100,67 @@ bool subghz_scene_set_counter_on_event(void* context, SceneManagerEvent event) {
             case GenKeeloq:
                 generated_protocol = subghz_txrx_gen_keeloq_protocol(
                     subghz->txrx,
-                    gen_info.mod,
-                    gen_info.freq,
-                    __bswap32(gen_info.keeloq.serial),
-                    gen_info.keeloq.btn,
-                    gen_info.keeloq.cnt,
-                    gen_info.keeloq.manuf);
+                    subghz->gen_info->mod,
+                    subghz->gen_info->freq,
+                    subghz->gen_info->keeloq.serial,
+                    subghz->gen_info->keeloq.btn,
+                    subghz->gen_info->keeloq.cnt,
+                    subghz->gen_info->keeloq.manuf);
                 break;
             case GenCameAtomo:
                 generated_protocol = subghz_txrx_gen_came_atomo_protocol(
                     subghz->txrx,
-                    gen_info.mod,
-                    gen_info.freq,
-                    __bswap32(gen_info.came_atomo.serial),
-                    gen_info.came_atomo.cnt);
+                    subghz->gen_info->mod,
+                    subghz->gen_info->freq,
+                    subghz->gen_info->came_atomo.serial,
+                    subghz->gen_info->came_atomo.cnt);
                 break;
             case GenAlutechAt4n:
                 generated_protocol = subghz_txrx_gen_alutech_at_4n_protocol(
                     subghz->txrx,
-                    gen_info.mod,
-                    gen_info.freq,
-                    __bswap32(gen_info.alutech_at_4n.serial),
-                    gen_info.alutech_at_4n.btn,
-                    gen_info.alutech_at_4n.cnt);
+                    subghz->gen_info->mod,
+                    subghz->gen_info->freq,
+                    subghz->gen_info->alutech_at_4n.serial,
+                    subghz->gen_info->alutech_at_4n.btn,
+                    subghz->gen_info->alutech_at_4n.cnt);
                 break;
             case GenSomfyTelis:
                 generated_protocol = subghz_txrx_gen_somfy_telis_protocol(
                     subghz->txrx,
-                    gen_info.mod,
-                    gen_info.freq,
-                    __bswap32(gen_info.somfy_telis.serial),
-                    gen_info.somfy_telis.btn,
-                    gen_info.somfy_telis.cnt);
+                    subghz->gen_info->mod,
+                    subghz->gen_info->freq,
+                    subghz->gen_info->somfy_telis.serial,
+                    subghz->gen_info->somfy_telis.btn,
+                    subghz->gen_info->somfy_telis.cnt);
                 break;
             case GenNiceFlorS:
                 generated_protocol = subghz_txrx_gen_nice_flor_s_protocol(
                     subghz->txrx,
-                    gen_info.mod,
-                    gen_info.freq,
-                    __bswap32(gen_info.nice_flor_s.serial),
-                    gen_info.nice_flor_s.btn,
-                    gen_info.nice_flor_s.cnt,
-                    gen_info.nice_flor_s.nice_one);
+                    subghz->gen_info->mod,
+                    subghz->gen_info->freq,
+                    subghz->gen_info->nice_flor_s.serial,
+                    subghz->gen_info->nice_flor_s.btn,
+                    subghz->gen_info->nice_flor_s.cnt,
+                    subghz->gen_info->nice_flor_s.nice_one);
                 break;
             case GenSecPlus2:
+                subghz->gen_info->sec_plus_2.cnt = __bswap32(subghz->gen_info->sec_plus_2.cnt);
                 generated_protocol = subghz_txrx_gen_secplus_v2_protocol(
                     subghz->txrx,
-                    gen_info.mod,
-                    gen_info.freq,
-                    __bswap32(gen_info.sec_plus_2.serial),
-                    gen_info.sec_plus_2.btn,
-                    __bswap32(gen_info.sec_plus_2.cnt));
+                    subghz->gen_info->mod,
+                    subghz->gen_info->freq,
+                    subghz->gen_info->sec_plus_2.serial,
+                    subghz->gen_info->sec_plus_2.btn,
+                    subghz->gen_info->sec_plus_2.cnt);
                 break;
             case GenPhoenixV2:
+                subghz->gen_info->phoenix_v2.cnt = __bswap16(subghz->gen_info->phoenix_v2.cnt);
                 generated_protocol = subghz_txrx_gen_phoenix_v2_protocol(
                     subghz->txrx,
-                    gen_info.mod,
-                    gen_info.freq,
-                    __bswap32(gen_info.phoenix_v2.serial),
-                    __bswap16(gen_info.phoenix_v2.cnt));
+                    subghz->gen_info->mod,
+                    subghz->gen_info->freq,
+                    subghz->gen_info->phoenix_v2.serial,
+                    subghz->gen_info->phoenix_v2.cnt);
                 break;
             // Not needed for these types
             case GenData:

--- a/applications/main/subghz/scenes/subghz_scene_set_key.c
+++ b/applications/main/subghz/scenes/subghz_scene_set_key.c
@@ -44,26 +44,27 @@ bool subghz_scene_set_key_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == SubGhzCustomEventByteInputDone) {
-            GenInfo gen_info = *subghz->gen_info;
 
-            if(gen_info.type == GenData) {
-                if(gen_info.data.te) {
+            if(subghz->gen_info->type == GenData) {
+                subghz->gen_info->data.key = __bswap64(subghz->gen_info->data.key);
+
+                if(subghz->gen_info->data.te) {
                     generated_protocol = subghz_txrx_gen_data_protocol_and_te(
                         subghz->txrx,
-                        gen_info.mod,
-                        gen_info.freq,
-                        gen_info.data.name,
-                        __bswap64(gen_info.data.key),
-                        gen_info.data.bits,
-                        gen_info.data.te);
+                        subghz->gen_info->mod,
+                        subghz->gen_info->freq,
+                        subghz->gen_info->data.name,
+                        subghz->gen_info->data.key,
+                        subghz->gen_info->data.bits,
+                        subghz->gen_info->data.te);
                 } else {
                     generated_protocol = subghz_txrx_gen_data_protocol(
                         subghz->txrx,
-                        gen_info.mod,
-                        gen_info.freq,
-                        gen_info.data.name,
-                        __bswap64(gen_info.data.key),
-                        gen_info.data.bits);
+                        subghz->gen_info->mod,
+                        subghz->gen_info->freq,
+                        subghz->gen_info->data.name,
+                        subghz->gen_info->data.key,
+                        subghz->gen_info->data.bits);
                 }
             }
 

--- a/applications/main/subghz/scenes/subghz_scene_set_seed.c
+++ b/applications/main/subghz/scenes/subghz_scene_set_seed.c
@@ -60,30 +60,31 @@ bool subghz_scene_set_seed_on_event(void* context, SceneManagerEvent event) {
     bool generated_protocol = false;
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == SubGhzCustomEventByteInputDone) {
-            GenInfo gen_info = *subghz->gen_info;
 
-            switch(gen_info.type) {
+            switch(subghz->gen_info->type) {
             case GenFaacSLH:
+                subghz->gen_info->faac_slh.seed = __bswap32(subghz->gen_info->faac_slh.seed);
                 generated_protocol = subghz_txrx_gen_faac_slh_protocol(
                     subghz->txrx,
-                    gen_info.mod,
-                    gen_info.freq,
-                    __bswap32(gen_info.faac_slh.serial),
-                    gen_info.faac_slh.btn,
-                    gen_info.faac_slh.cnt,
-                    __bswap32(gen_info.faac_slh.seed),
-                    gen_info.faac_slh.manuf);
+                    subghz->gen_info->mod,
+                    subghz->gen_info->freq,
+                    subghz->gen_info->faac_slh.serial,
+                    subghz->gen_info->faac_slh.btn,
+                    subghz->gen_info->faac_slh.cnt,
+                    subghz->gen_info->faac_slh.seed,
+                    subghz->gen_info->faac_slh.manuf);
                 break;
             case GenKeeloqBFT:
+                subghz->gen_info->keeloq_bft.seed = __bswap32(subghz->gen_info->keeloq_bft.seed);
                 generated_protocol = subghz_txrx_gen_keeloq_bft_protocol(
                     subghz->txrx,
-                    gen_info.mod,
-                    gen_info.freq,
-                    __bswap32(gen_info.keeloq_bft.serial),
-                    gen_info.keeloq_bft.btn,
-                    gen_info.keeloq_bft.cnt,
-                    __bswap32(gen_info.keeloq_bft.seed),
-                    gen_info.keeloq_bft.manuf);
+                    subghz->gen_info->mod,
+                    subghz->gen_info->freq,
+                    subghz->gen_info->keeloq_bft.serial,
+                    subghz->gen_info->keeloq_bft.btn,
+                    subghz->gen_info->keeloq_bft.cnt,
+                    subghz->gen_info->keeloq_bft.seed,
+                    subghz->gen_info->keeloq_bft.manuf);
                 break;
             // Not needed for these types
             case GenKeeloq:

--- a/applications/main/subghz/scenes/subghz_scene_set_serial.c
+++ b/applications/main/subghz/scenes/subghz_scene_set_serial.c
@@ -86,6 +86,43 @@ bool subghz_scene_set_serial_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == SubGhzCustomEventByteInputDone) {
+            // Swap bytes
+            switch(subghz->gen_info->type) {
+            case GenFaacSLH:
+                subghz->gen_info->faac_slh.serial = __bswap32(subghz->gen_info->faac_slh.serial);
+                break;
+            case GenKeeloq:
+                subghz->gen_info->keeloq.serial = __bswap32(subghz->gen_info->keeloq.serial);
+                break;
+            case GenCameAtomo:
+                subghz->gen_info->came_atomo.serial = __bswap32(subghz->gen_info->came_atomo.serial);
+                break;
+            case GenKeeloqBFT:
+                subghz->gen_info->keeloq_bft.serial = __bswap32(subghz->gen_info->keeloq_bft.serial);
+                break;
+            case GenAlutechAt4n:
+                subghz->gen_info->alutech_at_4n.serial = __bswap32(subghz->gen_info->alutech_at_4n.serial);
+                break;
+            case GenSomfyTelis:
+                subghz->gen_info->somfy_telis.serial = __bswap32(subghz->gen_info->somfy_telis.serial);
+                break;
+            case GenNiceFlorS:
+                subghz->gen_info->nice_flor_s.serial = __bswap32(subghz->gen_info->nice_flor_s.serial);
+                break;
+            case GenSecPlus2:
+                subghz->gen_info->sec_plus_2.serial = __bswap32(subghz->gen_info->sec_plus_2.serial);
+                break;
+            case GenPhoenixV2:
+                subghz->gen_info->phoenix_v2.serial = __bswap32(subghz->gen_info->phoenix_v2.serial);
+                break;
+            // Not needed for these types
+            case GenData:
+            case GenSecPlus1:
+            default:
+                furi_crash("Not implemented");
+                break;
+            }
+
             switch(subghz->gen_info->type) {
             case GenFaacSLH:
             case GenKeeloq:


### PR DESCRIPTION
# What's new

Fix for commit 2c0b7caf
When creating a remote in Add Manually [Advanced], you could set a value, go to the next step, and if you go back, the values would have been reversed.

This is because the byte order was not restored before leaving an input scene, causing the bytes to be swapped again when returning to a previous scene.

# Verification 

- Create a remote with the steps above and check if the byte order stays the same when going back to a previous scene.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
