### PR TITLE
Returning fix for reading PWD locked MFUL

### DIFF
--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
@@ -565,16 +565,12 @@ static NfcCommand mf_ultralight_poller_handler_read_pages(MfUltralightPoller* in
         instance->error = mf_ultralight_poller_read_page(instance, start_page, &data);
     }
 
-    // Regression review
-    const uint8_t read_cnt = instance->data->type == MfUltralightTypeMfulC ? 1 : 4;
     if(instance->error == MfUltralightErrorNone) {
-        for(size_t i = 0; i < read_cnt; i++) {
-            if(start_page + i < instance->pages_total) {
-                FURI_LOG_D(TAG, "Read page %d success", start_page + i);
-                instance->data->page[start_page + i] = data.page[i];
-                instance->pages_read++;
-                instance->data->pages_read = instance->pages_read;
-            }
+        if(start_page < instance->pages_total) {
+            FURI_LOG_D(TAG, "Read page %d success", start_page);
+            instance->data->page[start_page] = data.page[0];
+            instance->pages_read++;
+            instance->data->pages_read = instance->pages_read;
         }
 
         if(instance->pages_read == instance->pages_total) {


### PR DESCRIPTION
# What's new

- Return of #826 which was overwritten by UL-C dict attack 

# Verification 

- See #826

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
