### PR TITLE
Sub-GHz: Only fix Linear inverted bits in user interface, keep old remotes compatible

### DIFF
--- a/lib/subghz/protocols/linear.c
+++ b/lib/subghz/protocols/linear.c
@@ -116,32 +116,32 @@ static bool subghz_protocol_encoder_linear_get_upload(SubGhzProtocolEncoderLinea
         if(bit_read(instance->generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
-                level_duration_make(true, (uint32_t)subghz_protocol_linear_const.te_short);
-            instance->encoder.upload[index++] =
-                level_duration_make(false, (uint32_t)subghz_protocol_linear_const.te_long);
-        } else {
-            //send bit 0
-            instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_linear_const.te_long);
             instance->encoder.upload[index++] =
                 level_duration_make(false, (uint32_t)subghz_protocol_linear_const.te_short);
+        } else {
+            //send bit 0
+            instance->encoder.upload[index++] =
+                level_duration_make(true, (uint32_t)subghz_protocol_linear_const.te_short);
+            instance->encoder.upload[index++] =
+                level_duration_make(false, (uint32_t)subghz_protocol_linear_const.te_long);
         }
     }
     //Send end bit
     if(bit_read(instance->generic.data, 0)) {
         //send bit 1
         instance->encoder.upload[index++] =
-            level_duration_make(true, (uint32_t)subghz_protocol_linear_const.te_short);
-        //Send gap
-        instance->encoder.upload[index++] =
-            level_duration_make(false, (uint32_t)subghz_protocol_linear_const.te_short * 44);
-    } else {
-        //send bit 0
-        instance->encoder.upload[index++] =
             level_duration_make(true, (uint32_t)subghz_protocol_linear_const.te_long);
         //Send gap
         instance->encoder.upload[index++] =
             level_duration_make(false, (uint32_t)subghz_protocol_linear_const.te_short * 42);
+    } else {
+        //send bit 0
+        instance->encoder.upload[index++] =
+            level_duration_make(true, (uint32_t)subghz_protocol_linear_const.te_short);
+        //Send gap
+        instance->encoder.upload[index++] =
+            level_duration_make(false, (uint32_t)subghz_protocol_linear_const.te_short * 44);
     }
 
     return true;
@@ -249,11 +249,11 @@ void subghz_protocol_decoder_linear_feed(void* context, bool level, uint32_t dur
                 }
                 if(DURATION_DIFF(instance->decoder.te_last, subghz_protocol_linear_const.te_short) <
                    subghz_protocol_linear_const.te_delta) {
-                    subghz_protocol_blocks_add_bit(&instance->decoder, 1);
+                    subghz_protocol_blocks_add_bit(&instance->decoder, 0);
                 } else if(
                     DURATION_DIFF(instance->decoder.te_last, subghz_protocol_linear_const.te_long) <
                     subghz_protocol_linear_const.te_delta) {
-                    subghz_protocol_blocks_add_bit(&instance->decoder, 0);
+                    subghz_protocol_blocks_add_bit(&instance->decoder, 1);
                 }
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_linear_const.min_count_bit_for_found) {
@@ -273,14 +273,14 @@ void subghz_protocol_decoder_linear_feed(void* context, bool level, uint32_t dur
                 subghz_protocol_linear_const.te_delta) &&
                (DURATION_DIFF(duration, subghz_protocol_linear_const.te_long) <
                 subghz_protocol_linear_const.te_delta)) {
-                subghz_protocol_blocks_add_bit(&instance->decoder, 1);
+                subghz_protocol_blocks_add_bit(&instance->decoder, 0);
                 instance->decoder.parser_step = LinearDecoderStepSaveDuration;
             } else if(
                 (DURATION_DIFF(instance->decoder.te_last, subghz_protocol_linear_const.te_long) <
                  subghz_protocol_linear_const.te_delta) &&
                 (DURATION_DIFF(duration, subghz_protocol_linear_const.te_short) <
                  subghz_protocol_linear_const.te_delta)) {
-                subghz_protocol_blocks_add_bit(&instance->decoder, 0);
+                subghz_protocol_blocks_add_bit(&instance->decoder, 1);
                 instance->decoder.parser_step = LinearDecoderStepSaveDuration;
             } else {
                 instance->decoder.parser_step = LinearDecoderStepReset;
@@ -321,12 +321,15 @@ void subghz_protocol_decoder_linear_get_string(void* context, FuriString* output
     furi_assert(context);
     SubGhzProtocolDecoderLinear* instance = context;
 
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+    // Protocol is actually implemented wrong way around, bits are inverted.
+    // Instead of fixing it and breaking old saved remotes,
+    // only the display here is inverted to show correct values.
+    uint32_t code_found_reverse_lo = instance->generic.data & 0x00000000ffffffff;
 
-    uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
+    uint64_t code_found = subghz_protocol_blocks_reverse_key(
         instance->generic.data, instance->generic.data_count_bit);
 
-    uint32_t code_found_reverse_lo = code_found_reverse & 0x00000000ffffffff;
+    uint32_t code_found_lo = code_found & 0x00000000ffffffff;
 
     furi_string_cat_printf(
         output,


### PR DESCRIPTION
# What's new

- title :)

# Verification 

- Open old linear remote, still works as expected, but Key, Yek and DIP are correct (inverted from original implementation)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
