### PR TITLE
HID PTT: adding global zoom and google meet shortcuts for MacOS

### DIFF
--- a/applications/system/hid_app/views/hid_ptt.c
+++ b/applications/system/hid_app/views/hid_ptt.c
@@ -44,6 +44,7 @@ enum HidPushToTalkAppIndex {
     HidPushToTalkAppIndexFaceTime,
     HidPushToTalkAppIndexGather,
     HidPushToTalkAppIndexGoogleMeet,
+    HidPushToTalkAppIndexGoogleMeetGlobal,
     HidPushToTalkAppIndexGoogleHangouts,
     HidPushToTalkAppIndexJamulus,
     HidPushToTalkAppIndexSignal,
@@ -88,6 +89,32 @@ static void hid_ptt_trigger_hand_macos_meet(HidPushToTalk* hid_ptt) {
 static void hid_ptt_trigger_hand_linux_meet(HidPushToTalk* hid_ptt) {
     hid_hal_keyboard_press(hid_ptt->hid, KEY_MOD_LEFT_CTRL | KEY_MOD_LEFT_ALT | HID_KEYBOARD_H);
     hid_hal_keyboard_release(hid_ptt->hid, KEY_MOD_LEFT_CTRL | KEY_MOD_LEFT_ALT | HID_KEYBOARD_H);
+}
+
+// meet global macos
+static void hid_ptt_trigger_mute_macos_meet_global(HidPushToTalk* hid_ptt) {
+    hid_hal_keyboard_press(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_LEFT_CTRL | HID_KEYBOARD_7);
+    hid_hal_keyboard_release(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_LEFT_CTRL | HID_KEYBOARD_7);
+}
+static void hid_ptt_trigger_camera_macos_meet_global(HidPushToTalk* hid_ptt) {
+    hid_hal_keyboard_press(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_LEFT_CTRL | HID_KEYBOARD_8);
+    hid_hal_keyboard_release(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_LEFT_CTRL | HID_KEYBOARD_8);
+}
+static void hid_ptt_trigger_hand_macos_meet_global(HidPushToTalk* hid_ptt) {
+    hid_hal_keyboard_press(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_LEFT_CTRL | HID_KEYBOARD_9);
+    hid_hal_keyboard_release(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_LEFT_CTRL | HID_KEYBOARD_9);
 }
 static void hid_ptt_trigger_mute_macos_zoom(HidPushToTalk* hid_ptt) {
     hid_hal_keyboard_press(hid_ptt->hid, KEY_MOD_LEFT_GUI | KEY_MOD_LEFT_SHIFT | HID_KEYBOARD_A);
@@ -438,6 +465,13 @@ static void hid_ptt_menu_callback(
                     model->callback_start_ptt = hid_ptt_start_ptt_meet_zoom;
                     model->callback_stop_ptt = hid_ptt_stop_ptt_meet_zoom;
                     break;
+                case HidPushToTalkAppIndexGoogleMeetGlobal:
+                    model->callback_trigger_mute = hid_ptt_trigger_mute_macos_meet_global;
+                    model->callback_trigger_camera = hid_ptt_trigger_camera_macos_meet_global;
+                    model->callback_trigger_hand = hid_ptt_trigger_hand_macos_meet_global;
+                    model->callback_start_ptt = hid_ptt_trigger_mute_macos_meet_global;
+                    model->callback_stop_ptt = hid_ptt_trigger_mute_macos_meet_global;
+                    break;
                 case HidPushToTalkAppIndexJamulus:
                     model->callback_trigger_mute = hid_ptt_trigger_mute_jamulus;
                     model->callback_start_ptt = hid_ptt_trigger_mute_jamulus;
@@ -592,6 +626,15 @@ static void hid_ptt_menu_callback(
                     "This feature is off by default in your audio settings "
                     "and may not work for Windows users who use their screen "
                     "reader. In this situation, the spacebar performs a different action.\n\n";
+                break;
+            case HidPushToTalkAppIndexGoogleMeetGlobal:
+                app_specific_help =
+                    "Google Meet (Global):\n"
+                    "1. Install \"Google Meet - Global Shortcuts\" extension.\n"
+                    "2. Open chrome://extensions/shortcuts.\n"
+                    "3. Set 'Toggle microphone' to Cmd+Ctrl+7 and enable Global.\n"
+                    "4. Set 'Toggle camera' to Cmd+Ctrl+8 and enable Global.\n"
+                    "5. Set 'Raise hand' to Cmd+Ctrl+9 and enable Global.\n\n";
                 break;
             case HidPushToTalkAppIndexDiscord:
                 app_specific_help =
@@ -924,6 +967,13 @@ HidPushToTalk* hid_ptt_alloc(Hid* hid) {
         HidPushToTalkLinux,
         "Google Meet",
         HidPushToTalkAppIndexGoogleMeet,
+        hid_ptt_menu_callback,
+        hid_ptt);
+    ptt_menu_add_item_to_list(
+        hid->hid_ptt_menu,
+        HidPushToTalkMacOS,
+        "Google Meet Global",
+        HidPushToTalkAppIndexGoogleMeetGlobal,
         hid_ptt_menu_callback,
         hid_ptt);
     ptt_menu_add_item_to_list(

--- a/applications/system/hid_app/views/hid_ptt.c
+++ b/applications/system/hid_app/views/hid_ptt.c
@@ -54,6 +54,7 @@ enum HidPushToTalkAppIndex {
     HidPushToTalkAppIndexTeamSpeak,
     HidPushToTalkAppIndexWebex,
     HidPushToTalkAppIndexZoom,
+    HidPushToTalkAppIndexZoomGlobal,
     HidPushToTalkAppIndexSize,
 };
 
@@ -107,6 +108,40 @@ static void hid_ptt_trigger_camera_linux_zoom(HidPushToTalk* hid_ptt) {
 static void hid_ptt_trigger_hand_zoom(HidPushToTalk* hid_ptt) {
     hid_hal_keyboard_press(hid_ptt->hid, KEY_MOD_LEFT_ALT | HID_KEYBOARD_Y);
     hid_hal_keyboard_release(hid_ptt->hid, KEY_MOD_LEFT_ALT | HID_KEYBOARD_Y);
+}
+
+// zoom global macos
+static void hid_ptt_trigger_mute_macos_zoom_global(HidPushToTalk* hid_ptt) {
+    hid_hal_keyboard_press(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_RIGHT_ALT | KEY_MOD_LEFT_SHIFT |
+            HID_KEYBOARD_M);
+    hid_hal_keyboard_release(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_RIGHT_ALT | KEY_MOD_LEFT_SHIFT |
+            HID_KEYBOARD_M);
+}
+
+static void hid_ptt_trigger_camera_macos_zoom_global(HidPushToTalk* hid_ptt) {
+    hid_hal_keyboard_press(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_RIGHT_ALT | KEY_MOD_LEFT_SHIFT |
+            HID_KEYBOARD_U);
+    hid_hal_keyboard_release(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_RIGHT_ALT | KEY_MOD_LEFT_SHIFT |
+            HID_KEYBOARD_U);
+}
+
+static void hid_ptt_trigger_hand_zoom_global(HidPushToTalk* hid_ptt) {
+    hid_hal_keyboard_press(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_RIGHT_ALT | KEY_MOD_LEFT_SHIFT |
+            HID_KEYBOARD_Y);
+    hid_hal_keyboard_release(
+        hid_ptt->hid,
+        KEY_MOD_LEFT_GUI | KEY_MOD_RIGHT_ALT | KEY_MOD_LEFT_SHIFT |
+            HID_KEYBOARD_Y);
 }
 
 // this one is widely used across different apps
@@ -457,6 +492,13 @@ static void hid_ptt_menu_callback(
                     model->callback_start_ptt = hid_ptt_start_ptt_meet_zoom;
                     model->callback_stop_ptt = hid_ptt_stop_ptt_meet_zoom;
                     break;
+                case HidPushToTalkAppIndexZoomGlobal:
+                    model->callback_trigger_mute = hid_ptt_trigger_mute_macos_zoom_global;
+                    model->callback_trigger_camera = hid_ptt_trigger_camera_macos_zoom_global;
+                    model->callback_trigger_hand = hid_ptt_trigger_hand_zoom_global;
+                    model->callback_start_ptt = hid_ptt_trigger_mute_macos_zoom_global;
+                    model->callback_stop_ptt = hid_ptt_trigger_mute_macos_zoom_global;
+                    break;
                 }
             } else if(osIndex == HidPushToTalkLinux) {
                 switch(appIndex) {
@@ -569,6 +611,14 @@ static void hid_ptt_menu_callback(
                     "Teams:\n"
                     "Go to Settings > Privacy. Make sure Keyboard shortcut to unmute is toggled on.\n\n";
                 break;
+            case HidPushToTalkAppIndexZoomGlobal:
+                app_specific_help =
+                    "Zoom (Global):\n"
+                    "1. Go to Settings > Keyboard Shortcuts.\n"
+                    "2. Find the 'Mute/Unmute' shortcut and click 'Edit'.\n"
+                    "3. Press the Mute button in the app to bind it.\n"
+                    "4. Check global checkbox.\n"
+                    "5. Repeat for video and hand shortcuts.\n\n";
             }
 
             FuriString* msg = furi_string_alloc();
@@ -1028,6 +1078,13 @@ HidPushToTalk* hid_ptt_alloc(Hid* hid) {
         HidPushToTalkMacOS,
         "Zoom",
         HidPushToTalkAppIndexZoom,
+        hid_ptt_menu_callback,
+        hid_ptt);
+    ptt_menu_add_item_to_list(
+        hid->hid_ptt_menu,
+        HidPushToTalkMacOS,
+        "Zoom Global",
+        HidPushToTalkAppIndexZoomGlobal,
         hid_ptt_menu_callback,
         hid_ptt);
     ptt_menu_add_item_to_list(


### PR DESCRIPTION
# What's new

- Adding new PTT target to the hid app: zoom global.

    Default shortcuts conflict with other apps when made global: mute is "select all", video enable/disable – paste without format.

    PTT (space) can't be remapped and made global so it's implemented with mute/unmute.

    Also zoom doesn't see any difference between `KEY_MOD_LEFT_GUI | KEY_MOD_RIGHT_GUI` and `KEY_MOD_LEFT_GUI` so copying discord keys didn't help much.

- Adding new PTT target to the hid app: zoom global. Requires extention, i.e. [this](https://chromewebstore.google.com/detail/global-google-meet-hotkey/eleeackdlpfiamalcckoncdddheoejlh?hl=en). There's a [PR](https://github.com/mkobayashime/google-meet-global-shortcuts/pull/42) for the raising hand functionality.

    There's a different [extention](https://chromewebstore.google.com/detail/global-google-meet-hotkey/eleeackdlpfiamalcckoncdddheoejlh?hl=en) that has everything implemented but I didn't find it's source code.

# Verification 

I use makefile for that:

```makefile
build_usb:
	./fbt fap_hid_usb
run_usb:
	./fbt launch_app APPSRC=hid_usb
build_ble:
	./fbt fap_hid_ble
run_ble:
	./fbt launch_app APPSRC=hid_ble
build_fw:
	./fbt
install_fw:
	./fbt flash_usb
```

So `make build_usb run_usb` or

```sh
./fbt fap_hid_usb
./fbt launch_app APPSRC=hid_usb
```

- On MacOS open zoom, start a call, open keyboard settings
- On a flipper: Go to PTT => Zoom Global
- Change shortcuts for mute, video and hand rising, make them global
- Play with flipper buttons


# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
