### PR TITLE
Sub-GHz: Actually fix Linear display for real now

### DIFF
--- a/lib/subghz/protocols/linear.c
+++ b/lib/subghz/protocols/linear.c
@@ -10,10 +10,10 @@
 
 #define DIP_PATTERN "%c%c%c%c%c%c%c%c%c%c"
 #define DATA_TO_DIP(dip)                                                                    \
-    (dip & 0x0200 ? '0' : '1'), (dip & 0x0100 ? '0' : '1'), (dip & 0x0080 ? '0' : '1'),     \
-        (dip & 0x0040 ? '0' : '1'), (dip & 0x0020 ? '0' : '1'), (dip & 0x0010 ? '0' : '1'), \
-        (dip & 0x0008 ? '0' : '1'), (dip & 0x0004 ? '0' : '1'), (dip & 0x0002 ? '0' : '1'), \
-        (dip & 0x0001 ? '0' : '1')
+    (dip & 0x0200 ? '1' : '0'), (dip & 0x0100 ? '1' : '0'), (dip & 0x0080 ? '1' : '0'),     \
+        (dip & 0x0040 ? '1' : '0'), (dip & 0x0020 ? '1' : '0'), (dip & 0x0010 ? '1' : '0'), \
+        (dip & 0x0008 ? '1' : '0'), (dip & 0x0004 ? '1' : '0'), (dip & 0x0002 ? '1' : '0'), \
+        (dip & 0x0001 ? '1' : '0')
 
 static const SubGhzBlockConst subghz_protocol_linear_const = {
     .te_short = 500,
@@ -323,13 +323,13 @@ void subghz_protocol_decoder_linear_get_string(void* context, FuriString* output
 
     // Protocol is actually implemented wrong way around, bits are inverted.
     // Instead of fixing it and breaking old saved remotes,
-    // only the display here is inverted to show correct values.
-    uint32_t code_found_reverse_lo = instance->generic.data & 0x00000000ffffffff;
+    // only the display here is inverted (~) to show correct values.
+    uint32_t code_found_lo = ~instance->generic.data & 0x00000000000003ff;
 
-    uint64_t code_found = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit);
+    uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
+        ~instance->generic.data, instance->generic.data_count_bit);
 
-    uint32_t code_found_lo = code_found & 0x00000000ffffffff;
+    uint32_t code_found_reverse_lo = code_found_reverse & 0x00000000000003ff;
 
     furi_string_cat_printf(
         output,
@@ -341,5 +341,5 @@ void subghz_protocol_decoder_linear_get_string(void* context, FuriString* output
         instance->generic.data_count_bit,
         code_found_lo,
         code_found_reverse_lo,
-        DATA_TO_DIP(code_found_reverse_lo));
+        DATA_TO_DIP(code_found_lo));
 }


### PR DESCRIPTION
# What's new

- fix key/yek being reversed instead of inverted because my original fix was wrong from the premise

# Verification 

- DIP is still correct
- key/yek when converted to binary reflect DIP correctly (eg `bin(0x... from Key field)` in python CLI, should match DIP)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
