### PR TITLE
[SubGHz] [Fix] Use the correct size of the counter values in the GenInfo struct

### DIFF
--- a/applications/main/subghz/helpers/subghz_gen_info.h
+++ b/applications/main/subghz/helpers/subghz_gen_info.h
@@ -25,46 +25,46 @@ typedef struct {
             const char* name;
             uint64_t key;
             uint8_t bits;
-            uint16_t te;
+            uint32_t te;
         } data;
         struct {
             uint32_t serial;
             uint8_t btn;
-            uint8_t cnt;
+            uint32_t cnt;
             uint32_t seed;
             const char* manuf;
         } faac_slh;
         struct {
             uint32_t serial;
             uint8_t btn;
-            uint8_t cnt;
+            uint16_t cnt;
             const char* manuf;
         } keeloq;
         struct {
             uint32_t serial;
-            uint8_t cnt;
+            uint16_t cnt;
         } came_atomo;
         struct {
             uint32_t serial;
             uint8_t btn;
-            uint8_t cnt;
+            uint16_t cnt;
             uint32_t seed;
             const char* manuf;
         } keeloq_bft;
         struct {
             uint32_t serial;
             uint8_t btn;
-            uint8_t cnt;
+            uint16_t cnt;
         } alutech_at_4n;
         struct {
             uint32_t serial;
             uint8_t btn;
-            uint8_t cnt;
+            uint16_t cnt;
         } somfy_telis;
         struct {
             uint32_t serial;
             uint8_t btn;
-            uint8_t cnt;
+            uint16_t cnt;
             bool nice_one;
         } nice_flor_s;
         struct {

--- a/applications/main/subghz/scenes/subghz_scene_set_counter.c
+++ b/applications/main/subghz/scenes/subghz_scene_set_counter.c
@@ -19,31 +19,31 @@ void subghz_scene_set_counter_on_enter(void* context) {
 
     switch(subghz->gen_info->type) {
     case GenFaacSLH:
-        byte_ptr = &subghz->gen_info->faac_slh.cnt;
+        byte_ptr = (uint8_t*)&subghz->gen_info->faac_slh.cnt;
         byte_count = sizeof(subghz->gen_info->faac_slh.cnt);
         break;
     case GenKeeloq:
-        byte_ptr = &subghz->gen_info->keeloq.cnt;
+        byte_ptr = (uint8_t*)&subghz->gen_info->keeloq.cnt;
         byte_count = sizeof(subghz->gen_info->keeloq.cnt);
         break;
     case GenCameAtomo:
-        byte_ptr = &subghz->gen_info->came_atomo.cnt;
+        byte_ptr = (uint8_t*)&subghz->gen_info->came_atomo.cnt;
         byte_count = sizeof(subghz->gen_info->came_atomo.cnt);
         break;
     case GenKeeloqBFT:
-        byte_ptr = &subghz->gen_info->keeloq_bft.cnt;
+        byte_ptr = (uint8_t*)&subghz->gen_info->keeloq_bft.cnt;
         byte_count = sizeof(subghz->gen_info->keeloq_bft.cnt);
         break;
     case GenAlutechAt4n:
-        byte_ptr = &subghz->gen_info->alutech_at_4n.cnt;
+        byte_ptr = (uint8_t*)&subghz->gen_info->alutech_at_4n.cnt;
         byte_count = sizeof(subghz->gen_info->alutech_at_4n.cnt);
         break;
     case GenSomfyTelis:
-        byte_ptr = &subghz->gen_info->somfy_telis.cnt;
+        byte_ptr = (uint8_t*)&subghz->gen_info->somfy_telis.cnt;
         byte_count = sizeof(subghz->gen_info->somfy_telis.cnt);
         break;
     case GenNiceFlorS:
-        byte_ptr = &subghz->gen_info->nice_flor_s.cnt;
+        byte_ptr = (uint8_t*)&subghz->gen_info->nice_flor_s.cnt;
         byte_count = sizeof(subghz->gen_info->nice_flor_s.cnt);
         break;
     case GenSecPlus2:
@@ -92,6 +92,43 @@ bool subghz_scene_set_counter_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == SubGhzCustomEventByteInputDone) {
+            // Swap bytes
+            switch(subghz->gen_info->type) {
+            case GenFaacSLH:
+                subghz->gen_info->faac_slh.cnt = __bswap32(subghz->gen_info->faac_slh.cnt);
+                break;
+            case GenKeeloq:
+                subghz->gen_info->keeloq.cnt = __bswap16(subghz->gen_info->keeloq.cnt);
+                break;
+            case GenCameAtomo:
+                subghz->gen_info->came_atomo.cnt = __bswap16(subghz->gen_info->came_atomo.cnt);
+                break;
+            case GenKeeloqBFT:
+                subghz->gen_info->keeloq_bft.cnt = __bswap16(subghz->gen_info->keeloq_bft.cnt);
+                break;
+            case GenAlutechAt4n:
+                subghz->gen_info->alutech_at_4n.cnt = __bswap16(subghz->gen_info->alutech_at_4n.cnt);
+                break;
+            case GenSomfyTelis:
+                subghz->gen_info->somfy_telis.cnt = __bswap16(subghz->gen_info->somfy_telis.cnt);
+                break;
+            case GenNiceFlorS:
+                subghz->gen_info->nice_flor_s.cnt = __bswap16(subghz->gen_info->nice_flor_s.cnt);
+                break;
+            case GenSecPlus2:
+                subghz->gen_info->sec_plus_2.cnt = __bswap32(subghz->gen_info->sec_plus_2.cnt);
+                break;
+            case GenPhoenixV2:
+                subghz->gen_info->phoenix_v2.cnt = __bswap16(subghz->gen_info->phoenix_v2.cnt);
+                break;
+                // Not needed for these types
+            case GenData:
+            case GenSecPlus1:
+            default:
+                furi_crash("Not implemented");
+                break;
+            }
+
             switch(subghz->gen_info->type) {
             case GenFaacSLH:
             case GenKeeloqBFT:
@@ -144,7 +181,6 @@ bool subghz_scene_set_counter_on_event(void* context, SceneManagerEvent event) {
                     subghz->gen_info->nice_flor_s.nice_one);
                 break;
             case GenSecPlus2:
-                subghz->gen_info->sec_plus_2.cnt = __bswap32(subghz->gen_info->sec_plus_2.cnt);
                 generated_protocol = subghz_txrx_gen_secplus_v2_protocol(
                     subghz->txrx,
                     subghz->gen_info->mod,
@@ -154,7 +190,6 @@ bool subghz_scene_set_counter_on_event(void* context, SceneManagerEvent event) {
                     subghz->gen_info->sec_plus_2.cnt);
                 break;
             case GenPhoenixV2:
-                subghz->gen_info->phoenix_v2.cnt = __bswap16(subghz->gen_info->phoenix_v2.cnt);
                 generated_protocol = subghz_txrx_gen_phoenix_v2_protocol(
                     subghz->txrx,
                     subghz->gen_info->mod,

--- a/applications/main/subghz/scenes/subghz_scene_set_type.c
+++ b/applications/main/subghz/scenes/subghz_scene_set_type.c
@@ -254,15 +254,14 @@ bool subghz_scene_set_type_on_event(void* context, SceneManagerEvent event) {
                 scene_manager_next_scene(subghz->scene_manager, SubGhzSceneSetKey);
                 break;
             case GenSecPlus1: // None
-                generated_protocol = subghz_scene_set_type_generate_protocol_from_infos(subghz);
-                break;
-            case GenFaacSLH: // Serial (u32), Button (u8), Counter (u8), Seed (u32)
-            case GenKeeloq: // Serial (u32), Button (u8), Counter (u8)
-            case GenCameAtomo: // Serial (u32), Counter (u8)
-            case GenKeeloqBFT: // Serial (u32), Button (u8), Counter (u8), Seed (u32)
-            case GenAlutechAt4n: // Serial (u32), Button (u8), Counter (u8)
-            case GenSomfyTelis: // Serial (u32), Button (u8), Counter (u8)
-            case GenNiceFlorS: // Serial (u32), Button (u8), Counter (u8)
+                return subghz_scene_set_type_generate_protocol_from_infos(subghz);
+            case GenFaacSLH: // Serial (u32), Button (u8), Counter (u32), Seed (u32)
+            case GenKeeloq: // Serial (u32), Button (u8), Counter (u16)
+            case GenCameAtomo: // Serial (u32), Counter (u16)
+            case GenKeeloqBFT: // Serial (u32), Button (u8), Counter (u16), Seed (u32)
+            case GenAlutechAt4n: // Serial (u32), Button (u8), Counter (u16)
+            case GenSomfyTelis: // Serial (u32), Button (u8), Counter (u16)
+            case GenNiceFlorS: // Serial (u32), Button (u8), Counter (u16)
             case GenSecPlus2: // Serial (u32), Button (u8), Counter (u32)
             case GenPhoenixV2: // Serial (u32), Counter (u16)
                 scene_manager_next_scene(subghz->scene_manager, SubGhzSceneSetSerial);


### PR DESCRIPTION
# What's new

Fixes #912
The sizes of the counter values in the GenData struct was different from the sizes used by the generation functions.

# Verification 

- Check for the correct size when manually creating a remote

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
