### PR TITLE
rewrite subghz generic structure and all around it.

### DIFF
--- a/applications/main/subghz/scenes/subghz_scene_signal_settings.c
+++ b/applications/main/subghz/scenes/subghz_scene_signal_settings.c
@@ -4,16 +4,16 @@
 #include <lib/toolbox/value_index.h>
 #include <machine/endian.h>
 #include <toolbox/strint.h>
+#include <lib/subghz/blocks/generic.h>
 
 #define TAG "SubGhzSceneSignalSettings"
 
 static uint32_t counter_mode = 0xff;
-static uint32_t loaded_counter32 = 0x0;
 static uint32_t counter32 = 0x0;
 static uint16_t counter16 = 0x0;
+static uint8_t bits_count = 0;
 static uint8_t byte_count = 0;
 static uint8_t* byte_ptr = NULL;
-static uint8_t hex_char_lenght = 0;
 static FuriString* byte_input_text;
 
 #define COUNTER_MODE_COUNT 7
@@ -52,55 +52,6 @@ static Protocols protocols[] = {
 
 #define PROTOCOLS_COUNT (sizeof(protocols) / sizeof(Protocols));
 
-// our special case function based on strint_to_uint32 from strint.c
-StrintParseError strint_to_uint32_base16(const char* str, uint32_t* out, uint8_t* lenght) {
-    // skip whitespace
-    while(((*str >= '\t') && (*str <= '\r')) || *str == ' ') {
-        str++;
-    }
-
-    // read digits
-    uint32_t limit = UINT32_MAX;
-    uint32_t mul_limit = limit / 16;
-    uint32_t result = 0;
-    int read_total = 0;
-
-    while(*str != 0) {
-        int digit_value;
-        if(*str >= '0' && *str <= '9') {
-            digit_value = *str - '0';
-        } else if(*str >= 'A' && *str <= 'Z') {
-            digit_value = *str - 'A' + 10;
-        } else if(*str >= 'a' && *str <= 'z') {
-            digit_value = *str - 'a' + 10;
-        } else {
-            break;
-        }
-
-        if(digit_value >= 16) {
-            break;
-        }
-
-        if(result > mul_limit) return StrintParseOverflowError;
-        result *= 16;
-        if(result > limit - digit_value) return StrintParseOverflowError; //-V658
-        result += digit_value;
-
-        read_total++;
-        str++;
-    }
-
-    if(read_total == 0) {
-        result = 0;
-        *lenght = 0;
-        return StrintParseAbsentError;
-    }
-
-    if(out) *out = result;
-    if(lenght) *lenght = read_total;
-    return StrintParseNoError;
-}
-
 void subghz_scene_signal_settings_counter_mode_changed(VariableItem* item) {
     uint8_t index = variable_item_get_current_value_index(item);
     variable_item_set_current_value_text(item, counter_mode_text[index]);
@@ -117,8 +68,8 @@ void subghz_scene_signal_settings_variable_item_list_enter_callback(void* contex
 
     // when we click OK on "Edit counter" item
     if(index == 1) {
-        furi_string_cat_printf(byte_input_text, "%i", hex_char_lenght * 4);
-        furi_string_cat_str(byte_input_text, "-bit counter in HEX");
+        furi_string_cat_printf(byte_input_text, "%i", bits_count);
+        furi_string_cat_str(byte_input_text, "-bits counter in HEX");
 
         // Setup byte_input view
         ByteInput* byte_input = subghz->byte_input;
@@ -174,21 +125,18 @@ void subghz_scene_signal_settings_on_enter(void* context) {
             }
         }
     }
-    FURI_LOG_D(TAG, "Current CounterMode value %li", counter_mode);
+    FURI_LOG_D(TAG, "Loaded CounterMode value %li", counter_mode);
 
     flipper_format_file_close(fff_data_file);
     flipper_format_free(fff_data_file);
     furi_record_close(RECORD_STORAGE);
 
     // ### Counter edit section ###
-    FuriString* textCnt = furi_string_alloc_set_str("");
     byte_input_text = furi_string_alloc_set_str("Enter ");
-    furi_string_reset(tmp_text);
-
     bool counter_not_available = true;
     SubGhzProtocolDecoderBase* decoder = subghz_txrx_get_decoder(subghz->txrx);
 
-    // deserialaze and decode loaded sugbhz file and take information string from decoder
+    // deserialaze and decode loaded sugbhz file and push data to subghz_block_generic_global variable
     if(subghz_protocol_decoder_base_deserialize(decoder, subghz_txrx_get_fff_data(subghz->txrx)) ==
        SubGhzProtocolStatusOk) {
         subghz_protocol_decoder_base_get_string(decoder, tmp_text);
@@ -196,72 +144,27 @@ void subghz_scene_signal_settings_on_enter(void* context) {
         FURI_LOG_E(TAG, "Cant deserialize this subghz file");
     }
 
-    // In protocols output we allways have HEX format for "Cnt:" output (text formating like ...Cnt:%05lX\r\n")
-    // we take 8 simbols starting from  "Cnt:........"
-    // at first we search "Cnt:????" that mean for this protocol counter cannot be decoded
-
-    int8_t place = furi_string_search_str(tmp_text, "Cnt:??", 0);
-    if(place > 0) {
+    if(!subghz_block_generic.cnt_is_available) {
         counter_mode = 0xff;
-        FURI_LOG_D(
-            TAG, "Founded Cnt:???? - Counter mode and edit not available for this protocol");
+        FURI_LOG_D(TAG, "Counter mode and edit not available for this protocol");
     } else {
-        place = furi_string_search_str(tmp_text, "Cnt:", 0);
-        if(place > 0) {
-            // defence from memory leaks. Check can we take 8 symbols after 'Cnt:' ?
-            // if from current place to end of stirngs more than 8 symbols - ok, if not - just take symbols from current place to end of string.
-            // +4 - its 'Cnt:' lenght
-            uint8_t n_symbols_taken = 8;
-            if(sizeof(tmp_text) - (place + 4) < 8) {
-                n_symbols_taken = sizeof(tmp_text) - (place + 4);
-            }
-            furi_string_set_n(textCnt, tmp_text, place + 4, n_symbols_taken);
-            furi_string_trim(textCnt);
-            FURI_LOG_D(
-                TAG,
-                "Taked 8 bytes hex value starting after 'Cnt:' - %s",
-                furi_string_get_cstr(textCnt));
+        counter_not_available = false;
 
-            // trim and convert 8 simbols string to uint32 by base 16 (hex);
-            // later we use loaded_counter in subghz_scene_signal_settings_on_event to check is there 0 or not - special case
-
-            if(strint_to_uint32_base16(
-                   furi_string_get_cstr(textCnt), &loaded_counter32, &hex_char_lenght) ==
-               StrintParseNoError) {
-                counter_not_available = false;
-
-                // calculate and roundup number of hex bytes do display counter in byte_input (every 2 hex simbols = 1 byte for view)
-                // later must be used in byte_input to restrict number of available byte to edit
-                // cnt_byte_count = (hex_char_lenght + 1) / 2;
-
-                FURI_LOG_D(
-                    TAG,
-                    "Result of conversion from String to uint_32 DEC %li, HEX %lX, HEX lenght %i symbols",
-                    loaded_counter32,
-                    loaded_counter32,
-                    hex_char_lenght);
-
-                // Check is there byte_count more than 2 hex bytes long (16 bit) or not (32bit)
-                // To show hex value we must correct revert bytes for ByteInput view
-                if(hex_char_lenght > 4) {
-                    counter32 = loaded_counter32;
-                    furi_string_printf(tmp_text, "%lX", counter32);
-                    counter32 = __bswap32(counter32);
-                    byte_ptr = (uint8_t*)&counter32;
-                    byte_count = 4;
-                } else {
-                    counter16 = loaded_counter32;
-                    furi_string_printf(tmp_text, "%X", counter16);
-                    counter16 = __bswap16(counter16);
-                    byte_ptr = (uint8_t*)&counter16;
-                    byte_count = 2;
-                }
-            } else {
-                FURI_LOG_E(TAG, "Cant convert text counter value");
-            };
-
+        // Check is there byte_count more than 2 hex bytes long or not
+        // To show hex value we must correct revert bytes for ByteInput view with __bswapХХ
+        bits_count = subghz_block_generic.cnt_lenght_bit;
+        if(bits_count > 16) {
+            counter32 = subghz_block_generic.cnt;
+            furi_string_printf(tmp_text, "%lX", counter32);
+            counter32 = __bswap32(counter32);
+            byte_ptr = (uint8_t*)&counter32;
+            byte_count = 4;
         } else {
-            FURI_LOG_D(TAG, "Counter editor not available for this protocol");
+            counter16 = subghz_block_generic.cnt;
+            furi_string_printf(tmp_text, "%X", counter16);
+            counter16 = __bswap16(counter16);
+            byte_ptr = (uint8_t*)&counter16;
+            byte_count = 2;
         }
     }
 
@@ -272,9 +175,6 @@ void subghz_scene_signal_settings_on_enter(void* context) {
     VariableItemList* variable_item_list = subghz->variable_item_list;
     int32_t value_index;
     VariableItem* item;
-
-    // variable_item_list_set_selected_item(subghz->variable_item_list, 0);
-    // variable_item_list_reset(subghz->variable_item_list);
 
     variable_item_list_set_enter_callback(
         variable_item_list,
@@ -299,71 +199,29 @@ void subghz_scene_signal_settings_on_enter(void* context) {
     variable_item_set_locked(item, (counter_not_available), "Not available\nfor this\nprotocol !");
 
     furi_string_free(tmp_text);
-    furi_string_free(textCnt);
 
     view_dispatcher_switch_to_view(subghz->view_dispatcher, SubGhzViewIdVariableItemList);
 }
 
 bool subghz_scene_signal_settings_on_event(void* context, SceneManagerEvent event) {
     SubGhz* subghz = context;
-    int32_t tmp_counter = 0;
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == SubGhzCustomEventByteInputDone) {
             switch(byte_count) {
             case 2:
-                // when signal has Cnt:00 we can step only to 0000+FFFF = FFFF, but we need 0000 for next step
-                // for this case we must use +1 additional step to increace Cnt from FFFF to 0000.
-
-                // save current user definded counter increase value (mult)
-                tmp_counter = furi_hal_subghz_get_rolling_counter_mult();
-
-                // increase signal counter to max value - at result it must be 0000 in most cases
-                // but can be FFFF in case Cnt:0000 (for this we have +1 additional step below)
-                furi_hal_subghz_set_rolling_counter_mult(0xFFFF);
-                subghz_tx_start(subghz, subghz_txrx_get_fff_data(subghz->txrx));
-                subghz_txrx_stop(subghz->txrx);
-
-                // if file Cnt:00 then do +1 additional step
-                if(loaded_counter32 == 0) {
-                    furi_hal_subghz_set_rolling_counter_mult(1);
-                    subghz_tx_start(subghz, subghz_txrx_get_fff_data(subghz->txrx));
-                    subghz_txrx_stop(subghz->txrx);
-                }
-
-                // at this point we must have signal Cnt:00
-                // convert back after byte_input and do one send with our new mult (counter16) - at end we must have signal Cnt = counter16
+                // set new cnt value and override_flag to global variable and call transmit to generate and save subghz signal
                 counter16 = __bswap16(counter16);
-
-                furi_hal_subghz_set_rolling_counter_mult(counter16);
+                subghz_block_generic_counter_set_for_override(counter16);
                 subghz_tx_start(subghz, subghz_txrx_get_fff_data(subghz->txrx));
                 subghz_txrx_stop(subghz->txrx);
-
-                // restore user definded counter increase value (mult)
-                furi_hal_subghz_set_rolling_counter_mult(tmp_counter);
-
                 break;
             case 4:
                 // the same for 32 bit Counter
-                tmp_counter = furi_hal_subghz_get_rolling_counter_mult();
-
-                furi_hal_subghz_set_rolling_counter_mult(0xFFFFFFF);
-                subghz_tx_start(subghz, subghz_txrx_get_fff_data(subghz->txrx));
-                subghz_txrx_stop(subghz->txrx);
-
-                if(loaded_counter32 == 0) {
-                    furi_hal_subghz_set_rolling_counter_mult(1);
-                    subghz_tx_start(subghz, subghz_txrx_get_fff_data(subghz->txrx));
-                    subghz_txrx_stop(subghz->txrx);
-                }
-
                 counter32 = __bswap32(counter32);
-
-                furi_hal_subghz_set_rolling_counter_mult((counter32 & 0xFFFFFFF));
+                subghz_block_generic_counter_set_for_override(counter32);
                 subghz_tx_start(subghz, subghz_txrx_get_fff_data(subghz->txrx));
                 subghz_txrx_stop(subghz->txrx);
-
-                furi_hal_subghz_set_rolling_counter_mult(tmp_counter);
                 break;
             default:
                 break;

--- a/lib/subghz/blocks/generic.c
+++ b/lib/subghz/blocks/generic.c
@@ -4,6 +4,35 @@
 
 #define TAG "SubGhzBlockGeneric"
 
+// Main things: subghz protocols working (serialize, deserialize, decode and encode)
+// with flipper_format data isolated from upper level subghz functions and structures.
+// So if we need change something inside of protocol data - we need use this API from protocols to get and set data
+
+SubGhzBlockGeneric subghz_block_generic; //global structure for subghz described in generic.h
+
+void subghz_block_generic_counter_set_for_override(uint32_t counter) {
+    subghz_block_generic.cnt = counter; // set global variable
+    subghz_block_generic.cnt_need_override = true; // set flag for protocols
+}
+
+bool subghz_block_generic_counter_is_overrided(uint32_t* counter) {
+    // if override flag was enabled then return succes TRUE and return overrided counter, else return success = FALSE
+    // we cut counter bit lenght to available protocol bits lenght by the logical AND function
+    if(subghz_block_generic.cnt_need_override) {
+        *counter = subghz_block_generic.cnt &
+                   ((0xFFFFFFFF >> (32 - subghz_block_generic.cnt_lenght_bit)));
+        subghz_block_generic.cnt_need_override = false;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void subghz_block_generic_reset(void* p) {
+    UNUSED(p);
+    memset(&subghz_block_generic, 0, sizeof(subghz_block_generic));
+}
+
 void subghz_block_generic_get_preset_name(const char* preset_name, FuriString* preset_str) {
     const char* preset_name_temp;
     if(!strcmp(preset_name, "AM270")) {

--- a/lib/subghz/blocks/generic.h
+++ b/lib/subghz/blocks/generic.h
@@ -25,7 +25,29 @@ struct SubGhzBlockGeneric {
     uint32_t cnt;
     uint8_t cnt_2;
     uint32_t seed;
+    bool cnt_need_override; // flag for protocols to override signals counter inside of protocols
+    uint8_t cnt_lenght_bit; // counter lenght in bits (used in counter editor giu)
+    bool cnt_is_available; // is there counter available for protocol (used in counter editor giu)
 };
+
+extern SubGhzBlockGeneric subghz_block_generic; //global structure for subghz
+/**
+ * Set global variable generic.cnt and flag to be used for override counter inside of subghz protocols;
+ * @param new_counter new counter value;
+ */
+void subghz_block_generic_counter_set_for_override(uint32_t counter);
+
+/**
+ * Return true if incomming variable was overrided to value of global variable generic.cnt
+ * else return false and not change incomming variable
+ * @param counter pointer to counter variable that must be setup
+ */
+bool subghz_block_generic_counter_is_overrided(uint32_t* counter);
+
+/**
+ * Reset subghz_block_generic global structure;
+ */
+void subghz_block_generic_reset(void* p);
 
 /**
  * Get name preset.

--- a/lib/subghz/protocols/alutech_at_4n.c
+++ b/lib/subghz/protocols/alutech_at_4n.c
@@ -20,22 +20,16 @@ static const SubGhzBlockConst subghz_protocol_alutech_at_4n_const = {
 
 struct SubGhzProtocolDecoderAlutech_at_4n {
     SubGhzProtocolDecoderBase base;
-
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
-
     uint64_t data;
     uint32_t crc;
     uint16_t header_count;
-
     const char* alutech_at_4n_rainbow_table_file_name;
 };
 
 struct SubGhzProtocolEncoderAlutech_at_4n {
     SubGhzProtocolEncoderBase base;
-
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
     const char* alutech_at_4n_rainbow_table_file_name;
     uint32_t crc;
 };
@@ -92,7 +86,7 @@ void* subghz_protocol_encoder_alutech_at_4n_alloc(SubGhzEnvironment* environment
         malloc(sizeof(SubGhzProtocolEncoderAlutech_at_4n));
 
     instance->base.protocol = &subghz_protocol_alutech_at_4n;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 512;
@@ -264,61 +258,70 @@ static uint64_t subghz_protocol_alutech_at_4n_encrypt(uint64_t data, const char*
 static bool subghz_protocol_alutech_at_4n_gen_data(
     SubGhzProtocolEncoderAlutech_at_4n* instance,
     uint8_t btn) {
-    uint64_t data = subghz_protocol_blocks_reverse_key(instance->generic.data, 64);
+    uint64_t data = subghz_protocol_blocks_reverse_key(subghz_block_generic.data, 64);
 
     data = subghz_protocol_alutech_at_4n_decrypt(
         data, instance->alutech_at_4n_rainbow_table_file_name);
     uint8_t crc = data >> 56;
     if(crc == subghz_protocol_alutech_at_4n_decrypt_data_crc((uint8_t)((data >> 8) & 0xFF))) {
-        instance->generic.btn = (uint8_t)data & 0xFF;
-        instance->generic.cnt = (uint16_t)(data >> 8) & 0xFFFF;
-        instance->generic.serial = (uint32_t)(data >> 24) & 0xFFFFFFFF;
+        subghz_block_generic.btn = (uint8_t)data & 0xFF;
+        subghz_block_generic.cnt = (uint16_t)(data >> 8) & 0xFFFF;
+        subghz_block_generic.serial = (uint32_t)(data >> 24) & 0xFFFFFFFF;
     }
 
     if(alutech_at4n_counter_mode == 0) {
         // Check for OFEX (overflow experimental) mode
         if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-            if((instance->generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
-                instance->generic.cnt = 0;
-            } else {
-                instance->generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+            // standart counter mode. PULL data from subghz_block_generic_global variables
+            if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+                // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+                // so we increase counter by standart mult value
+                if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) >
+                   0xFFFF) {
+                    subghz_block_generic.cnt = 0;
+                } else {
+                    subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+                }
             }
+
         } else {
-            if((instance->generic.cnt + 0x1) > 0xFFFF) {
-                instance->generic.cnt = 0;
-            } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-                instance->generic.cnt = 0xFFFE;
+            //OFFEX mode
+            if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+                subghz_block_generic.cnt = 0;
+            } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+                subghz_block_generic.cnt = 0xFFFE;
             } else {
-                instance->generic.cnt++;
+                subghz_block_generic.cnt++;
             }
         }
     } else if(alutech_at4n_counter_mode == 1) {
         // Mode 1
         // 0000 / 0001 / FFFE / FFFF
-        if((instance->generic.cnt + 0x1) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-            instance->generic.cnt = 0xFFFE;
+        if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+            subghz_block_generic.cnt = 0;
+        } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+            subghz_block_generic.cnt = 0xFFFE;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     } else {
         // Mode 2
         // 0x0000 / 0x0001 / 0x0002 / 0x0003 / 0x0004 / 0x0005
-        if(instance->generic.cnt >= 0x0005) {
-            instance->generic.cnt = 0;
+        if(subghz_block_generic.cnt >= 0x0005) {
+            subghz_block_generic.cnt = 0;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     }
-    crc = subghz_protocol_alutech_at_4n_decrypt_data_crc((uint8_t)(instance->generic.cnt & 0xFF));
-    data = (uint64_t)crc << 56 | (uint64_t)instance->generic.serial << 24 |
-           (uint32_t)instance->generic.cnt << 8 | btn;
+    crc =
+        subghz_protocol_alutech_at_4n_decrypt_data_crc((uint8_t)(subghz_block_generic.cnt & 0xFF));
+    data = (uint64_t)crc << 56 | (uint64_t)subghz_block_generic.serial << 24 |
+           (uint32_t)subghz_block_generic.cnt << 8 | btn;
 
     data = subghz_protocol_alutech_at_4n_encrypt(
         data, instance->alutech_at_4n_rainbow_table_file_name);
     crc = subghz_protocol_alutech_at_4n_crc(data);
-    instance->generic.data = subghz_protocol_blocks_reverse_key(data, 64);
+    subghz_block_generic.data = subghz_protocol_blocks_reverse_key(data, 64);
     instance->crc = subghz_protocol_blocks_reverse_key(crc, 8);
     return true;
 }
@@ -332,11 +335,14 @@ bool subghz_protocol_alutech_at_4n_create_data(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolEncoderAlutech_at_4n* instance = context;
-    instance->generic.serial = serial;
-    instance->generic.cnt = cnt;
-    instance->generic.data_count_bit = 72;
+
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.serial = serial;
+    subghz_block_generic.cnt = cnt;
+    subghz_block_generic.data_count_bit = 72;
+
     if(subghz_protocol_alutech_at_4n_gen_data(instance, btn)) {
-        if((subghz_block_generic_serialize(&instance->generic, flipper_format, preset) !=
+        if((subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset) !=
             SubGhzProtocolStatusOk)) {
             FURI_LOG_E(TAG, "Serialize error");
             return false;
@@ -396,7 +402,7 @@ static bool subghz_protocol_encoder_alutech_at_4n_get_upload(
 
     // Send key data
     for(uint8_t i = 64; i > 0; --i) {
-        if(bit_read(instance->generic.data, i - 1)) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_alutech_at_4n_const.te_short);
@@ -449,7 +455,7 @@ SubGhzProtocolStatus subghz_protocol_encoder_alutech_at_4n_deserialize(
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
@@ -476,9 +482,9 @@ SubGhzProtocolStatus subghz_protocol_encoder_alutech_at_4n_deserialize(
         }
 
         subghz_protocol_alutech_at_4n_remote_controller(
-            &instance->generic, instance->crc, instance->alutech_at_4n_rainbow_table_file_name);
+            &subghz_block_generic, instance->crc, instance->alutech_at_4n_rainbow_table_file_name);
 
-        subghz_protocol_encoder_alutech_at_4n_get_upload(instance, instance->generic.btn);
+        subghz_protocol_encoder_alutech_at_4n_get_upload(instance, subghz_block_generic.btn);
 
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
@@ -486,7 +492,7 @@ SubGhzProtocolStatus subghz_protocol_encoder_alutech_at_4n_deserialize(
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -513,7 +519,7 @@ void* subghz_protocol_decoder_alutech_at_4n_alloc(SubGhzEnvironment* environment
     SubGhzProtocolDecoderAlutech_at_4n* instance =
         malloc(sizeof(SubGhzProtocolDecoderAlutech_at_4n));
     instance->base.protocol = &subghz_protocol_alutech_at_4n;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->alutech_at_4n_rainbow_table_file_name =
         subghz_environment_get_alutech_at_4n_rainbow_table_file_name(environment);
     if(instance->alutech_at_4n_rainbow_table_file_name) {
@@ -593,10 +599,10 @@ void subghz_protocol_decoder_alutech_at_4n_feed(void* context, bool level, uint3
                 instance->decoder.parser_step = Alutech_at_4nDecoderStepReset;
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_alutech_at_4n_const.min_count_bit_for_found) {
-                    if(instance->generic.data != instance->data) {
-                        instance->generic.data = instance->data;
+                    if(subghz_block_generic.data != instance->data) {
+                        subghz_block_generic.data = instance->data;
 
-                        instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                        subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                         instance->crc = instance->decoder.decode_data;
 
                         if(instance->base.callback)
@@ -711,7 +717,7 @@ SubGhzProtocolStatus subghz_protocol_decoder_alutech_at_4n_serialize(
     furi_assert(context);
     SubGhzProtocolDecoderAlutech_at_4n* instance = context;
     SubGhzProtocolStatus res =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
     if(!flipper_format_rewind(flipper_format)) {
         FURI_LOG_E(TAG, "Rewind error");
         res = SubGhzProtocolStatusErrorParserOthers;
@@ -729,10 +735,14 @@ SubGhzProtocolStatus subghz_protocol_decoder_alutech_at_4n_deserialize(
     FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderAlutech_at_4n* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_alutech_at_4n_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -865,10 +875,16 @@ static uint8_t subghz_protocol_alutech_at_4n_get_btn_code(void) {
 void subghz_protocol_decoder_alutech_at_4n_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderAlutech_at_4n* instance = context;
+    UNUSED(instance);
     subghz_protocol_alutech_at_4n_remote_controller(
-        &instance->generic, instance->crc, instance->alutech_at_4n_rainbow_table_file_name);
-    uint32_t code_found_hi = instance->generic.data >> 32;
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+        &subghz_block_generic, instance->crc, instance->alutech_at_4n_rainbow_table_file_name);
+    uint32_t code_found_hi = subghz_block_generic.data >> 32;
+    uint32_t code_found_lo = subghz_block_generic.data & 0x00000000ffffffff;
+
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = true;
+    subghz_block_generic.cnt_lenght_bit = 16;
+    //
 
     furi_string_cat_printf(
         output,
@@ -876,12 +892,12 @@ void subghz_protocol_decoder_alutech_at_4n_get_string(void* context, FuriString*
         "Key:0x%08lX%08lX\nCRC:%02X  %dbit\r\n"
         "Sn:0x%08lX  Btn:0x%01X\r\n"
         "Cnt:%04lX\r\n",
-        instance->generic.protocol_name,
+        subghz_block_generic.protocol_name,
         code_found_hi,
         code_found_lo,
         (uint8_t)instance->crc,
-        instance->generic.data_count_bit,
-        instance->generic.serial,
-        instance->generic.btn,
-        instance->generic.cnt);
+        subghz_block_generic.data_count_bit,
+        subghz_block_generic.serial,
+        subghz_block_generic.btn,
+        subghz_block_generic.cnt);
 }

--- a/lib/subghz/protocols/ansonic.c
+++ b/lib/subghz/protocols/ansonic.c
@@ -23,16 +23,12 @@ static const SubGhzBlockConst subghz_protocol_ansonic_const = {
 
 struct SubGhzProtocolDecoderAnsonic {
     SubGhzProtocolDecoderBase base;
-
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderAnsonic {
     SubGhzProtocolEncoderBase base;
-
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -78,10 +74,8 @@ const SubGhzProtocol subghz_protocol_ansonic = {
 void* subghz_protocol_encoder_ansonic_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolEncoderAnsonic* instance = malloc(sizeof(SubGhzProtocolEncoderAnsonic));
-
     instance->base.protocol = &subghz_protocol_ansonic;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 52;
     instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
@@ -104,7 +98,7 @@ void subghz_protocol_encoder_ansonic_free(void* context) {
 static bool subghz_protocol_encoder_ansonic_get_upload(SubGhzProtocolEncoderAnsonic* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -118,8 +112,8 @@ static bool subghz_protocol_encoder_ansonic_get_upload(SubGhzProtocolEncoderAnso
     instance->encoder.upload[index++] =
         level_duration_make(true, (uint32_t)subghz_protocol_ansonic_const.te_short);
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(false, (uint32_t)subghz_protocol_ansonic_const.te_short);
@@ -143,7 +137,7 @@ SubGhzProtocolStatus
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         res = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_ansonic_const.min_count_bit_for_found);
         if(res != SubGhzProtocolStatusOk) {
@@ -191,7 +185,7 @@ void* subghz_protocol_decoder_ansonic_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderAnsonic* instance = malloc(sizeof(SubGhzProtocolDecoderAnsonic));
     instance->base.protocol = &subghz_protocol_ansonic;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -239,11 +233,11 @@ void subghz_protocol_decoder_ansonic_feed(void* context, bool level, uint32_t du
                 instance->decoder.parser_step = AnsonicDecoderStepFoundStartBit;
                 if(instance->decoder.decode_count_bit >=
                    subghz_protocol_ansonic_const.min_count_bit_for_found) {
-                    instance->generic.serial = 0x0;
-                    instance->generic.btn = 0x0;
+                    subghz_block_generic.serial = 0x0;
+                    subghz_block_generic.btn = 0x0;
 
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -308,30 +302,36 @@ SubGhzProtocolStatus subghz_protocol_decoder_ansonic_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderAnsonic* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_ansonic_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderAnsonic* instance = context;
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_ansonic_const.min_count_bit_for_found);
+        &subghz_block_generic,
+        flipper_format,
+        subghz_protocol_ansonic_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_ansonic_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderAnsonic* instance = context;
-    subghz_protocol_ansonic_check_remote_controller(&instance->generic);
+    UNUSED(instance);
+    subghz_protocol_ansonic_check_remote_controller(&subghz_block_generic);
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
         "Key:%03lX\r\n"
         "Btn:%X\r\n"
         "DIP:" DIP_PATTERN "\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        instance->generic.btn,
-        CNT_TO_DIP(instance->generic.cnt));
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        subghz_block_generic.btn,
+        CNT_TO_DIP(subghz_block_generic.cnt));
 }

--- a/lib/subghz/protocols/bett.c
+++ b/lib/subghz/protocols/bett.c
@@ -34,16 +34,12 @@ static const SubGhzBlockConst subghz_protocol_bett_const = {
 
 struct SubGhzProtocolDecoderBETT {
     SubGhzProtocolDecoderBase base;
-
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderBETT {
     SubGhzProtocolEncoderBase base;
-
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -89,7 +85,7 @@ void* subghz_protocol_encoder_bett_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderBETT* instance = malloc(sizeof(SubGhzProtocolEncoderBETT));
 
     instance->base.protocol = &subghz_protocol_bett;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 52;
@@ -113,7 +109,7 @@ void subghz_protocol_encoder_bett_free(void* context) {
 static bool subghz_protocol_encoder_bett_get_upload(SubGhzProtocolEncoderBETT* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2);
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2);
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -121,8 +117,8 @@ static bool subghz_protocol_encoder_bett_get_upload(SubGhzProtocolEncoderBETT* i
         instance->encoder.size_upload = size_upload;
     }
 
-    for(uint8_t i = instance->generic.data_count_bit; i > 1; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 1; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_bett_const.te_long);
@@ -136,7 +132,7 @@ static bool subghz_protocol_encoder_bett_get_upload(SubGhzProtocolEncoderBETT* i
                 level_duration_make(false, (uint32_t)subghz_protocol_bett_const.te_long);
         }
     }
-    if(bit_read(instance->generic.data, 0)) {
+    if(bit_read(subghz_block_generic.data, 0)) {
         //send bit 1
         instance->encoder.upload[index++] =
             level_duration_make(true, (uint32_t)subghz_protocol_bett_const.te_long);
@@ -162,7 +158,7 @@ SubGhzProtocolStatus
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_bett_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -210,7 +206,7 @@ void* subghz_protocol_decoder_bett_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderBETT* instance = malloc(sizeof(SubGhzProtocolDecoderBETT));
     instance->base.protocol = &subghz_protocol_bett;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -245,8 +241,8 @@ void subghz_protocol_decoder_bett_feed(void* context, bool level, uint32_t durat
                (subghz_protocol_bett_const.te_delta * 15)) {
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_bett_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -302,21 +298,27 @@ SubGhzProtocolStatus subghz_protocol_decoder_bett_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderBETT* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_bett_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderBETT* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_bett_const.min_count_bit_for_found);
+        &subghz_block_generic, flipper_format, subghz_protocol_bett_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_bett_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderBETT* instance = context;
-    uint32_t data = (uint32_t)(instance->generic.data & 0x3FFFF);
+    UNUSED(instance);
+    uint32_t data = (uint32_t)(subghz_block_generic.data & 0x3FFFF);
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
@@ -324,8 +326,8 @@ void subghz_protocol_decoder_bett_get_string(void* context, FuriString* output) 
         "  +:   " DIP_PATTERN "\r\n"
         "  o:   " DIP_PATTERN "\r\n"
         "  -:   " DIP_PATTERN "\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         data,
         SHOW_DIP_P(data, DIP_P),
         SHOW_DIP_P(data, DIP_O),

--- a/lib/subghz/protocols/bin_raw.c
+++ b/lib/subghz/protocols/bin_raw.c
@@ -67,9 +67,7 @@ typedef struct BinRAW_Markup BinRAW_Markup;
 
 struct SubGhzProtocolDecoderBinRAW {
     SubGhzProtocolDecoderBase base;
-
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
     int32_t* data_raw;
     uint8_t* data;
     BinRAW_Markup data_markup[BIN_RAW_MAX_MARKUP_COUNT];
@@ -80,10 +78,7 @@ struct SubGhzProtocolDecoderBinRAW {
 
 struct SubGhzProtocolEncoderBinRAW {
     SubGhzProtocolEncoderBase base;
-
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
-
     uint8_t* data;
     BinRAW_Markup data_markup[BIN_RAW_MAX_MARKUP_COUNT];
     uint32_t te;
@@ -140,7 +135,7 @@ void* subghz_protocol_encoder_bin_raw_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderBinRAW* instance = malloc(sizeof(SubGhzProtocolEncoderBinRAW));
 
     instance->base.protocol = &subghz_protocol_bin_raw;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = BIN_RAW_BUF_DATA_SIZE * 5;
@@ -241,7 +236,7 @@ SubGhzProtocolStatus
             break;
         }
 
-        instance->generic.data_count_bit = (uint16_t)temp_data;
+        subghz_block_generic.data_count_bit = (uint16_t)temp_data;
 
         if(!flipper_format_read_uint32(flipper_format, "TE", (uint32_t*)&instance->te, 1)) {
             FURI_LOG_E(TAG, "Missing TE");
@@ -353,7 +348,7 @@ void* subghz_protocol_decoder_bin_raw_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderBinRAW* instance = malloc(sizeof(SubGhzProtocolDecoderBinRAW));
     instance->base.protocol = &subghz_protocol_bin_raw;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->data_raw_ind = 0;
     instance->data_raw = malloc(BIN_RAW_BUF_RAW_SIZE * sizeof(int32_t));
     instance->data = malloc(BIN_RAW_BUF_RAW_SIZE * sizeof(uint8_t));
@@ -920,7 +915,7 @@ void subghz_protocol_decoder_bin_raw_data_input_rssi(
             bin_raw_debug("\r\n\t count data= %zu\r\n\r\n", instance->data_raw_ind);
 #endif
             instance->decoder.parser_step = BinRAWDecoderStepReset;
-            instance->generic.data_count_bit = 0;
+            subghz_block_generic.data_count_bit = 0;
             if(instance->data_raw_ind >= BIN_RAW_BUF_MIN_DATA_COUNT) {
                 if(subghz_protocol_bin_raw_check_remote_controller(instance)) {
                     bin_raw_debug_tag(TAG, "Sequence found\r\n");
@@ -928,7 +923,7 @@ void subghz_protocol_decoder_bin_raw_data_input_rssi(
                     uint16_t i = 0;
                     while((i < BIN_RAW_MAX_MARKUP_COUNT) &&
                           (instance->data_markup[i].bit_count != 0)) {
-                        instance->generic.data_count_bit += instance->data_markup[i].bit_count;
+                        subghz_block_generic.data_count_bit += instance->data_markup[i].bit_count;
 #ifdef BIN_RAW_DEBUG
                         bin_raw_debug(
                             "\r\n\t%d\t%d\t%d :\t",
@@ -1017,13 +1012,13 @@ SubGhzProtocolStatus subghz_protocol_decoder_bin_raw_serialize(
             }
         }
         if(!flipper_format_write_string_cstr(
-               flipper_format, "Protocol", instance->generic.protocol_name)) {
+               flipper_format, "Protocol", subghz_block_generic.protocol_name)) {
             FURI_LOG_E(TAG, "Unable to add Protocol");
             res = SubGhzProtocolStatusErrorParserProtocolName;
             break;
         }
 
-        uint32_t temp = instance->generic.data_count_bit;
+        uint32_t temp = subghz_block_generic.data_count_bit;
         if(!flipper_format_write_uint32(flipper_format, "Bit", &temp, 1)) {
             FURI_LOG_E(TAG, "Unable to add Bit");
             res = SubGhzProtocolStatusErrorParserBitCount;
@@ -1067,6 +1062,9 @@ SubGhzProtocolStatus
     furi_assert(context);
     SubGhzProtocolDecoderBinRAW* instance = context;
 
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     uint32_t temp_data = 0;
 
@@ -1082,7 +1080,7 @@ SubGhzProtocolStatus
             break;
         }
 
-        instance->generic.data_count_bit = (uint16_t)temp_data;
+        subghz_block_generic.data_count_bit = (uint16_t)temp_data;
 
         if(!flipper_format_read_uint32(flipper_format, "TE", (uint32_t*)&instance->te, 1)) {
             FURI_LOG_E(TAG, "Missing TE");
@@ -1138,10 +1136,11 @@ void subghz_protocol_decoder_bin_raw_get_string(void* context, FuriString* outpu
         output,
         "%s %dbit\r\n"
         "Key:",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit);
 
-    uint16_t byte_count = subghz_protocol_bin_raw_get_full_byte(instance->generic.data_count_bit);
+    uint16_t byte_count =
+        subghz_protocol_bin_raw_get_full_byte(subghz_block_generic.data_count_bit);
     for(size_t i = 0; (byte_count < 36 ? i < byte_count : i < 36); i++) {
         furi_string_cat_printf(output, "%02X", instance->data[i]);
     }

--- a/lib/subghz/protocols/came.c
+++ b/lib/subghz/protocols/came.c
@@ -31,16 +31,12 @@ static const SubGhzBlockConst subghz_protocol_came_const = {
 
 struct SubGhzProtocolDecoderCame {
     SubGhzProtocolDecoderBase base;
-
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderCame {
     SubGhzProtocolEncoderBase base;
-
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -88,7 +84,7 @@ void* subghz_protocol_encoder_came_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderCame* instance = malloc(sizeof(SubGhzProtocolEncoderCame));
 
     instance->base.protocol = &subghz_protocol_came;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 128;
@@ -113,7 +109,7 @@ static bool subghz_protocol_encoder_came_get_upload(SubGhzProtocolEncoderCame* i
     furi_assert(instance);
     uint32_t header_te = 0;
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -122,7 +118,7 @@ static bool subghz_protocol_encoder_came_get_upload(SubGhzProtocolEncoderCame* i
     }
     //Send header
 
-    switch(instance->generic.data_count_bit) {
+    switch(subghz_block_generic.data_count_bit) {
     case CAME_24_COUNT_BIT:
     case PRASTEL_42_COUNT_BIT:
         // CAME 24 Bit = 24320 us
@@ -148,8 +144,8 @@ static bool subghz_protocol_encoder_came_get_upload(SubGhzProtocolEncoderCame* i
     instance->encoder.upload[index++] =
         level_duration_make(true, (uint32_t)subghz_protocol_came_const.te_short);
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(false, (uint32_t)subghz_protocol_came_const.te_long);
@@ -170,13 +166,14 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_came_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderCame* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
-        ret = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+        ret = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
-        if(instance->generic.data_count_bit > PRASTEL_42_COUNT_BIT) {
+        if(subghz_block_generic.data_count_bit > PRASTEL_42_COUNT_BIT) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             ret = SubGhzProtocolStatusErrorValueBitCount;
             break;
@@ -222,7 +219,7 @@ void* subghz_protocol_decoder_came_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderCame* instance = malloc(sizeof(SubGhzProtocolDecoderCame));
     instance->base.protocol = &subghz_protocol_came;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -276,11 +273,11 @@ void subghz_protocol_decoder_came_feed(void* context, bool level, uint32_t durat
                    (instance->decoder.decode_count_bit == PRASTEL_25_COUNT_BIT) ||
                    (instance->decoder.decode_count_bit == PRASTEL_42_COUNT_BIT) ||
                    (instance->decoder.decode_count_bit == CAME_24_COUNT_BIT)) {
-                    instance->generic.serial = 0x0;
-                    instance->generic.btn = 0x0;
+                    subghz_block_generic.serial = 0x0;
+                    subghz_block_generic.btn = 0x0;
 
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -330,20 +327,23 @@ SubGhzProtocolStatus subghz_protocol_decoder_came_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderCame* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_came_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderCame* instance = context;
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
-        ret = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+        ret = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
-        if(instance->generic.data_count_bit > PRASTEL_42_COUNT_BIT) {
+        if(subghz_block_generic.data_count_bit > PRASTEL_42_COUNT_BIT) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             ret = SubGhzProtocolStatusErrorValueBitCount;
             break;
@@ -355,16 +355,17 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_came_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderCame* instance = context;
+    UNUSED(instance);
 
-    uint32_t code_found_lo = instance->generic.data & 0x000003ffffffffff;
+    uint32_t code_found_lo = subghz_block_generic.data & 0x000003ffffffffff;
 
     uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit);
 
     uint32_t code_found_reverse_lo = code_found_reverse & 0x000003ffffffffff;
 
-    const char* name = instance->generic.protocol_name;
-    switch(instance->generic.data_count_bit) {
+    const char* name = subghz_block_generic.protocol_name;
+    switch(subghz_block_generic.data_count_bit) {
     case PRASTEL_25_COUNT_BIT:
     case PRASTEL_42_COUNT_BIT:
         name = PRASTEL_NAME;
@@ -380,7 +381,7 @@ void subghz_protocol_decoder_came_get_string(void* context, FuriString* output) 
         "Key:0x%08lX\r\n"
         "Yek:0x%08lX\r\n",
         name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.data_count_bit,
         code_found_lo,
         code_found_reverse_lo);
 }

--- a/lib/subghz/protocols/came_atomo.c
+++ b/lib/subghz/protocols/came_atomo.c
@@ -20,18 +20,13 @@ static const SubGhzBlockConst subghz_protocol_came_atomo_const = {
 
 struct SubGhzProtocolDecoderCameAtomo {
     SubGhzProtocolDecoderBase base;
-
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
-
     ManchesterState manchester_saved_state;
 };
 
 struct SubGhzProtocolEncoderCameAtomo {
     SubGhzProtocolEncoderBase base;
-
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -87,8 +82,7 @@ void* subghz_protocol_encoder_came_atomo_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderCameAtomo* instance = malloc(sizeof(SubGhzProtocolEncoderCameAtomo));
 
     instance->base.protocol = &subghz_protocol_came_atomo;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 900; //actual size 766+
     instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
@@ -139,36 +133,37 @@ bool subghz_protocol_came_atomo_create_data(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolEncoderCameAtomo* instance = context;
-    instance->generic.btn = 0x1;
-    instance->generic.serial = serial;
-    instance->generic.cnt = cnt;
-    instance->generic.cnt_2 = 0x7e;
-    instance->generic.data_count_bit = 62;
-    instance->generic.data_2 =
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.btn = 0x1;
+    subghz_block_generic.serial = serial;
+    subghz_block_generic.cnt = cnt;
+    subghz_block_generic.cnt_2 = 0x7e;
+    subghz_block_generic.data_count_bit = 62;
+    subghz_block_generic.data_2 =
         ((uint64_t)0x7e << 56 | (uint64_t)cnt << 40 | (uint64_t)serial << 8);
 
     uint8_t pack[8] = {};
 
-    pack[0] = (instance->generic.cnt_2);
-    pack[1] = (instance->generic.cnt >> 8);
-    pack[2] = (instance->generic.cnt & 0xFF);
-    pack[3] = ((instance->generic.data_2 >> 32) & 0xFF);
-    pack[4] = ((instance->generic.data_2 >> 24) & 0xFF);
-    pack[5] = ((instance->generic.data_2 >> 16) & 0xFF);
-    pack[6] = ((instance->generic.data_2 >> 8) & 0xFF);
-    pack[7] = (instance->generic.data_2 & 0xFF);
+    pack[0] = (subghz_block_generic.cnt_2);
+    pack[1] = (subghz_block_generic.cnt >> 8);
+    pack[2] = (subghz_block_generic.cnt & 0xFF);
+    pack[3] = ((subghz_block_generic.data_2 >> 32) & 0xFF);
+    pack[4] = ((subghz_block_generic.data_2 >> 24) & 0xFF);
+    pack[5] = ((subghz_block_generic.data_2 >> 16) & 0xFF);
+    pack[6] = ((subghz_block_generic.data_2 >> 8) & 0xFF);
+    pack[7] = (subghz_block_generic.data_2 & 0xFF);
 
     atomo_encrypt(pack);
     uint32_t hi = pack[0] << 24 | pack[1] << 16 | pack[2] << 8 | pack[3];
     uint32_t lo = pack[4] << 24 | pack[5] << 16 | pack[6] << 8 | pack[7];
-    instance->generic.data = (uint64_t)hi << 32 | lo;
+    subghz_block_generic.data = (uint64_t)hi << 32 | lo;
 
-    instance->generic.data ^= 0xFFFFFFFFFFFFFFFF;
-    instance->generic.data >>= 4;
-    instance->generic.data &= 0xFFFFFFFFFFFFFFF;
+    subghz_block_generic.data ^= 0xFFFFFFFFFFFFFFFF;
+    subghz_block_generic.data >>= 4;
+    subghz_block_generic.data &= 0xFFFFFFFFFFFFFFF;
 
     return SubGhzProtocolStatusOk ==
-           subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+           subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 /**
@@ -190,40 +185,48 @@ static void subghz_protocol_encoder_came_atomo_get_upload(
     if(came_atomo_counter_mode == 0) {
         // Check for OFEX (overflow experimental) mode
         if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-            if((instance->generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
-                instance->generic.cnt = 0;
-            } else {
-                instance->generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+            // standart counter mode. PULL data from subghz_block_generic_global variables
+            if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+                // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+                // so we increase counter by standart mult value
+                if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) >
+                   0xFFFF) {
+                    subghz_block_generic.cnt = 0;
+                } else {
+                    subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+                }
             }
+
         } else {
-            if((instance->generic.cnt + 0x1) > 0xFFFF) {
-                instance->generic.cnt = 0;
-            } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-                instance->generic.cnt = 0xFFFE;
+            //OFFEX mode
+            if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+                subghz_block_generic.cnt = 0;
+            } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+                subghz_block_generic.cnt = 0xFFFE;
             } else {
-                instance->generic.cnt++;
+                subghz_block_generic.cnt++;
             }
         }
     } else if(came_atomo_counter_mode == 1) {
         // Mode 1
         // 0000 / 0001 / FFFE / FFFF
-        if((instance->generic.cnt + 0x1) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-            instance->generic.cnt = 0xFFFE;
+        if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+            subghz_block_generic.cnt = 0;
+        } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+            subghz_block_generic.cnt = 0xFFFE;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     } else if(came_atomo_counter_mode == 2) {
         // Mode 2
         // 0x807B / 0x807C / 0x007B / 0x007C
-        if(instance->generic.cnt != 0x807B && instance->generic.cnt != 0x807C &&
-           instance->generic.cnt != 0x007B) {
-            instance->generic.cnt = 0x807B;
-        } else if(instance->generic.cnt == 0x807C) {
-            instance->generic.cnt = 0x007B;
+        if(subghz_block_generic.cnt != 0x807B && subghz_block_generic.cnt != 0x807C &&
+           subghz_block_generic.cnt != 0x007B) {
+            subghz_block_generic.cnt = 0x807B;
+        } else if(subghz_block_generic.cnt == 0x807C) {
+            subghz_block_generic.cnt = 0x007B;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     } else {
         // Mode 3 - Freeze counter
@@ -255,13 +258,13 @@ static void subghz_protocol_encoder_came_atomo_get_upload(
     // Btn counter 0x0 - 0x7F
     pack[0] = 0;
     for(uint8_t i = 0; i < 8; i++) {
-        //pack[0] = (instance->generic.data_2 >> 56);
-        pack[1] = (instance->generic.cnt >> 8);
-        pack[2] = (instance->generic.cnt & 0xFF);
-        pack[3] = ((instance->generic.data_2 >> 32) & 0xFF);
-        pack[4] = ((instance->generic.data_2 >> 24) & 0xFF);
-        pack[5] = ((instance->generic.data_2 >> 16) & 0xFF);
-        pack[6] = ((instance->generic.data_2 >> 8) & 0xFF);
+        //pack[0] = (subghz_block_generic.data_2 >> 56);
+        pack[1] = (subghz_block_generic.cnt >> 8);
+        pack[2] = (subghz_block_generic.cnt & 0xFF);
+        pack[3] = ((subghz_block_generic.data_2 >> 32) & 0xFF);
+        pack[4] = ((subghz_block_generic.data_2 >> 24) & 0xFF);
+        pack[5] = ((subghz_block_generic.data_2 >> 16) & 0xFF);
+        pack[6] = ((subghz_block_generic.data_2 >> 8) & 0xFF);
         pack[7] = (btn << 4);
 
         /* if(pack[0] == 0x7F) {
@@ -304,24 +307,24 @@ static void subghz_protocol_encoder_came_atomo_get_upload(
         atomo_encrypt(pack);
         uint32_t hi = pack[0] << 24 | pack[1] << 16 | pack[2] << 8 | pack[3];
         uint32_t lo = pack[4] << 24 | pack[5] << 16 | pack[6] << 8 | pack[7];
-        instance->generic.data = (uint64_t)hi << 32 | lo;
+        subghz_block_generic.data = (uint64_t)hi << 32 | lo;
 
-        instance->generic.data ^= 0xFFFFFFFFFFFFFFFF;
-        instance->generic.data >>= 4;
-        instance->generic.data &= 0xFFFFFFFFFFFFFFF;
+        subghz_block_generic.data ^= 0xFFFFFFFFFFFFFFFF;
+        subghz_block_generic.data >>= 4;
+        subghz_block_generic.data &= 0xFFFFFFFFFFFFFFF;
 
         instance->encoder.upload[index++] =
             level_duration_make(true, (uint32_t)subghz_protocol_came_atomo_const.te_long);
         instance->encoder.upload[index++] =
             level_duration_make(false, (uint32_t)subghz_protocol_came_atomo_const.te_short);
 
-        for(uint8_t i = (instance->generic.data_count_bit - 2); i > 0; i--) {
+        for(uint8_t i = (subghz_block_generic.data_count_bit - 2); i > 0; i--) {
             if(!manchester_encoder_advance(
-                   &enc_state, !bit_read(instance->generic.data, i - 1), &result)) {
+                   &enc_state, !bit_read(subghz_block_generic.data, i - 1), &result)) {
                 instance->encoder.upload[index++] =
                     subghz_protocol_encoder_came_atomo_add_duration_to_upload(result);
                 manchester_encoder_advance(
-                    &enc_state, !bit_read(instance->generic.data, i - 1), &result);
+                    &enc_state, !bit_read(subghz_block_generic.data, i - 1), &result);
             }
             instance->encoder.upload[index++] =
                 subghz_protocol_encoder_came_atomo_add_duration_to_upload(result);
@@ -337,34 +340,35 @@ static void subghz_protocol_encoder_came_atomo_get_upload(
             level_duration_make(false, (uint32_t)subghz_protocol_came_atomo_const.te_delta * 272);
     }
     instance->encoder.size_upload = index;
-    instance->generic.cnt_2++;
-    pack[0] = (instance->generic.cnt_2);
-    pack[1] = (instance->generic.cnt >> 8);
-    pack[2] = (instance->generic.cnt & 0xFF);
-    pack[3] = ((instance->generic.data_2 >> 32) & 0xFF);
-    pack[4] = ((instance->generic.data_2 >> 24) & 0xFF);
-    pack[5] = ((instance->generic.data_2 >> 16) & 0xFF);
-    pack[6] = ((instance->generic.data_2 >> 8) & 0xFF);
+    subghz_block_generic.cnt_2++;
+    pack[0] = (subghz_block_generic.cnt_2);
+    pack[1] = (subghz_block_generic.cnt >> 8);
+    pack[2] = (subghz_block_generic.cnt & 0xFF);
+    pack[3] = ((subghz_block_generic.data_2 >> 32) & 0xFF);
+    pack[4] = ((subghz_block_generic.data_2 >> 24) & 0xFF);
+    pack[5] = ((subghz_block_generic.data_2 >> 16) & 0xFF);
+    pack[6] = ((subghz_block_generic.data_2 >> 8) & 0xFF);
     pack[7] = (btn << 4);
 
     atomo_encrypt(pack);
     uint32_t hi = pack[0] << 24 | pack[1] << 16 | pack[2] << 8 | pack[3];
     uint32_t lo = pack[4] << 24 | pack[5] << 16 | pack[6] << 8 | pack[7];
-    instance->generic.data = (uint64_t)hi << 32 | lo;
+    subghz_block_generic.data = (uint64_t)hi << 32 | lo;
 
-    instance->generic.data ^= 0xFFFFFFFFFFFFFFFF;
-    instance->generic.data >>= 4;
-    instance->generic.data &= 0xFFFFFFFFFFFFFFF;
+    subghz_block_generic.data ^= 0xFFFFFFFFFFFFFFFF;
+    subghz_block_generic.data >>= 4;
+    subghz_block_generic.data &= 0xFFFFFFFFFFFFFFF;
 }
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_came_atomo_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderCameAtomo* instance = context;
+
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
@@ -385,8 +389,8 @@ SubGhzProtocolStatus
             came_atomo_counter_mode = 0;
         }
 
-        subghz_protocol_came_atomo_remote_controller(&instance->generic);
-        subghz_protocol_encoder_came_atomo_get_upload(instance, instance->generic.btn);
+        subghz_protocol_came_atomo_remote_controller(&subghz_block_generic);
+        subghz_protocol_encoder_came_atomo_get_upload(instance, subghz_block_generic.btn);
 
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
@@ -394,7 +398,7 @@ SubGhzProtocolStatus
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -436,7 +440,6 @@ void* subghz_protocol_decoder_came_atomo_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderCameAtomo* instance = malloc(sizeof(SubGhzProtocolDecoderCameAtomo));
     instance->base.protocol = &subghz_protocol_came_atomo;
-    instance->generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -499,8 +502,8 @@ void subghz_protocol_decoder_came_atomo_feed(void* context, bool level, uint32_t
                              subghz_protocol_came_atomo_const.te_delta)) {
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_came_atomo_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -778,7 +781,8 @@ SubGhzProtocolStatus subghz_protocol_decoder_came_atomo_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderCameAtomo* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
@@ -786,13 +790,16 @@ SubGhzProtocolStatus
     furi_assert(context);
     SubGhzProtocolDecoderCameAtomo* instance = context;
 
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus status = SubGhzProtocolStatusOk;
-    status = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    status = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
     if(status != SubGhzProtocolStatusOk) {
         FURI_LOG_E(TAG, "Deserialize error");
         return status;
     }
-    if(instance->generic.data_count_bit !=
+    if(subghz_block_generic.data_count_bit !=
        subghz_protocol_came_atomo_const.min_count_bit_for_found) {
         FURI_LOG_E(TAG, "Wrong number of bits in key");
         return SubGhzProtocolStatusErrorValueBitCount;
@@ -816,9 +823,15 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_came_atomo_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderCameAtomo* instance = context;
-    subghz_protocol_came_atomo_remote_controller(&instance->generic);
-    uint32_t code_found_hi = instance->generic.data >> 32;
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+    UNUSED(instance);
+    subghz_protocol_came_atomo_remote_controller(&subghz_block_generic);
+    uint32_t code_found_hi = subghz_block_generic.data >> 32;
+    uint32_t code_found_lo = subghz_block_generic.data & 0x00000000ffffffff;
+
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = true;
+    subghz_block_generic.cnt_lenght_bit = 16;
+    //
 
     furi_string_cat_printf(
         output,
@@ -828,12 +841,12 @@ void subghz_protocol_decoder_came_atomo_get_string(void* context, FuriString* ou
         "Cnt:%04lX\r\n"
         "Btn_Cnt:0x%02X",
 
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         code_found_hi,
         code_found_lo,
-        instance->generic.serial,
-        instance->generic.btn,
-        instance->generic.cnt,
-        instance->generic.cnt_2);
+        subghz_block_generic.serial,
+        subghz_block_generic.btn,
+        subghz_block_generic.cnt,
+        subghz_block_generic.cnt_2);
 }

--- a/lib/subghz/protocols/came_twee.c
+++ b/lib/subghz/protocols/came_twee.c
@@ -52,17 +52,13 @@ static const SubGhzBlockConst subghz_protocol_came_twee_const = {
 
 struct SubGhzProtocolDecoderCameTwee {
     SubGhzProtocolDecoderBase base;
-
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
     ManchesterState manchester_saved_state;
 };
 
 struct SubGhzProtocolEncoderCameTwee {
     SubGhzProtocolEncoderBase base;
-
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -107,7 +103,7 @@ void* subghz_protocol_encoder_came_twee_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderCameTwee* instance = malloc(sizeof(SubGhzProtocolEncoderCameTwee));
 
     instance->base.protocol = &subghz_protocol_came_twee;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 1536; //max upload 92*14 = 1288 !!!!
@@ -167,9 +163,9 @@ static void subghz_protocol_encoder_came_twee_get_upload(SubGhzProtocolEncoderCa
 
     for(int i = 14; i >= 0; i--) {
         temp_parcel = (temp_parcel & 0xFFFFFFFF00000000) |
-                      (instance->generic.serial ^ came_twee_magic_numbers_xor[i]);
+                      (subghz_block_generic.serial ^ came_twee_magic_numbers_xor[i]);
 
-        for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
+        for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
             if(!manchester_encoder_advance(&enc_state, !bit_read(temp_parcel, i - 1), &result)) {
                 instance->encoder.upload[index++] =
                     subghz_protocol_encoder_came_twee_add_duration_to_upload(result);
@@ -245,10 +241,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_came_twee_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderCameTwee* instance = context;
+
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         res = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_came_twee_const.min_count_bit_for_found);
         if(res != SubGhzProtocolStatusOk) {
@@ -258,7 +255,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_came_twee_remote_controller(&instance->generic);
+        subghz_protocol_came_twee_remote_controller(&subghz_block_generic);
         subghz_protocol_encoder_came_twee_get_upload(instance);
         instance->encoder.front = 0; // reset position before start
         instance->encoder.is_running = true;
@@ -295,7 +292,7 @@ void* subghz_protocol_decoder_came_twee_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderCameTwee* instance = malloc(sizeof(SubGhzProtocolDecoderCameTwee));
     instance->base.protocol = &subghz_protocol_came_twee;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -359,8 +356,8 @@ void subghz_protocol_decoder_came_twee_feed(void* context, bool level, uint32_t 
                              subghz_protocol_came_twee_const.te_delta)) {
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_came_twee_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -424,15 +421,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_came_twee_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderCameTwee* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_came_twee_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderCameTwee* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_came_twee_const.min_count_bit_for_found);
 }
@@ -440,9 +442,11 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_came_twee_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderCameTwee* instance = context;
-    subghz_protocol_came_twee_remote_controller(&instance->generic);
-    uint32_t code_found_hi = instance->generic.data >> 32;
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+    UNUSED(instance);
+
+    subghz_protocol_came_twee_remote_controller(&subghz_block_generic);
+    uint32_t code_found_hi = subghz_block_generic.data >> 32;
+    uint32_t code_found_lo = subghz_block_generic.data & 0x00000000ffffffff;
 
     furi_string_cat_printf(
         output,
@@ -450,10 +454,10 @@ void subghz_protocol_decoder_came_twee_get_string(void* context, FuriString* out
         "Key:0x%lX%08lX\r\n"
         "Btn:%X\r\n"
         "DIP:" DIP_PATTERN "\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         code_found_hi,
         code_found_lo,
-        instance->generic.btn,
-        CNT_TO_DIP(instance->generic.cnt));
+        subghz_block_generic.btn,
+        CNT_TO_DIP(subghz_block_generic.cnt));
 }

--- a/lib/subghz/protocols/chamberlain_code.c
+++ b/lib/subghz/protocols/chamberlain_code.c
@@ -47,16 +47,12 @@ static const SubGhzBlockConst subghz_protocol_chamb_code_const = {
 
 struct SubGhzProtocolDecoderChamb_Code {
     SubGhzProtocolDecoderBase base;
-
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderChamb_Code {
     SubGhzProtocolEncoderBase base;
-
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -103,7 +99,7 @@ void* subghz_protocol_encoder_chamb_code_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderChamb_Code* instance = malloc(sizeof(SubGhzProtocolEncoderChamb_Code));
 
     instance->base.protocol = &subghz_protocol_chamb_code;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 24;
@@ -141,9 +137,9 @@ static bool
     furi_assert(instance);
 
     uint64_t data = subghz_protocol_chamb_bit_to_code(
-        instance->generic.data, instance->generic.data_count_bit);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit);
 
-    switch(instance->generic.data_count_bit) {
+    switch(subghz_block_generic.data_count_bit) {
     case 7:
         data = ((data >> 4) << 16) | (data & 0xF) << 4 | CHAMBERLAIN_7_CODE_MASK_CHECK;
         break;
@@ -170,7 +166,7 @@ static bool
     }
 
     //insert data
-    switch(instance->generic.data_count_bit) {
+    switch(subghz_block_generic.data_count_bit) {
     case 7:
     case 9:
         for(uint8_t i = 44; i > 0; i--) {
@@ -211,13 +207,14 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_chamb_code_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderChamb_Code* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
-        ret = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+        ret = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
-        if(instance->generic.data_count_bit >
+        if(subghz_block_generic.data_count_bit >
            subghz_protocol_chamb_code_const.min_count_bit_for_found) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             ret = SubGhzProtocolStatusErrorValueBitCount;
@@ -265,7 +262,7 @@ void* subghz_protocol_decoder_chamb_code_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderChamb_Code* instance = malloc(sizeof(SubGhzProtocolDecoderChamb_Code));
     instance->base.protocol = &subghz_protocol_chamb_code;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -361,11 +358,11 @@ void subghz_protocol_decoder_chamb_code_feed(void* context, bool level, uint32_t
             if(duration > subghz_protocol_chamb_code_const.te_short * 5) {
                 if(instance->decoder.decode_count_bit >=
                    subghz_protocol_chamb_code_const.min_count_bit_for_found) {
-                    instance->generic.serial = 0x0;
-                    instance->generic.btn = 0x0;
+                    subghz_block_generic.serial = 0x0;
+                    subghz_block_generic.btn = 0x0;
                     if(subghz_protocol_decoder_chamb_code_check_mask_and_parse(instance)) {
-                        instance->generic.data = instance->decoder.decode_data;
-                        instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                        subghz_block_generic.data = instance->decoder.decode_data;
+                        subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                         if(instance->base.callback)
                             instance->base.callback(&instance->base, instance->base.context);
                     }
@@ -435,20 +432,23 @@ SubGhzProtocolStatus subghz_protocol_decoder_chamb_code_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderChamb_Code* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_chamb_code_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderChamb_Code* instance = context;
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
-        ret = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+        ret = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
-        if(instance->generic.data_count_bit >
+        if(subghz_block_generic.data_count_bit >
            subghz_protocol_chamb_code_const.min_count_bit_for_found) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             ret = SubGhzProtocolStatusErrorValueBitCount;
@@ -461,11 +461,12 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_chamb_code_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderChamb_Code* instance = context;
+    UNUSED(instance);
 
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+    uint32_t code_found_lo = subghz_block_generic.data & 0x00000000ffffffff;
 
     uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit);
 
     uint32_t code_found_reverse_lo = code_found_reverse & 0x00000000ffffffff;
 
@@ -474,12 +475,12 @@ void subghz_protocol_decoder_chamb_code_get_string(void* context, FuriString* ou
         "%s %db\r\n"
         "Key:0x%03lX\r\n"
         "Yek:0x%03lX\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         code_found_lo,
         code_found_reverse_lo);
 
-    switch(instance->generic.data_count_bit) {
+    switch(subghz_block_generic.data_count_bit) {
     case 7:
         furi_string_cat_printf(
             output,

--- a/lib/subghz/protocols/clemsa.c
+++ b/lib/subghz/protocols/clemsa.c
@@ -35,14 +35,12 @@ struct SubGhzProtocolDecoderClemsa {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderClemsa {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -88,7 +86,7 @@ void* subghz_protocol_encoder_clemsa_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderClemsa* instance = malloc(sizeof(SubGhzProtocolEncoderClemsa));
 
     instance->base.protocol = &subghz_protocol_clemsa;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 52;
@@ -112,7 +110,7 @@ void subghz_protocol_encoder_clemsa_free(void* context) {
 static bool subghz_protocol_encoder_clemsa_get_upload(SubGhzProtocolEncoderClemsa* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2);
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2);
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -120,8 +118,8 @@ static bool subghz_protocol_encoder_clemsa_get_upload(SubGhzProtocolEncoderClems
         instance->encoder.size_upload = size_upload;
     }
 
-    for(uint8_t i = instance->generic.data_count_bit; i > 1; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 1; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_clemsa_const.te_long);
@@ -135,7 +133,7 @@ static bool subghz_protocol_encoder_clemsa_get_upload(SubGhzProtocolEncoderClems
                 level_duration_make(false, (uint32_t)subghz_protocol_clemsa_const.te_long);
         }
     }
-    if(bit_read(instance->generic.data, 0)) {
+    if(bit_read(subghz_block_generic.data, 0)) {
         //send bit 1
         instance->encoder.upload[index++] =
             level_duration_make(true, (uint32_t)subghz_protocol_clemsa_const.te_long);
@@ -159,10 +157,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_clemsa_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderClemsa* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_clemsa_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -210,7 +209,7 @@ void* subghz_protocol_decoder_clemsa_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderClemsa* instance = malloc(sizeof(SubGhzProtocolDecoderClemsa));
     instance->base.protocol = &subghz_protocol_clemsa;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -280,8 +279,8 @@ void subghz_protocol_decoder_clemsa_feed(void* context, bool level, uint32_t dur
 
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_clemsa_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -322,22 +321,28 @@ SubGhzProtocolStatus subghz_protocol_decoder_clemsa_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderClemsa* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_clemsa_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderClemsa* instance = context;
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_clemsa_const.min_count_bit_for_found);
+        &subghz_block_generic,
+        flipper_format,
+        subghz_protocol_clemsa_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_clemsa_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderClemsa* instance = context;
-    subghz_protocol_clemsa_check_remote_controller(&instance->generic);
-    //uint32_t data = (uint32_t)(instance->generic.data & 0xFFFFFF);
+    UNUSED(instance);
+    subghz_protocol_clemsa_check_remote_controller(&subghz_block_generic);
+    //uint32_t data = (uint32_t)(subghz_block_generic.data & 0xFFFFFF);
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
@@ -345,11 +350,11 @@ void subghz_protocol_decoder_clemsa_get_string(void* context, FuriString* output
         "  +:   " DIP_PATTERN "\r\n"
         "  o:   " DIP_PATTERN "\r\n"
         "  -:   " DIP_PATTERN "\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0x3FFFF),
-        instance->generic.btn,
-        SHOW_DIP_P(instance->generic.serial, DIP_P),
-        SHOW_DIP_P(instance->generic.serial, DIP_O),
-        SHOW_DIP_P(instance->generic.serial, DIP_N));
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0x3FFFF),
+        subghz_block_generic.btn,
+        SHOW_DIP_P(subghz_block_generic.serial, DIP_P),
+        SHOW_DIP_P(subghz_block_generic.serial, DIP_O),
+        SHOW_DIP_P(subghz_block_generic.serial, DIP_N));
 }

--- a/lib/subghz/protocols/dickert_mahs.c
+++ b/lib/subghz/protocols/dickert_mahs.c
@@ -23,7 +23,6 @@ struct SubGhzProtocolDecoderDickertMAHS {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 
     uint32_t tmp[2];
     uint8_t tmp_cnt;
@@ -33,7 +32,6 @@ struct SubGhzProtocolEncoderDickertMAHS {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -77,8 +75,9 @@ const SubGhzProtocol subghz_protocol_dickert_mahs = {
 static void subghz_protocol_encoder_dickert_mahs_parse_buffer(
     SubGhzProtocolDecoderDickertMAHS* instance,
     FuriString* output) {
+    UNUSED(instance);
     // We assume we have only decodes < 64 bit!
-    uint64_t data = instance->generic.data;
+    uint64_t data = subghz_block_generic.data;
     uint8_t bits[36] = {};
 
     // Convert uint64_t into bit array
@@ -117,7 +116,7 @@ static void subghz_protocol_encoder_dickert_mahs_parse_buffer(
         "%s\r\n"
         "User-Dips:\t%s\r\n"
         "Fac-Code:\t%s\r\n",
-        instance->generic.protocol_name,
+        subghz_block_generic.protocol_name,
         furi_string_get_cstr(user_dips),
         furi_string_get_cstr(fact_dips));
     furi_string_free(user_dips);
@@ -130,7 +129,7 @@ void* subghz_protocol_encoder_dickert_mahs_alloc(SubGhzEnvironment* environment)
     SubGhzProtocolEncoderDickertMAHS* instance = malloc(sizeof(SubGhzProtocolEncoderDickertMAHS));
 
     instance->base.protocol = &subghz_protocol_dickert_mahs;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 128;
@@ -155,7 +154,7 @@ static bool
     subghz_protocol_encoder_dickert_mahs_get_upload(SubGhzProtocolEncoderDickertMAHS* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -170,8 +169,8 @@ static bool
         level_duration_make(true, (uint32_t)subghz_protocol_dickert_mahs_const.te_short);
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(false, (uint32_t)subghz_protocol_dickert_mahs_const.te_long);
@@ -193,15 +192,16 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_dickert_mahs_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderDickertMAHS* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
-        ret = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+        ret = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
 
         // Allow for longer keys (<) instead of !=
-        if((instance->generic.data_count_bit <
+        if((subghz_block_generic.data_count_bit <
             subghz_protocol_dickert_mahs_const.min_count_bit_for_found)) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             ret = SubGhzProtocolStatusErrorValueBitCount;
@@ -248,7 +248,7 @@ void* subghz_protocol_decoder_dickert_mahs_alloc(SubGhzEnvironment* environment)
     UNUSED(environment);
     SubGhzProtocolDecoderDickertMAHS* instance = malloc(sizeof(SubGhzProtocolDecoderDickertMAHS));
     instance->base.protocol = &subghz_protocol_dickert_mahs;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->tmp_cnt = 0;
 
     return instance;
@@ -275,11 +275,11 @@ void subghz_protocol_decoder_dickert_mahs_feed(void* context, bool level, uint32
         // Check if done
         if(instance->decoder.decode_count_bit >=
            subghz_protocol_dickert_mahs_const.min_count_bit_for_found) {
-            instance->generic.serial = 0x0;
-            instance->generic.btn = 0x0;
+            subghz_block_generic.serial = 0x0;
+            subghz_block_generic.btn = 0x0;
 
-            instance->generic.data = instance->decoder.decode_data;
-            instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+            subghz_block_generic.data = instance->decoder.decode_data;
+            subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
             if(instance->base.callback)
                 instance->base.callback(&instance->base, instance->base.context);
@@ -355,22 +355,27 @@ SubGhzProtocolStatus subghz_protocol_decoder_dickert_mahs_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderDickertMAHS* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_dickert_mahs_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderDickertMAHS* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
-        ret = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+        ret = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
 
         // Allow for longer keys (<) instead of !=
-        if((instance->generic.data_count_bit <
+        if((subghz_block_generic.data_count_bit <
             subghz_protocol_dickert_mahs_const.min_count_bit_for_found)) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             ret = SubGhzProtocolStatusErrorValueBitCount;

--- a/lib/subghz/protocols/doitrand.c
+++ b/lib/subghz/protocols/doitrand.c
@@ -26,14 +26,12 @@ struct SubGhzProtocolDecoderDoitrand {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderDoitrand {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -80,7 +78,7 @@ void* subghz_protocol_encoder_doitrand_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderDoitrand* instance = malloc(sizeof(SubGhzProtocolEncoderDoitrand));
 
     instance->base.protocol = &subghz_protocol_doitrand;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 128;
@@ -104,7 +102,7 @@ void subghz_protocol_encoder_doitrand_free(void* context) {
 static bool subghz_protocol_encoder_doitrand_get_upload(SubGhzProtocolEncoderDoitrand* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -118,8 +116,8 @@ static bool subghz_protocol_encoder_doitrand_get_upload(SubGhzProtocolEncoderDoi
     instance->encoder.upload[index++] =
         level_duration_make(true, (uint32_t)subghz_protocol_doitrand_const.te_short * 2 - 100);
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(false, (uint32_t)subghz_protocol_doitrand_const.te_long);
@@ -140,10 +138,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_doitrand_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderDoitrand* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_doitrand_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -190,7 +189,7 @@ void* subghz_protocol_decoder_doitrand_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderDoitrand* instance = malloc(sizeof(SubGhzProtocolDecoderDoitrand));
     instance->base.protocol = &subghz_protocol_doitrand;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -236,8 +235,8 @@ void subghz_protocol_decoder_doitrand_feed(void* context, bool level, uint32_t d
                 instance->decoder.parser_step = DoitrandDecoderStepFoundStartBit;
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_doitrand_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -316,15 +315,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_doitrand_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderDoitrand* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_doitrand_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderDoitrand* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_doitrand_const.min_count_bit_for_found);
 }
@@ -332,17 +336,18 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_doitrand_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderDoitrand* instance = context;
-    subghz_protocol_doitrand_check_remote_controller(&instance->generic);
+    UNUSED(instance);
+    subghz_protocol_doitrand_check_remote_controller(&subghz_block_generic);
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
         "Key:%02lX%08lX\r\n"
         "Btn:%X\r\n"
         "DIP:" DIP_PATTERN "\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32) & 0xFFFFFFFF,
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        instance->generic.btn,
-        CNT_TO_DIP(instance->generic.cnt));
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32) & 0xFFFFFFFF,
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        subghz_block_generic.btn,
+        CNT_TO_DIP(subghz_block_generic.cnt));
 }

--- a/lib/subghz/protocols/dooya.c
+++ b/lib/subghz/protocols/dooya.c
@@ -20,14 +20,12 @@ struct SubGhzProtocolDecoderDooya {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderDooya {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -75,7 +73,7 @@ void* subghz_protocol_encoder_dooya_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderDooya* instance = malloc(sizeof(SubGhzProtocolEncoderDooya));
 
     instance->base.protocol = &subghz_protocol_dooya;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 128;
@@ -100,7 +98,7 @@ static bool subghz_protocol_encoder_dooya_get_upload(SubGhzProtocolEncoderDooya*
     furi_assert(instance);
 
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -109,7 +107,7 @@ static bool subghz_protocol_encoder_dooya_get_upload(SubGhzProtocolEncoderDooya*
     }
 
     //Send header
-    if(bit_read(instance->generic.data, 0)) {
+    if(bit_read(subghz_block_generic.data, 0)) {
         instance->encoder.upload[index++] = level_duration_make(
             false,
             (uint32_t)subghz_protocol_dooya_const.te_long * 12 +
@@ -128,8 +126,8 @@ static bool subghz_protocol_encoder_dooya_get_upload(SubGhzProtocolEncoderDooya*
         level_duration_make(false, (uint32_t)subghz_protocol_dooya_const.te_long * 2);
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_dooya_const.te_long);
@@ -150,10 +148,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_dooya_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderDooya* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_dooya_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -200,7 +199,7 @@ void* subghz_protocol_decoder_dooya_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderDooya* instance = malloc(sizeof(SubGhzProtocolDecoderDooya));
     instance->base.protocol = &subghz_protocol_dooya;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -274,8 +273,8 @@ void subghz_protocol_decoder_dooya_feed(void* context, bool level, uint32_t dura
                 instance->decoder.parser_step = DooyaDecoderStepFoundStartBit;
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_dooya_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -360,15 +359,22 @@ SubGhzProtocolStatus subghz_protocol_decoder_dooya_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderDooya* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_dooya_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderDooya* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_dooya_const.min_count_bit_for_found);
+        &subghz_block_generic,
+        flipper_format,
+        subghz_protocol_dooya_const.min_count_bit_for_found);
 }
 
 /**
@@ -415,8 +421,8 @@ static const char* subghz_protocol_dooya_get_name_button(uint8_t btn) {
 void subghz_protocol_decoder_dooya_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderDooya* instance = context;
-
-    subghz_protocol_dooya_check_remote_controller(&instance->generic);
+    UNUSED(instance);
+    subghz_protocol_dooya_check_remote_controller(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
@@ -424,14 +430,14 @@ void subghz_protocol_decoder_dooya_get_string(void* context, FuriString* output)
         "Key:0x%010llX\r\n"
         "Sn:0x%08lX\r\n"
         "Btn:%s\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        instance->generic.data,
-        instance->generic.serial,
-        subghz_protocol_dooya_get_name_button(instance->generic.btn));
-    if(instance->generic.cnt == DOYA_SINGLE_CHANNEL) {
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        subghz_block_generic.data,
+        subghz_block_generic.serial,
+        subghz_protocol_dooya_get_name_button(subghz_block_generic.btn));
+    if(subghz_block_generic.cnt == DOYA_SINGLE_CHANNEL) {
         furi_string_cat_printf(output, "Ch:Single\r\n");
     } else {
-        furi_string_cat_printf(output, "Ch:%lu\r\n", instance->generic.cnt);
+        furi_string_cat_printf(output, "Ch:%lu\r\n", subghz_block_generic.cnt);
     }
 }

--- a/lib/subghz/protocols/elplast.c
+++ b/lib/subghz/protocols/elplast.c
@@ -18,14 +18,12 @@ struct SubGhzProtocolDecoderElplast {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderElplast {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -69,9 +67,9 @@ const SubGhzProtocol subghz_protocol_elplast = {
 void* subghz_protocol_encoder_elplast_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolEncoderElplast* instance = malloc(sizeof(SubGhzProtocolEncoderElplast));
-
+    subghz_block_generic_reset(0);
     instance->base.protocol = &subghz_protocol_elplast;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -96,8 +94,8 @@ static void subghz_protocol_encoder_elplast_get_upload(SubGhzProtocolEncoderElpl
     size_t index = 0;
 
     // Send key and GAP
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             // Send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_elplast_const.te_long);
@@ -132,10 +130,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_elplast_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderElplast* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_elplast_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -179,7 +178,7 @@ void* subghz_protocol_decoder_elplast_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderElplast* instance = malloc(sizeof(SubGhzProtocolDecoderElplast));
     instance->base.protocol = &subghz_protocol_elplast;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -259,8 +258,8 @@ void subghz_protocol_decoder_elplast_feed(void* context, bool level, volatile ui
                 // If got 18 bits key reading is finished
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_elplast_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -290,23 +289,31 @@ SubGhzProtocolStatus subghz_protocol_decoder_elplast_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderElplast* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_elplast_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderElplast* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_elplast_const.min_count_bit_for_found);
+        &subghz_block_generic,
+        flipper_format,
+        subghz_protocol_elplast_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_elplast_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderElplast* instance = context;
+    UNUSED(instance);
 
     uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit);
 
     uint32_t code_found_reverse_lo = code_found_reverse & 0x000003ffffffffff;
 
@@ -315,8 +322,8 @@ void subghz_protocol_decoder_elplast_get_string(void* context, FuriString* outpu
         "%s %db\r\n"
         "Key: 0x%05lX\r\n"
         "Yek: 0x%05lX",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0xFFFFFF),
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFF),
         code_found_reverse_lo);
 }

--- a/lib/subghz/protocols/faac_slh.c
+++ b/lib/subghz/protocols/faac_slh.c
@@ -35,7 +35,6 @@ struct SubGhzProtocolDecoderFaacSLH {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 
     SubGhzKeystore* keystore;
     const char* manufacture_name;
@@ -45,7 +44,6 @@ struct SubGhzProtocolEncoderFaacSLH {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 
     SubGhzKeystore* keystore;
     const char* manufacture_name;
@@ -106,7 +104,7 @@ void* subghz_protocol_encoder_faac_slh_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderFaacSLH* instance = malloc(sizeof(SubGhzProtocolEncoderFaacSLH));
 
     instance->base.protocol = &subghz_protocol_faac_slh;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->keystore = subghz_environment_get_keystore(environment);
 
     instance->encoder.repeat = 10;
@@ -133,37 +131,46 @@ static bool subghz_protocol_faac_slh_gen_data(SubGhzProtocolEncoderFaacSLH* inst
 
     // If we are using UP button - generate programming mode key and send it, otherwise - send regular key if possible
     if((custom_btn_id == SUBGHZ_CUSTOM_BTN_UP) &&
-       !(!allow_zero_seed && (instance->generic.seed == 0x0))) {
+       !(!allow_zero_seed && (subghz_block_generic.seed == 0x0))) {
         uint8_t data_tmp = 0;
         uint8_t data_prg[8];
 
         data_prg[0] = 0x00;
         // faac slh protocol have 20-bit counter so we take only 20 bits from mult (by AND 0xFFFFF)
 
-        if(allow_zero_seed || (instance->generic.seed != 0x0)) {
+        if(allow_zero_seed || (subghz_block_generic.seed != 0x0)) {
             // check OFEX mode
             if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-                if((instance->generic.cnt +
-                    (furi_hal_subghz_get_rolling_counter_mult() & 0xFFFFF)) > 0xFFFFF) {
-                    instance->generic.cnt = 0;
-                } else {
-                    instance->generic.cnt +=
-                        (furi_hal_subghz_get_rolling_counter_mult() & 0xFFFFF);
+                // standart counter mode. PULL data from subghz_block_generic_global variables
+                if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+                    // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+                    // so we increase counter by standart mult value
+                    if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) >
+                       0xFFFFF) {
+                        subghz_block_generic.cnt = 0;
+                    } else {
+                        subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+                    }
                 }
             } else {
                 // to do OFEX mode
-                instance->generic.cnt += 1;
+                subghz_block_generic.cnt += 1;
             }
 
             if(temp_counter_backup != 0x0) {
                 // check OFEX mode
                 if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-                    if((temp_counter_backup +
-                        (furi_hal_subghz_get_rolling_counter_mult() & 0xFFFFF)) > 0xFFFFF) {
-                        temp_counter_backup = 0;
-                    } else {
-                        temp_counter_backup +=
-                            (furi_hal_subghz_get_rolling_counter_mult() & 0xFFFFF);
+                    // standart counter mode. PULL data from subghz_block_generic_global variables
+                    if(!subghz_block_generic_counter_is_overrided(&temp_counter_backup)) {
+                        // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+                        // so we increase counter by standart mult value
+                        if((temp_counter_backup +
+                            (furi_hal_subghz_get_rolling_counter_mult() & 0xFFFFF)) > 0xFFFFF) {
+                            temp_counter_backup = 0;
+                        } else {
+                            temp_counter_backup +=
+                                (furi_hal_subghz_get_rolling_counter_mult() & 0xFFFFF);
+                        }
                     }
                 } else {
                     // todo OFEX mode
@@ -172,12 +179,12 @@ static bool subghz_protocol_faac_slh_gen_data(SubGhzProtocolEncoderFaacSLH* inst
             }
         }
 
-        data_prg[1] = instance->generic.cnt & 0xFF;
+        data_prg[1] = subghz_block_generic.cnt & 0xFF;
 
-        data_prg[2] = (uint8_t)(instance->generic.seed & 0xFF);
-        data_prg[3] = (uint8_t)(instance->generic.seed >> 8 & 0xFF);
-        data_prg[4] = (uint8_t)(instance->generic.seed >> 16 & 0xFF);
-        data_prg[5] = (uint8_t)(instance->generic.seed >> 24);
+        data_prg[2] = (uint8_t)(subghz_block_generic.seed & 0xFF);
+        data_prg[3] = (uint8_t)(subghz_block_generic.seed >> 8 & 0xFF);
+        data_prg[4] = (uint8_t)(subghz_block_generic.seed >> 16 & 0xFF);
+        data_prg[5] = (uint8_t)(subghz_block_generic.seed >> 24);
 
         data_prg[2] ^= data_prg[1];
         data_prg[3] ^= data_prg[1];
@@ -199,31 +206,31 @@ static bool subghz_protocol_faac_slh_gen_data(SubGhzProtocolEncoderFaacSLH* inst
                              data_prg[4];
         uint32_t enc_prg_2 = data_prg[3] << 24 | data_prg[2] << 16 | data_prg[1] << 8 |
                              data_prg[0];
-        instance->generic.data = (uint64_t)enc_prg_1 << 32 | enc_prg_2;
-        //FURI_LOG_D(TAG, "New Prog Mode Key Generated: %016llX\r", instance->generic.data);
+        subghz_block_generic.data = (uint64_t)enc_prg_1 << 32 | enc_prg_2;
+        //FURI_LOG_D(TAG, "New Prog Mode Key Generated: %016llX\r", subghz_block_generic.data);
 
         return true;
     } else {
-        if(!allow_zero_seed && (instance->generic.seed == 0x0)) {
+        if(!allow_zero_seed && (subghz_block_generic.seed == 0x0)) {
             // Do not generate new data, send data from buffer
             return true;
         }
         // If we are in prog mode and regular Send button is used - Do not generate new data, send data from buffer
-        if((faac_prog_mode == true) && (instance->generic.serial == 0x0) &&
-           (instance->generic.btn == 0x0) && (temp_fix_backup == 0x0)) {
+        if((faac_prog_mode == true) && (subghz_block_generic.serial == 0x0) &&
+           (subghz_block_generic.btn == 0x0) && (temp_fix_backup == 0x0)) {
             return true;
         }
     }
     // Restore main remote data when we exit programming mode
-    if((instance->generic.serial == 0x0) && (instance->generic.btn == 0x0) &&
+    if((subghz_block_generic.serial == 0x0) && (subghz_block_generic.btn == 0x0) &&
        (temp_fix_backup != 0x0) && !faac_prog_mode) {
-        instance->generic.serial = temp_fix_backup >> 4;
-        instance->generic.btn = temp_fix_backup & 0xF;
+        subghz_block_generic.serial = temp_fix_backup >> 4;
+        subghz_block_generic.btn = temp_fix_backup & 0xF;
         if(temp_counter_backup != 0x0) {
-            instance->generic.cnt = temp_counter_backup;
+            subghz_block_generic.cnt = temp_counter_backup;
         }
     }
-    uint32_t fix = instance->generic.serial << 4 | instance->generic.btn;
+    uint32_t fix = subghz_block_generic.serial << 4 | subghz_block_generic.btn;
     uint32_t hop = 0;
     uint32_t decrypt = 0;
     uint64_t man = 0;
@@ -235,38 +242,43 @@ static bool subghz_protocol_faac_slh_gen_data(SubGhzProtocolEncoderFaacSLH* inst
     }
 
     // faac slh protocol have 20-bit counter so we take only 20 bits from mult (by AND 0xFFFFF)
-    if(allow_zero_seed || (instance->generic.seed != 0x0)) {
+    if(allow_zero_seed || (subghz_block_generic.seed != 0x0)) {
         // check OFEX mode
         if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-            if((instance->generic.cnt + (furi_hal_subghz_get_rolling_counter_mult() & 0xFFFFF)) >
-               0xFFFFF) {
-                instance->generic.cnt = 0;
-            } else {
-                instance->generic.cnt += (furi_hal_subghz_get_rolling_counter_mult() & 0xFFFFF);
+            // standart counter mode. PULL data from subghz_block_generic_global variables
+            if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+                // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+                // so we increase counter by standart mult value
+                if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) >
+                   0xFFFFF) {
+                    subghz_block_generic.cnt = 0;
+                } else {
+                    subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+                }
             }
 
         } else {
             // OFEX mode
-            if(instance->generic.cnt < 0xFFFFF) {
-                if((instance->generic.cnt + 0xFFFFF) > 0xFFFFF) {
-                    instance->generic.cnt = 0;
+            if(subghz_block_generic.cnt < 0xFFFFF) {
+                if((subghz_block_generic.cnt + 0xFFFFF) > 0xFFFFF) {
+                    subghz_block_generic.cnt = 0;
                 } else {
-                    instance->generic.cnt += 0xFFFFF;
+                    subghz_block_generic.cnt += 0xFFFFF;
                 }
             } else if(
-                (instance->generic.cnt >= 0xFFFFF) &&
+                (subghz_block_generic.cnt >= 0xFFFFF) &&
                 (furi_hal_subghz_get_rolling_counter_mult() != 0)) {
-                instance->generic.cnt = 0;
+                subghz_block_generic.cnt = 0;
             }
         }
     }
 
-    if((instance->generic.cnt % 2) == 0) {
+    if((subghz_block_generic.cnt % 2) == 0) {
         decrypt = fixx[6] << 28 | fixx[7] << 24 | fixx[5] << 20 |
-                  (instance->generic.cnt & 0xFFFFF);
+                  (subghz_block_generic.cnt & 0xFFFFF);
     } else {
         decrypt = fixx[2] << 28 | fixx[3] << 24 | fixx[4] << 20 |
-                  (instance->generic.cnt & 0xFFFFF);
+                  (subghz_block_generic.cnt & 0xFFFFF);
     }
     for
         M_EACH(manufacture_code, *subghz_keystore_get_data(instance->keystore), SubGhzKeyArray_t) {
@@ -276,7 +288,7 @@ static bool subghz_protocol_faac_slh_gen_data(SubGhzProtocolEncoderFaacSLH* inst
                 case KEELOQ_LEARNING_FAAC:
                     //FAAC Learning
                     man = subghz_protocol_keeloq_common_faac_learning(
-                        instance->generic.seed, manufacture_code->key);
+                        subghz_block_generic.seed, manufacture_code->key);
                     hop = subghz_protocol_keeloq_common_encrypt(decrypt, man);
                     break;
                 }
@@ -284,7 +296,7 @@ static bool subghz_protocol_faac_slh_gen_data(SubGhzProtocolEncoderFaacSLH* inst
             }
         }
     if(hop) {
-        instance->generic.data = (uint64_t)fix << 32 | hop;
+        subghz_block_generic.data = (uint64_t)fix << 32 | hop;
     }
     return true;
 }
@@ -301,17 +313,18 @@ bool subghz_protocol_faac_slh_create_data(
     furi_assert(context);
     // OwO
     SubGhzProtocolEncoderFaacSLH* instance = context;
-    instance->generic.serial = serial;
-    instance->generic.btn = btn;
-    instance->generic.cnt = (cnt & 0xFFFFF);
-    instance->generic.seed = seed;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.serial = serial;
+    subghz_block_generic.btn = btn;
+    subghz_block_generic.cnt = (cnt & 0xFFFFF);
+    subghz_block_generic.seed = seed;
     instance->manufacture_name = manufacture_name;
-    instance->generic.data_count_bit = 64;
+    subghz_block_generic.data_count_bit = 64;
     allow_zero_seed = true;
     bool res = subghz_protocol_faac_slh_gen_data(instance);
     if(res) {
         return SubGhzProtocolStatusOk ==
-               subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+               subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
     }
     return res;
 }
@@ -326,7 +339,7 @@ static bool subghz_protocol_encoder_faac_slh_get_upload(SubGhzProtocolEncoderFaa
 
     subghz_protocol_faac_slh_gen_data(instance);
     size_t index = 0;
-    size_t size_upload = 2 + (instance->generic.data_count_bit * 2);
+    size_t size_upload = 2 + (subghz_block_generic.data_count_bit * 2);
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -341,8 +354,8 @@ static bool subghz_protocol_encoder_faac_slh_get_upload(SubGhzProtocolEncoderFaa
         level_duration_make(false, (uint32_t)subghz_protocol_faac_slh_const.te_long * 2);
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_faac_slh_const.te_long);
@@ -363,16 +376,17 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_faac_slh_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderFaacSLH* instance = context;
+
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
         uint8_t seed_data[sizeof(uint32_t)] = {0};
         for(size_t i = 0; i < sizeof(uint32_t); i++) {
-            seed_data[sizeof(uint32_t) - i - 1] = (instance->generic.seed >> i * 8) & 0xFF;
+            seed_data[sizeof(uint32_t) - i - 1] = (subghz_block_generic.seed >> i * 8) & 0xFF;
         }
         if(!flipper_format_read_hex(flipper_format, "Seed", seed_data, sizeof(uint32_t))) {
             FURI_LOG_E(TAG, "Missing Seed");
@@ -385,11 +399,11 @@ SubGhzProtocolStatus
             allow_zero_seed = false;
         }
 
-        instance->generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
-                                 seed_data[3];
+        subghz_block_generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
+                                    seed_data[3];
 
         subghz_protocol_faac_slh_check_remote_controller(
-            &instance->generic, instance->keystore, &instance->manufacture_name);
+            &subghz_block_generic, instance->keystore, &instance->manufacture_name);
 
         //optional parameter parameter
         flipper_format_read_uint32(
@@ -403,7 +417,7 @@ SubGhzProtocolStatus
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -445,7 +459,7 @@ void* subghz_protocol_decoder_faac_slh_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderFaacSLH* instance = malloc(sizeof(SubGhzProtocolDecoderFaacSLH));
     instance->base.protocol = &subghz_protocol_faac_slh;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->keystore = subghz_environment_get_keystore(environment);
     return instance;
 }
@@ -491,8 +505,8 @@ void subghz_protocol_decoder_faac_slh_feed(void* context, bool level, uint32_t d
                 instance->decoder.parser_step = FaacSLHDecoderStepFoundPreambula;
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_faac_slh_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -636,26 +650,26 @@ SubGhzProtocolStatus subghz_protocol_decoder_faac_slh_serialize(
     SubGhzProtocolDecoderFaacSLH* instance = context;
 
     // Reset seed leftover from previous decoded signal
-    instance->generic.seed = 0x0;
+    subghz_block_generic.seed = 0x0;
     temp_fix_backup = 0x0;
 
     SubGhzProtocolStatus res =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 
     uint8_t seed_data[sizeof(uint32_t)] = {0};
     for(size_t i = 0; i < sizeof(uint32_t); i++) {
-        seed_data[sizeof(uint32_t) - i - 1] = (instance->generic.seed >> i * 8) & 0xFF;
+        seed_data[sizeof(uint32_t) - i - 1] = (subghz_block_generic.seed >> i * 8) & 0xFF;
     }
     if((res == SubGhzProtocolStatusOk) &&
        !flipper_format_write_hex(flipper_format, "Seed", seed_data, sizeof(uint32_t))) {
         FURI_LOG_E(TAG, "Unable to add Seed");
         res = SubGhzProtocolStatusError;
     }
-    instance->generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
-                             seed_data[3];
+    subghz_block_generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
+                                seed_data[3];
 
     subghz_protocol_faac_slh_check_remote_controller(
-        &instance->generic, instance->keystore, &instance->manufacture_name);
+        &subghz_block_generic, instance->keystore, &instance->manufacture_name);
 
     return res;
 }
@@ -664,14 +678,18 @@ SubGhzProtocolStatus
     subghz_protocol_decoder_faac_slh_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderFaacSLH* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-        if(instance->generic.data_count_bit !=
+        if(subghz_block_generic.data_count_bit !=
            subghz_protocol_faac_slh_const.min_count_bit_for_found) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             break;
@@ -679,7 +697,7 @@ SubGhzProtocolStatus
 
         uint8_t seed_data[sizeof(uint32_t)] = {0};
         for(size_t i = 0; i < sizeof(uint32_t); i++) {
-            seed_data[sizeof(uint32_t) - i - 1] = (instance->generic.seed >> i * 8) & 0xFF;
+            seed_data[sizeof(uint32_t) - i - 1] = (subghz_block_generic.seed >> i * 8) & 0xFF;
         }
         if(!flipper_format_read_hex(flipper_format, "Seed", seed_data, sizeof(uint32_t))) {
             FURI_LOG_E(TAG, "Missing Seed");
@@ -691,8 +709,8 @@ SubGhzProtocolStatus
         } else {
             allow_zero_seed = false;
         }
-        instance->generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
-                                 seed_data[3];
+        subghz_block_generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
+                                    seed_data[3];
 
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
@@ -708,9 +726,9 @@ void subghz_protocol_decoder_faac_slh_get_string(void* context, FuriString* outp
     furi_assert(context);
     SubGhzProtocolDecoderFaacSLH* instance = context;
     subghz_protocol_faac_slh_check_remote_controller(
-        &instance->generic, instance->keystore, &instance->manufacture_name);
-    uint32_t code_fix = instance->generic.data >> 32;
-    uint32_t code_hop = instance->generic.data & 0xFFFFFFFF;
+        &subghz_block_generic, instance->keystore, &instance->manufacture_name);
+    uint32_t code_fix = subghz_block_generic.data >> 32;
+    uint32_t code_hop = subghz_block_generic.data & 0xFFFFFFFF;
 
     if(faac_prog_mode == true) {
         furi_string_cat_printf(
@@ -720,15 +738,15 @@ void subghz_protocol_decoder_faac_slh_get_string(void* context, FuriString* outp
             "Ke:%lX%08lX\r\n"
             "Kd:%lX%08lX\r\n"
             "Seed:%08lX mCnt:%02X",
-            instance->generic.protocol_name,
-            instance->generic.data_count_bit,
-            (uint32_t)(instance->generic.data >> 32),
-            (uint32_t)instance->generic.data,
-            (uint32_t)(instance->generic.data_2 >> 32),
-            (uint32_t)instance->generic.data_2,
-            instance->generic.seed,
-            (uint8_t)(instance->generic.cnt & 0xFF));
-    } else if((allow_zero_seed == false) && (instance->generic.seed == 0x0)) {
+            subghz_block_generic.protocol_name,
+            subghz_block_generic.data_count_bit,
+            (uint32_t)(subghz_block_generic.data >> 32),
+            (uint32_t)subghz_block_generic.data,
+            (uint32_t)(subghz_block_generic.data_2 >> 32),
+            (uint32_t)subghz_block_generic.data_2,
+            subghz_block_generic.seed,
+            (uint8_t)(subghz_block_generic.cnt & 0xFF));
+    } else if((allow_zero_seed == false) && (subghz_block_generic.seed == 0x0)) {
         furi_string_cat_printf(
             output,
             "%s %dbit\r\n"
@@ -736,15 +754,19 @@ void subghz_protocol_decoder_faac_slh_get_string(void* context, FuriString* outp
             "Fix:%08lX\r\n"
             "Hop:%08lX    Btn:%X\r\n"
             "Sn:%07lX Sd:Unknown",
-            instance->generic.protocol_name,
-            instance->generic.data_count_bit,
-            (uint32_t)(instance->generic.data >> 32),
-            (uint32_t)instance->generic.data,
+            subghz_block_generic.protocol_name,
+            subghz_block_generic.data_count_bit,
+            (uint32_t)(subghz_block_generic.data >> 32),
+            (uint32_t)subghz_block_generic.data,
             code_fix,
             code_hop,
-            instance->generic.btn,
-            instance->generic.serial);
+            subghz_block_generic.btn,
+            subghz_block_generic.serial);
     } else {
+        // push protocol data to global variable
+        subghz_block_generic.cnt_is_available = true;
+        subghz_block_generic.cnt_lenght_bit = 20;
+        //
         furi_string_cat_printf(
             output,
             "%s %dbit\r\n"
@@ -752,15 +774,15 @@ void subghz_protocol_decoder_faac_slh_get_string(void* context, FuriString* outp
             "Fix:%08lX    Cnt:%05lX\r\n"
             "Hop:%08lX    Btn:%X\r\n"
             "Sn:%07lX Sd:%08lX",
-            instance->generic.protocol_name,
-            instance->generic.data_count_bit,
-            (uint32_t)(instance->generic.data >> 32),
-            (uint32_t)instance->generic.data,
+            subghz_block_generic.protocol_name,
+            subghz_block_generic.data_count_bit,
+            (uint32_t)(subghz_block_generic.data >> 32),
+            (uint32_t)subghz_block_generic.data,
             code_fix,
-            instance->generic.cnt,
+            subghz_block_generic.cnt,
             code_hop,
-            instance->generic.btn,
-            instance->generic.serial,
-            instance->generic.seed);
+            subghz_block_generic.btn,
+            subghz_block_generic.serial,
+            subghz_block_generic.seed);
     }
 }

--- a/lib/subghz/protocols/feron.c
+++ b/lib/subghz/protocols/feron.c
@@ -18,14 +18,14 @@ struct SubGhzProtocolDecoderFeron {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 struct SubGhzProtocolEncoderFeron {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -72,7 +72,7 @@ void* subghz_protocol_encoder_feron_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderFeron* instance = malloc(sizeof(SubGhzProtocolEncoderFeron));
 
     instance->base.protocol = &subghz_protocol_feron;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -97,8 +97,8 @@ static void subghz_protocol_encoder_feron_get_upload(SubGhzProtocolEncoderFeron*
     size_t index = 0;
 
     // Send key and GAP
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             // Send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_feron_const.te_long);
@@ -151,10 +151,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_feron_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderFeron* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_feron_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -164,7 +165,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_feron_check_remote_controller(&instance->generic);
+        subghz_protocol_feron_check_remote_controller(&subghz_block_generic);
         subghz_protocol_encoder_feron_get_upload(instance);
         instance->encoder.is_running = true;
     } while(false);
@@ -199,7 +200,7 @@ void* subghz_protocol_decoder_feron_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderFeron* instance = malloc(sizeof(SubGhzProtocolDecoderFeron));
     instance->base.protocol = &subghz_protocol_feron;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -289,8 +290,8 @@ void subghz_protocol_decoder_feron_feed(void* context, bool level, volatile uint
                 // If got 32 bits key reading is finished
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_feron_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -320,22 +321,27 @@ SubGhzProtocolStatus subghz_protocol_decoder_feron_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderFeron* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_feron_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderFeron* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_feron_const.min_count_bit_for_found);
+        &subghz_block_generic, flipper_format, subghz_protocol_feron_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_feron_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderFeron* instance = context;
-
-    subghz_protocol_feron_check_remote_controller(&instance->generic);
+    UNUSED(instance);
+    subghz_protocol_feron_check_remote_controller(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
@@ -343,9 +349,9 @@ void subghz_protocol_decoder_feron_get_string(void* context, FuriString* output)
         "Key: 0x%08lX\r\n"
         "Serial: 0x%04lX\r\n"
         "Command: 0x%04lX\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        instance->generic.serial,
-        (uint32_t)(instance->generic.data & 0xFFFF));
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        subghz_block_generic.serial,
+        (uint32_t)(subghz_block_generic.data & 0xFFFF));
 }

--- a/lib/subghz/protocols/gangqi.c
+++ b/lib/subghz/protocols/gangqi.c
@@ -20,14 +20,12 @@ struct SubGhzProtocolDecoderGangQi {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderGangQi {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -74,7 +72,7 @@ void* subghz_protocol_encoder_gangqi_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderGangQi* instance = malloc(sizeof(SubGhzProtocolEncoderGangQi));
 
     instance->base.protocol = &subghz_protocol_gangqi;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -167,22 +165,22 @@ static void subghz_protocol_encoder_gangqi_get_upload(SubGhzProtocolEncoderGangQ
     furi_assert(instance);
 
     // Generate new key using custom or default button
-    instance->generic.btn = subghz_protocol_gangqi_get_btn_code();
+    subghz_block_generic.btn = subghz_protocol_gangqi_get_btn_code();
 
-    uint16_t serial = (uint16_t)((instance->generic.data >> 18) & 0xFFFF);
-    uint8_t const_and_button = (uint8_t)(0xD0 | instance->generic.btn);
+    uint16_t serial = (uint16_t)((subghz_block_generic.data >> 18) & 0xFFFF);
+    uint8_t const_and_button = (uint8_t)(0xD0 | subghz_block_generic.btn);
     uint8_t serial_high = (uint8_t)(serial >> 8);
     uint8_t serial_low = (uint8_t)(serial & 0xFF);
     uint8_t bytesum = (uint8_t)(0xC8 - serial_high - serial_low - const_and_button);
 
-    instance->generic.data = (instance->generic.data >> 14) << 14 | (instance->generic.btn << 10) |
-                             (bytesum << 2);
+    subghz_block_generic.data = (subghz_block_generic.data >> 14) << 14 |
+                                (subghz_block_generic.btn << 10) | (bytesum << 2);
 
     size_t index = 0;
 
     // Send key and GAP between parcels
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             // Send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_gangqi_const.te_long);
@@ -244,10 +242,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_gangqi_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderGangQi* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_gangqi_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -257,7 +256,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_gangqi_remote_controller(&instance->generic);
+        subghz_protocol_gangqi_remote_controller(&subghz_block_generic);
         subghz_protocol_encoder_gangqi_get_upload(instance);
 
         if(!flipper_format_rewind(flipper_format)) {
@@ -266,7 +265,7 @@ SubGhzProtocolStatus
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> (i * 8)) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> (i * 8)) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -306,7 +305,7 @@ void* subghz_protocol_decoder_gangqi_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderGangQi* instance = malloc(sizeof(SubGhzProtocolDecoderGangQi));
     instance->base.protocol = &subghz_protocol_gangqi;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -378,8 +377,8 @@ void subghz_protocol_decoder_gangqi_feed(void* context, bool level, volatile uin
                 // If got 34 bits key reading is finished
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_gangqi_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -434,27 +433,34 @@ SubGhzProtocolStatus subghz_protocol_decoder_gangqi_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderGangQi* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_gangqi_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderGangQi* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_gangqi_const.min_count_bit_for_found);
+        &subghz_block_generic,
+        flipper_format,
+        subghz_protocol_gangqi_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_gangqi_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderGangQi* instance = context;
-
+    UNUSED(instance);
     // Parse serial
-    subghz_protocol_gangqi_remote_controller(&instance->generic);
+    subghz_protocol_gangqi_remote_controller(&subghz_block_generic);
 
     // Get byte sum
-    uint16_t serial = (uint16_t)((instance->generic.data >> 18) & 0xFFFF);
-    uint8_t const_and_button = (uint8_t)(0xD0 | instance->generic.btn);
+    uint16_t serial = (uint16_t)((subghz_block_generic.data >> 18) & 0xFFFF);
+    uint8_t const_and_button = (uint8_t)(0xD0 | subghz_block_generic.btn);
     uint8_t serial_high = (uint8_t)(serial >> 8);
     uint8_t serial_low = (uint8_t)(serial & 0xFF);
     // Type 1 is what original remotes use, type 2 is "backdoor" sum that receiver accepts too
@@ -468,13 +474,13 @@ void subghz_protocol_decoder_gangqi_get_string(void* context, FuriString* output
         "Serial: 0x%05lX\r\n"
         "Sum: 0x%02X   Sum2: 0x%02X\r\n"
         "Btn: 0x%01X - %s\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint8_t)(instance->generic.data >> 32),
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        instance->generic.serial,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint8_t)(subghz_block_generic.data >> 32),
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        subghz_block_generic.serial,
         sum_type1,
         sum_type2,
-        instance->generic.btn,
-        subghz_protocol_gangqi_get_button_name(instance->generic.btn));
+        subghz_block_generic.btn,
+        subghz_protocol_gangqi_get_button_name(subghz_block_generic.btn));
 }

--- a/lib/subghz/protocols/gate_tx.c
+++ b/lib/subghz/protocols/gate_tx.c
@@ -19,14 +19,14 @@ struct SubGhzProtocolDecoderGateTx {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 struct SubGhzProtocolEncoderGateTx {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -73,7 +73,7 @@ void* subghz_protocol_encoder_gate_tx_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderGateTx* instance = malloc(sizeof(SubGhzProtocolEncoderGateTx));
 
     instance->base.protocol = &subghz_protocol_gate_tx;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 52; //max 24bit*2 + 2 (start, stop)
@@ -97,7 +97,7 @@ void subghz_protocol_encoder_gate_tx_free(void* context) {
 static bool subghz_protocol_encoder_gate_tx_get_upload(SubGhzProtocolEncoderGateTx* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -111,8 +111,8 @@ static bool subghz_protocol_encoder_gate_tx_get_upload(SubGhzProtocolEncoderGate
     instance->encoder.upload[index++] =
         level_duration_make(true, (uint32_t)subghz_protocol_gate_tx_const.te_long);
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(false, (uint32_t)subghz_protocol_gate_tx_const.te_long);
@@ -133,10 +133,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_gate_tx_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderGateTx* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_gate_tx_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -183,7 +184,7 @@ void* subghz_protocol_decoder_gate_tx_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderGateTx* instance = malloc(sizeof(SubGhzProtocolDecoderGateTx));
     instance->base.protocol = &subghz_protocol_gate_tx;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -229,8 +230,8 @@ void subghz_protocol_decoder_gate_tx_feed(void* context, bool level, uint32_t du
                 instance->decoder.parser_step = GateTXDecoderStepFoundStartBit;
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_gate_tx_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -296,29 +297,35 @@ SubGhzProtocolStatus subghz_protocol_decoder_gate_tx_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderGateTx* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_gate_tx_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderGateTx* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_gate_tx_const.min_count_bit_for_found);
+        &subghz_block_generic, flipper_format, subghz_protocol_gate_tx_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_gate_tx_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderGateTx* instance = context;
-    subghz_protocol_gate_tx_check_remote_controller(&instance->generic);
+    UNUSED (instance);
+    subghz_protocol_gate_tx_check_remote_controller(&subghz_block_generic);
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
         "Key:%06lX\r\n"
         "Sn:%05lX  Btn:%X\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0xFFFFFF),
-        instance->generic.serial,
-        instance->generic.btn);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFF),
+        subghz_block_generic.serial,
+        subghz_block_generic.btn);
 }

--- a/lib/subghz/protocols/hay21.c
+++ b/lib/subghz/protocols/hay21.c
@@ -20,14 +20,12 @@ struct SubGhzProtocolDecoderHay21 {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderHay21 {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -73,7 +71,7 @@ void* subghz_protocol_encoder_hay21_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderHay21* instance = malloc(sizeof(SubGhzProtocolEncoderHay21));
 
     instance->base.protocol = &subghz_protocol_hay21;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -142,39 +140,44 @@ static void subghz_protocol_encoder_hay21_get_upload(SubGhzProtocolEncoderHay21*
     furi_assert(instance);
 
     // Generate new key using custom or default button
-    instance->generic.btn = subghz_protocol_hay21_get_btn_code();
+    subghz_block_generic.btn = subghz_protocol_hay21_get_btn_code();
 
     // Counter increment
     // Check for OFEX (overflow experimental) mode
     if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-        //not matter how big and long mult - we take only 4 bits ( AND 0xF) beacose hay21 counter have only 4 bits long (0..F)
-        if((instance->generic.cnt + (furi_hal_subghz_get_rolling_counter_mult() & 0xF)) > 0xF) {
-            instance->generic.cnt = 0;
-        } else {
-            instance->generic.cnt += (furi_hal_subghz_get_rolling_counter_mult() & 0xF);
+        // standart counter mode. PULL data from subghz_block_generic_global variables
+        if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+            // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+            // so we increase counter by standart mult value
+            if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xF) {
+                subghz_block_generic.cnt = 0;
+            } else {
+                subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+            }
         }
+
     } else {
         // OFEX mode
-        if((instance->generic.cnt + 0x1) > 0xF) {
-            instance->generic.cnt = 0;
-        } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xE) {
-            instance->generic.cnt = 0xE;
+        if((subghz_block_generic.cnt + 0x1) > 0xF) {
+            subghz_block_generic.cnt = 0;
+        } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xE) {
+            subghz_block_generic.cnt = 0xE;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     }
 
     // Reconstruction of the data
-    instance->generic.data =
-        ((uint64_t)instance->generic.btn << 13 | (uint64_t)instance->generic.serial << 5 |
-         instance->generic.cnt << 1) |
+    subghz_block_generic.data =
+        ((uint64_t)subghz_block_generic.btn << 13 | (uint64_t)subghz_block_generic.serial << 5 |
+         subghz_block_generic.cnt << 1) |
         0b1;
 
     size_t index = 0;
 
     // Send key and GAP between parcels
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             // Send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_hay21_const.te_long);
@@ -255,10 +258,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_hay21_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderHay21* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_hay21_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -268,7 +272,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_hay21_remote_controller(&instance->generic);
+        subghz_protocol_hay21_remote_controller(&subghz_block_generic);
         subghz_protocol_encoder_hay21_get_upload(instance);
 
         if(!flipper_format_rewind(flipper_format)) {
@@ -277,7 +281,7 @@ SubGhzProtocolStatus
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -317,7 +321,7 @@ void* subghz_protocol_decoder_hay21_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderHay21* instance = malloc(sizeof(SubGhzProtocolDecoderHay21));
     instance->base.protocol = &subghz_protocol_hay21;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -388,8 +392,8 @@ void subghz_protocol_decoder_hay21_feed(void* context, bool level, volatile uint
                 // If got 21 bits key reading is finished
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_hay21_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -442,23 +446,35 @@ SubGhzProtocolStatus subghz_protocol_decoder_hay21_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderHay21* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_hay21_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderHay21* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_hay21_const.min_count_bit_for_found);
+        &subghz_block_generic,
+        flipper_format,
+        subghz_protocol_hay21_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_hay21_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderHay21* instance = context;
-
+    UNUSED(instance);
     // Parse serial, button, counter
-    subghz_protocol_hay21_remote_controller(&instance->generic);
+    subghz_protocol_hay21_remote_controller(&subghz_block_generic);
+
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = true;
+    subghz_block_generic.cnt_lenght_bit = 4;
+    //
 
     furi_string_cat_printf(
         output,
@@ -467,11 +483,11 @@ void subghz_protocol_decoder_hay21_get_string(void* context, FuriString* output)
         "Serial:0x%02X\r\n"
         "Btn:0x%01X - %s\r\n"
         "Cnt:%01X\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        (uint8_t)(instance->generic.serial & 0xFF),
-        instance->generic.btn,
-        subghz_protocol_hay21_get_button_name(instance->generic.btn),
-        (uint8_t)(instance->generic.cnt & 0xF));
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        (uint8_t)(subghz_block_generic.serial & 0xFF),
+        subghz_block_generic.btn,
+        subghz_protocol_hay21_get_button_name(subghz_block_generic.btn),
+        (uint8_t)(subghz_block_generic.cnt & 0xF));
 }

--- a/lib/subghz/protocols/hollarm.c
+++ b/lib/subghz/protocols/hollarm.c
@@ -20,14 +20,12 @@ struct SubGhzProtocolDecoderHollarm {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderHollarm {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -74,7 +72,7 @@ void* subghz_protocol_encoder_hollarm_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderHollarm* instance = malloc(sizeof(SubGhzProtocolEncoderHollarm));
 
     instance->base.protocol = &subghz_protocol_hollarm;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -166,21 +164,21 @@ static void subghz_protocol_encoder_hollarm_get_upload(SubGhzProtocolEncoderHoll
     furi_assert(instance);
 
     // Generate new key using custom or default button
-    instance->generic.btn = subghz_protocol_hollarm_get_btn_code();
+    subghz_block_generic.btn = subghz_protocol_hollarm_get_btn_code();
 
-    uint64_t new_key = (instance->generic.data >> 12) << 12 | (instance->generic.btn << 8);
+    uint64_t new_key = (subghz_block_generic.data >> 12) << 12 | (subghz_block_generic.btn << 8);
 
     uint8_t bytesum = ((new_key >> 32) & 0xFF) + ((new_key >> 24) & 0xFF) +
                       ((new_key >> 16) & 0xFF) + ((new_key >> 8) & 0xFF);
 
-    instance->generic.data = (new_key | bytesum);
+    subghz_block_generic.data = (new_key | bytesum);
 
     size_t index = 0;
 
     // Send key and GAP between parcels
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
         // Read and prepare levels with 2 bit (was saved for better parsing) to the left offset to fit with the original remote transmission
-        if(bit_read((instance->generic.data << 2), i - 1)) {
+        if(bit_read((subghz_block_generic.data << 2), i - 1)) {
             // Send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_hollarm_const.te_short);
@@ -245,10 +243,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_hollarm_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderHollarm* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_hollarm_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -258,7 +257,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_hollarm_remote_controller(&instance->generic);
+        subghz_protocol_hollarm_remote_controller(&subghz_block_generic);
         subghz_protocol_encoder_hollarm_get_upload(instance);
 
         if(!flipper_format_rewind(flipper_format)) {
@@ -267,7 +266,7 @@ SubGhzProtocolStatus
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> (i * 8)) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> (i * 8)) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -307,7 +306,7 @@ void* subghz_protocol_decoder_hollarm_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderHollarm* instance = malloc(sizeof(SubGhzProtocolDecoderHollarm));
     instance->base.protocol = &subghz_protocol_hollarm;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -375,18 +374,18 @@ void subghz_protocol_decoder_hollarm_feed(void* context, bool level, volatile ui
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_hollarm_const.min_count_bit_for_found) {
                     // Saving with 2bit to the right offset for proper parsing
-                    instance->generic.data = (instance->decoder.decode_data >> 2);
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = (instance->decoder.decode_data >> 2);
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
-                    uint8_t bytesum = ((instance->generic.data >> 32) & 0xFF) +
-                                      ((instance->generic.data >> 24) & 0xFF) +
-                                      ((instance->generic.data >> 16) & 0xFF) +
-                                      ((instance->generic.data >> 8) & 0xFF);
+                    uint8_t bytesum = ((subghz_block_generic.data >> 32) & 0xFF) +
+                                      ((subghz_block_generic.data >> 24) & 0xFF) +
+                                      ((subghz_block_generic.data >> 16) & 0xFF) +
+                                      ((subghz_block_generic.data >> 8) & 0xFF);
 
-                    if(bytesum != (instance->generic.data & 0xFF)) {
+                    if(bytesum != (subghz_block_generic.data & 0xFF)) {
                         // Check if the key is valid by verifying the sum
-                        instance->generic.data = 0;
-                        instance->generic.data_count_bit = 0;
+                        subghz_block_generic.data = 0;
+                        subghz_block_generic.data_count_bit = 0;
                         instance->decoder.decode_data = 0;
                         instance->decoder.decode_count_bit = 0;
                         instance->decoder.parser_step = HollarmDecoderStepReset;
@@ -446,27 +445,35 @@ SubGhzProtocolStatus subghz_protocol_decoder_hollarm_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderHollarm* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_hollarm_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderHollarm* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_hollarm_const.min_count_bit_for_found);
+        &subghz_block_generic,
+        flipper_format,
+        subghz_protocol_hollarm_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_hollarm_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderHollarm* instance = context;
+    UNUSED(instance);
 
     // Parse serial
-    subghz_protocol_hollarm_remote_controller(&instance->generic);
+    subghz_protocol_hollarm_remote_controller(&subghz_block_generic);
     // Get byte sum
     uint8_t bytesum =
-        ((instance->generic.data >> 32) & 0xFF) + ((instance->generic.data >> 24) & 0xFF) +
-        ((instance->generic.data >> 16) & 0xFF) + ((instance->generic.data >> 8) & 0xFF);
+        ((subghz_block_generic.data >> 32) & 0xFF) + ((subghz_block_generic.data >> 24) & 0xFF) +
+        ((subghz_block_generic.data >> 16) & 0xFF) + ((subghz_block_generic.data >> 8) & 0xFF);
 
     furi_string_cat_printf(
         output,
@@ -474,12 +481,12 @@ void subghz_protocol_decoder_hollarm_get_string(void* context, FuriString* outpu
         "Key: 0x%02lX%08lX\r\n"
         "Serial: 0x%06lX  Sum: %02X\r\n"
         "Btn: 0x%01X - %s\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32),
-        (uint32_t)instance->generic.data,
-        instance->generic.serial,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32),
+        (uint32_t)subghz_block_generic.data,
+        subghz_block_generic.serial,
         bytesum,
-        instance->generic.btn,
-        subghz_protocol_hollarm_get_button_name(instance->generic.btn));
+        subghz_block_generic.btn,
+        subghz_protocol_hollarm_get_button_name(subghz_block_generic.btn));
 }

--- a/lib/subghz/protocols/holtek.c
+++ b/lib/subghz/protocols/holtek.c
@@ -29,14 +29,14 @@ struct SubGhzProtocolDecoderHoltek {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 struct SubGhzProtocolEncoderHoltek {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -84,7 +84,7 @@ void* subghz_protocol_encoder_holtek_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderHoltek* instance = malloc(sizeof(SubGhzProtocolEncoderHoltek));
 
     instance->base.protocol = &subghz_protocol_holtek;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 128;
@@ -109,7 +109,7 @@ static bool subghz_protocol_encoder_holtek_get_upload(SubGhzProtocolEncoderHolte
     furi_assert(instance);
 
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -124,8 +124,8 @@ static bool subghz_protocol_encoder_holtek_get_upload(SubGhzProtocolEncoderHolte
     instance->encoder.upload[index++] =
         level_duration_make(true, (uint32_t)subghz_protocol_holtek_const.te_short);
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(false, (uint32_t)subghz_protocol_holtek_const.te_long);
@@ -146,10 +146,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_holtek_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderHoltek* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_holtek_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -196,7 +197,7 @@ void* subghz_protocol_decoder_holtek_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderHoltek* instance = malloc(sizeof(SubGhzProtocolDecoderHoltek));
     instance->base.protocol = &subghz_protocol_holtek;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -243,8 +244,8 @@ void subghz_protocol_decoder_holtek_feed(void* context, bool level, uint32_t dur
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_holtek_const.min_count_bit_for_found) {
                     if((instance->decoder.decode_data & HOLTEK_HEADER_MASK) == HOLTEK_HEADER) {
-                        instance->generic.data = instance->decoder.decode_data;
-                        instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                        subghz_block_generic.data = instance->decoder.decode_data;
+                        subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                         if(instance->base.callback)
                             instance->base.callback(&instance->base, instance->base.context);
@@ -328,37 +329,44 @@ SubGhzProtocolStatus subghz_protocol_decoder_holtek_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderHoltek* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_holtek_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderHoltek* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_holtek_const.min_count_bit_for_found);
+        &subghz_block_generic, flipper_format, subghz_protocol_holtek_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_holtek_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderHoltek* instance = context;
-    subghz_protocol_holtek_check_remote_controller(&instance->generic);
+    UNUSED(instance);
+
+    subghz_protocol_holtek_check_remote_controller(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%05lX Btn:%X ",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)((instance->generic.data >> 32) & 0xFFFFFFFF),
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        instance->generic.serial,
-        instance->generic.btn >> 4);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)((subghz_block_generic.data >> 32) & 0xFFFFFFFF),
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        subghz_block_generic.serial,
+        subghz_block_generic.btn >> 4);
 
-    if((instance->generic.btn & 0xF) == 0xE) {
+    if((subghz_block_generic.btn & 0xF) == 0xE) {
         furi_string_cat_printf(output, "ON\r\n");
-    } else if((instance->generic.btn & 0xF) == 0xB) {
+    } else if((subghz_block_generic.btn & 0xF) == 0xB) {
         furi_string_cat_printf(output, "OFF\r\n");
     }
 }

--- a/lib/subghz/protocols/holtek_ht12x.c
+++ b/lib/subghz/protocols/holtek_ht12x.c
@@ -31,7 +31,7 @@ struct SubGhzProtocolDecoderHoltek_HT12X {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint32_t te;
     uint32_t last_data;
@@ -41,7 +41,7 @@ struct SubGhzProtocolEncoderHoltek_HT12X {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint32_t te;
 };
@@ -92,7 +92,7 @@ void* subghz_protocol_encoder_holtek_th12x_alloc(SubGhzEnvironment* environment)
         malloc(sizeof(SubGhzProtocolEncoderHoltek_HT12X));
 
     instance->base.protocol = &subghz_protocol_holtek_th12x;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 128;
@@ -118,7 +118,7 @@ static bool
     furi_assert(instance);
 
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -131,8 +131,8 @@ static bool
     //Send start bit
     instance->encoder.upload[index++] = level_duration_make(true, (uint32_t)instance->te);
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(false, (uint32_t)instance->te * 2);
@@ -151,10 +151,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_holtek_th12x_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderHoltek_HT12X* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_holtek_th12x_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -212,7 +213,7 @@ void* subghz_protocol_decoder_holtek_th12x_alloc(SubGhzEnvironment* environment)
     SubGhzProtocolDecoderHoltek_HT12X* instance =
         malloc(sizeof(SubGhzProtocolDecoderHoltek_HT12X));
     instance->base.protocol = &subghz_protocol_holtek_th12x;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -265,8 +266,8 @@ void subghz_protocol_decoder_holtek_th12x_feed(void* context, bool level, uint32
                        instance->last_data) {
                         instance->te /= (instance->decoder.decode_count_bit * 3 + 1);
 
-                        instance->generic.data = instance->decoder.decode_data;
-                        instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                        subghz_block_generic.data = instance->decoder.decode_data;
+                        subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                         if(instance->base.callback)
                             instance->base.callback(&instance->base, instance->base.context);
@@ -337,8 +338,9 @@ SubGhzProtocolStatus subghz_protocol_decoder_holtek_th12x_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderHoltek_HT12X* instance = context;
+
     SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
     if((ret == SubGhzProtocolStatusOk) &&
        !flipper_format_write_uint32(flipper_format, "TE", &instance->te, 1)) {
         FURI_LOG_E(TAG, "Unable to add TE");
@@ -351,10 +353,14 @@ SubGhzProtocolStatus
     subghz_protocol_decoder_holtek_th12x_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderHoltek_HT12X* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+    
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_holtek_th12x_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -387,21 +393,21 @@ static void subghz_protocol_holtek_th12x_event_serialize(uint8_t event, FuriStri
 void subghz_protocol_decoder_holtek_th12x_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderHoltek_HT12X* instance = context;
-    subghz_protocol_holtek_th12x_check_remote_controller(&instance->generic);
+    subghz_protocol_holtek_th12x_check_remote_controller(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
         "%s %db\r\n"
         "Key:0x%03lX\r\n"
         "Btn: ",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0xFFF));
-    subghz_protocol_holtek_th12x_event_serialize(instance->generic.btn, output);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0xFFF));
+    subghz_protocol_holtek_th12x_event_serialize(subghz_block_generic.btn, output);
     furi_string_cat_printf(
         output,
         "DIP:" DIP_PATTERN "\r\n"
         "Te:%luus\r\n",
-        CNT_TO_DIP(instance->generic.cnt),
+        CNT_TO_DIP(subghz_block_generic.cnt),
         instance->te);
 }

--- a/lib/subghz/protocols/honeywell.c
+++ b/lib/subghz/protocols/honeywell.c
@@ -40,14 +40,14 @@ static const SubGhzBlockConst subghz_protocol_honeywell_const = {
 
 struct SubGhzProtocolDecoderHoneywell {
     SubGhzProtocolDecoderBase base;
-    SubGhzBlockGeneric generic;
+    
     SubGhzBlockDecoder decoder;
     ManchesterState manchester_saved_state;
 };
 
 struct SubGhzProtocolEncoderHoneywell {
     SubGhzProtocolEncoderBase base;
-    SubGhzBlockGeneric generic;
+    
     SubGhzProtocolBlockEncoder encoder;
 };
 
@@ -87,7 +87,7 @@ void* subghz_protocol_decoder_honeywell_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderHoneywell* instance = malloc(sizeof(SubGhzProtocolDecoderHoneywell));
     instance->base.protocol = &subghz_protocol_honeywell;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -96,7 +96,7 @@ void* subghz_protocol_encoder_honeywell_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderHoneywell* instance = malloc(sizeof(SubGhzProtocolEncoderHoneywell));
 
     instance->base.protocol = &subghz_protocol_honeywell;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 4;
     instance->encoder.size_upload = 64 * 2 + 10;
@@ -178,11 +178,11 @@ static void
 
     for(uint8_t i = 63; i > 0; i--) {
         if(!manchester_encoder_advance(
-               &enc_state, bit_read(instance->generic.data, i - 1), &result)) {
+               &enc_state, bit_read(subghz_block_generic.data, i - 1), &result)) {
             instance->encoder.upload[index++] =
                 subghz_protocol_encoder_honeywell_add_duration_to_upload(result);
             manchester_encoder_advance(
-                &enc_state, bit_read(instance->generic.data, i - 1), &result);
+                &enc_state, bit_read(subghz_block_generic.data, i - 1), &result);
         }
         instance->encoder.upload[index++] =
             subghz_protocol_encoder_honeywell_add_duration_to_upload(result);
@@ -203,10 +203,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_honeywell_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderHoneywell* instance = context;
+
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
@@ -327,14 +328,14 @@ static void subghz_protocol_decoder_honeywell_addbit(void* context, bool data) {
         uint16_t crc = instance->decoder.decode_data & 0xFFFF;
         if(crc == crc_calc) {
             // Removing possible artifacts from higher bits and setting header to FF FE
-            instance->generic.data =
+            subghz_block_generic.data =
                 ((((((0xFF << 16) | ((instance->decoder.decode_data >> 40) & 0xFFFF)) << 16) |
                    ((instance->decoder.decode_data >> 24) & 0xFFFF))
                   << 16) |
                  ((instance->decoder.decode_data >> 8) & 0xFFFF))
                     << 8 |
                 (instance->decoder.decode_data & 0xFF);
-            instance->generic.data_count_bit = 64;
+            subghz_block_generic.data_count_bit = 64;
             if(instance->base.callback)
                 instance->base.callback(&instance->base, instance->base.context);
             instance->decoder.decode_data = 0;
@@ -364,7 +365,8 @@ SubGhzProtocolStatus subghz_protocol_decoder_honeywell_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderHoneywell* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
@@ -372,25 +374,28 @@ SubGhzProtocolStatus
     furi_assert(context);
     SubGhzProtocolDecoderHoneywell* instance = context;
 
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
-    res = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    res = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
     if(res != SubGhzProtocolStatusOk) {
         return res;
     }
 
-    if(instance->generic.data_count_bit != 64) {
-        if(instance->generic.data_count_bit < 62) {
+    if(subghz_block_generic.data_count_bit != 64) {
+        if(subghz_block_generic.data_count_bit < 62) {
             return SubGhzProtocolStatusErrorValueBitCount;
         }
         // Removing possible artifacts from higher bits and setting header to FF FE
-        instance->generic.data =
-            ((((((0xFF << 16) | ((instance->generic.data >> 40) & 0xFFFF)) << 16) |
-               ((instance->generic.data >> 24) & 0xFFFF))
+        subghz_block_generic.data =
+            ((((((0xFF << 16) | ((subghz_block_generic.data >> 40) & 0xFFFF)) << 16) |
+               ((subghz_block_generic.data >> 24) & 0xFFFF))
               << 16) |
-             ((instance->generic.data >> 8) & 0xFFFF))
+             ((subghz_block_generic.data >> 8) & 0xFFFF))
                 << 8 |
-            (instance->generic.data & 0xFF);
-        instance->generic.data_count_bit = 64;
+            (subghz_block_generic.data & 0xFF);
+        subghz_block_generic.data_count_bit = 64;
     }
 
     return res;
@@ -399,14 +404,15 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_honeywell_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderHoneywell* instance = context;
+    UNUSED (instance);
 
-    uint32_t code_found_hi = instance->generic.data >> 32;
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+    uint32_t code_found_hi = subghz_block_generic.data >> 32;
+    uint32_t code_found_lo = subghz_block_generic.data & 0x00000000ffffffff;
 
-    instance->generic.serial = (instance->generic.data >> 24) & 0xFFFFF;
-    uint8_t sensor_status = (instance->generic.data >> 16) & 0xFF;
+    subghz_block_generic.serial = (subghz_block_generic.data >> 24) & 0xFFFFF;
+    uint8_t sensor_status = (subghz_block_generic.data >> 16) & 0xFF;
 
-    uint8_t channel = (instance->generic.data >> 44) & 0xF;
+    uint8_t channel = (subghz_block_generic.data >> 44) & 0xF;
     uint8_t contact = (sensor_status & 0x80) >> 7;
     uint8_t tamper = (sensor_status & 0x40) >> 6;
     uint8_t reed = (sensor_status & 0x20) >> 5;
@@ -421,9 +427,9 @@ void subghz_protocol_decoder_honeywell_get_string(void* context, FuriString* out
         "LowBat:%d  HB: %d  Cont: %s\r\n"
         "Key:%08lX%08lX\r\n"
         "State: L1:%u  L2:%u  L3:%u  L4:%u",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        instance->generic.serial,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        subghz_block_generic.serial,
         channel,
         battery_low,
         heartbeat,

--- a/lib/subghz/protocols/honeywell_wdb.c
+++ b/lib/subghz/protocols/honeywell_wdb.c
@@ -25,7 +25,7 @@ struct SubGhzProtocolDecoderHoneywell_WDB {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
     const char* device_type;
     const char* alert;
     uint8_t secret_knock;
@@ -37,7 +37,7 @@ struct SubGhzProtocolEncoderHoneywell_WDB {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -86,7 +86,7 @@ void* subghz_protocol_encoder_honeywell_wdb_alloc(SubGhzEnvironment* environment
         malloc(sizeof(SubGhzProtocolEncoderHoneywell_WDB));
 
     instance->base.protocol = &subghz_protocol_honeywell_wdb;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 128;
@@ -111,7 +111,7 @@ static bool subghz_protocol_encoder_honeywell_wdb_get_upload(
     SubGhzProtocolEncoderHoneywell_WDB* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -122,8 +122,8 @@ static bool subghz_protocol_encoder_honeywell_wdb_get_upload(
     instance->encoder.upload[index++] =
         level_duration_make(false, (uint32_t)subghz_protocol_honeywell_wdb_const.te_short * 3);
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_honeywell_wdb_const.te_long);
@@ -147,10 +147,11 @@ SubGhzProtocolStatus subghz_protocol_encoder_honeywell_wdb_deserialize(
     FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderHoneywell_WDB* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_honeywell_wdb_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -198,7 +199,7 @@ void* subghz_protocol_decoder_honeywell_wdb_alloc(SubGhzEnvironment* environment
     SubGhzProtocolDecoderHoneywell_WDB* instance =
         malloc(sizeof(SubGhzProtocolDecoderHoneywell_WDB));
     instance->base.protocol = &subghz_protocol_honeywell_wdb;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -237,8 +238,8 @@ void subghz_protocol_decoder_honeywell_wdb_feed(void* context, bool level, uint3
                     subghz_protocol_blocks_get_parity(
                         instance->decoder.decode_data >> 1,
                         subghz_protocol_honeywell_wdb_const.min_count_bit_for_found - 1))) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -303,8 +304,8 @@ static void subghz_protocol_honeywell_wdb_check_remote_controller(
  * 
  */
 
-    instance->generic.serial = (instance->generic.data >> 28) & 0xFFFFF;
-    switch((instance->generic.data >> 20) & 0x3) {
+    subghz_block_generic.serial = (subghz_block_generic.data >> 28) & 0xFFFFF;
+    switch((subghz_block_generic.data >> 20) & 0x3) {
     case 0x02:
         instance->device_type = "Doorbell";
         break;
@@ -316,7 +317,7 @@ static void subghz_protocol_honeywell_wdb_check_remote_controller(
         break;
     }
 
-    switch((instance->generic.data >> 16) & 0x3) {
+    switch((subghz_block_generic.data >> 16) & 0x3) {
     case 0x00:
         instance->alert = "Normal";
         break;
@@ -332,9 +333,9 @@ static void subghz_protocol_honeywell_wdb_check_remote_controller(
         break;
     }
 
-    instance->secret_knock = (uint8_t)((instance->generic.data >> 4) & 0x1);
-    instance->relay = (uint8_t)((instance->generic.data >> 3) & 0x1);
-    instance->lowbat = (uint8_t)((instance->generic.data >> 1) & 0x1);
+    instance->secret_knock = (uint8_t)((subghz_block_generic.data >> 4) & 0x1);
+    instance->relay = (uint8_t)((subghz_block_generic.data >> 3) & 0x1);
+    instance->lowbat = (uint8_t)((subghz_block_generic.data >> 1) & 0x1);
 }
 
 uint8_t subghz_protocol_decoder_honeywell_wdb_get_hash_data(void* context) {
@@ -350,7 +351,8 @@ SubGhzProtocolStatus subghz_protocol_decoder_honeywell_wdb_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderHoneywell_WDB* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus subghz_protocol_decoder_honeywell_wdb_deserialize(
@@ -358,8 +360,12 @@ SubGhzProtocolStatus subghz_protocol_decoder_honeywell_wdb_deserialize(
     FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderHoneywell_WDB* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_honeywell_wdb_const.min_count_bit_for_found);
 }
@@ -376,11 +382,11 @@ void subghz_protocol_decoder_honeywell_wdb_get_string(void* context, FuriString*
         "Sn:0x%05lX\r\n"
         "DT:%s  Al:%s\r\n"
         "SK:%01X R:%01X LBat:%01X\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)((instance->generic.data >> 32) & 0xFFFFFFFF),
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        instance->generic.serial,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)((subghz_block_generic.data >> 32) & 0xFFFFFFFF),
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        subghz_block_generic.serial,
         instance->device_type,
         instance->alert,
         instance->secret_knock,

--- a/lib/subghz/protocols/hormann.c
+++ b/lib/subghz/protocols/hormann.c
@@ -21,14 +21,14 @@ struct SubGhzProtocolDecoderHormann {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 struct SubGhzProtocolEncoderHormann {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -78,7 +78,7 @@ void* subghz_protocol_encoder_hormann_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderHormann* instance = malloc(sizeof(SubGhzProtocolEncoderHormann));
 
     instance->base.protocol = &subghz_protocol_hormann;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 2048;
@@ -103,7 +103,7 @@ static bool subghz_protocol_encoder_hormann_get_upload(SubGhzProtocolEncoderHorm
     furi_assert(instance);
 
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2 + 2) * 20 + 1;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2 + 2) * 20 + 1;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -119,8 +119,8 @@ static bool subghz_protocol_encoder_hormann_get_upload(SubGhzProtocolEncoderHorm
         instance->encoder.upload[index++] =
             level_duration_make(false, (uint32_t)subghz_protocol_hormann_const.te_short);
         //Send key data
-        for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-            if(bit_read(instance->generic.data, i - 1)) {
+        for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+            if(bit_read(subghz_block_generic.data, i - 1)) {
                 //send bit 1
                 instance->encoder.upload[index++] =
                     level_duration_make(true, (uint32_t)subghz_protocol_hormann_const.te_long);
@@ -144,10 +144,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_hormann_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderHormann* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_hormann_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -196,7 +197,7 @@ void* subghz_protocol_decoder_hormann_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderHormann* instance = malloc(sizeof(SubGhzProtocolDecoderHormann));
     instance->base.protocol = &subghz_protocol_hormann;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -244,8 +245,8 @@ void subghz_protocol_decoder_hormann_feed(void* context, bool level, uint32_t du
                 instance->decoder.parser_step = HormannDecoderStepFoundStartBit;
                 if(instance->decoder.decode_count_bit >=
                    subghz_protocol_hormann_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -303,21 +304,27 @@ SubGhzProtocolStatus subghz_protocol_decoder_hormann_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderHormann* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_hormann_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderHormann* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_hormann_const.min_count_bit_for_found);
+        &subghz_block_generic, flipper_format, subghz_protocol_hormann_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_hormann_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderHormann* instance = context;
-    subghz_protocol_hormann_check_remote_controller(&instance->generic);
+    UNUSED (instance);
+    subghz_protocol_hormann_check_remote_controller(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
@@ -325,9 +332,9 @@ void subghz_protocol_decoder_hormann_get_string(void* context, FuriString* outpu
         "%dbit\r\n"
         "Key:0x%03lX%08lX\r\n"
         "Btn:0x%01X\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32),
-        (uint32_t)instance->generic.data,
-        instance->generic.btn);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32),
+        (uint32_t)subghz_block_generic.data,
+        subghz_block_generic.btn);
 }

--- a/lib/subghz/protocols/ido.c
+++ b/lib/subghz/protocols/ido.c
@@ -19,14 +19,14 @@ struct SubGhzProtocolDecoderIDo {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 struct SubGhzProtocolEncoderIDo {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -72,7 +72,7 @@ void* subghz_protocol_decoder_ido_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderIDo* instance = malloc(sizeof(SubGhzProtocolDecoderIDo));
     instance->base.protocol = &subghz_protocol_ido;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     return instance;
 }
@@ -118,8 +118,8 @@ void subghz_protocol_decoder_ido_feed(void* context, bool level, uint32_t durati
                 instance->decoder.parser_step = IDoDecoderStepFoundPreambula;
                 if(instance->decoder.decode_count_bit >=
                    subghz_protocol_ido_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -186,24 +186,30 @@ SubGhzProtocolStatus subghz_protocol_decoder_ido_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderIDo* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_ido_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderIDo* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_ido_const.min_count_bit_for_found);
+        &subghz_block_generic, flipper_format, subghz_protocol_ido_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_ido_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderIDo* instance = context;
+    UNUSED(instance);
 
-    subghz_protocol_ido_check_remote_controller(&instance->generic);
+    subghz_protocol_ido_check_remote_controller(&subghz_block_generic);
     uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit);
     uint32_t code_fix = code_found_reverse & 0xFFFFFF;
     uint32_t code_hop = (code_found_reverse >> 24) & 0xFFFFFF;
 
@@ -214,12 +220,12 @@ void subghz_protocol_decoder_ido_get_string(void* context, FuriString* output) {
         "Fix:%06lX \r\n"
         "Hop:%06lX \r\n"
         "Sn:%05lX Btn:%X\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32),
-        (uint32_t)instance->generic.data,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32),
+        (uint32_t)subghz_block_generic.data,
         code_fix,
         code_hop,
-        instance->generic.serial,
-        instance->generic.btn);
+        subghz_block_generic.serial,
+        subghz_block_generic.btn);
 }

--- a/lib/subghz/protocols/intertechno_v3.c
+++ b/lib/subghz/protocols/intertechno_v3.c
@@ -25,14 +25,14 @@ struct SubGhzProtocolDecoderIntertechno_V3 {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 struct SubGhzProtocolEncoderIntertechno_V3 {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -84,7 +84,7 @@ void* subghz_protocol_encoder_intertechno_v3_alloc(SubGhzEnvironment* environmen
         malloc(sizeof(SubGhzProtocolEncoderIntertechno_V3));
 
     instance->base.protocol = &subghz_protocol_intertechno_v3;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -121,8 +121,8 @@ static bool subghz_protocol_encoder_intertechno_v3_get_upload(
     instance->encoder.upload[index++] =
         level_duration_make(false, (uint32_t)subghz_protocol_intertechno_v3_const.te_short * 10);
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if((instance->generic.data_count_bit == INTERTECHNO_V3_DIMMING_COUNT_BIT) && (i == 9)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if((subghz_block_generic.data_count_bit == INTERTECHNO_V3_DIMMING_COUNT_BIT) && (i == 9)) {
             //send bit dimm
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_intertechno_v3_const.te_short);
@@ -132,7 +132,7 @@ static bool subghz_protocol_encoder_intertechno_v3_get_upload(
                 level_duration_make(true, (uint32_t)subghz_protocol_intertechno_v3_const.te_short);
             instance->encoder.upload[index++] = level_duration_make(
                 false, (uint32_t)subghz_protocol_intertechno_v3_const.te_short);
-        } else if(bit_read(instance->generic.data, i - 1)) {
+        } else if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_intertechno_v3_const.te_short);
@@ -163,15 +163,16 @@ SubGhzProtocolStatus subghz_protocol_encoder_intertechno_v3_deserialize(
     FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderIntertechno_V3* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
-        ret = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+        ret = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
-        if((instance->generic.data_count_bit !=
+        if((subghz_block_generic.data_count_bit !=
             subghz_protocol_intertechno_v3_const.min_count_bit_for_found) &&
-           (instance->generic.data_count_bit != INTERTECHNO_V3_DIMMING_COUNT_BIT)) {
+           (subghz_block_generic.data_count_bit != INTERTECHNO_V3_DIMMING_COUNT_BIT)) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             ret = SubGhzProtocolStatusErrorValueBitCount;
             break;
@@ -219,7 +220,7 @@ void* subghz_protocol_decoder_intertechno_v3_alloc(SubGhzEnvironment* environmen
     SubGhzProtocolDecoderIntertechno_V3* instance =
         malloc(sizeof(SubGhzProtocolDecoderIntertechno_V3));
     instance->base.protocol = &subghz_protocol_intertechno_v3;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -282,8 +283,8 @@ void subghz_protocol_decoder_intertechno_v3_feed(void* context, bool level, uint
                 if((instance->decoder.decode_count_bit ==
                     subghz_protocol_intertechno_v3_const.min_count_bit_for_found) ||
                    (instance->decoder.decode_count_bit == INTERTECHNO_V3_DIMMING_COUNT_BIT)) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -413,7 +414,8 @@ SubGhzProtocolStatus subghz_protocol_decoder_intertechno_v3_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderIntertechno_V3* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus subghz_protocol_decoder_intertechno_v3_deserialize(
@@ -421,15 +423,19 @@ SubGhzProtocolStatus subghz_protocol_decoder_intertechno_v3_deserialize(
     FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderIntertechno_V3* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
-        ret = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+        ret = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
-        if((instance->generic.data_count_bit !=
+        if((subghz_block_generic.data_count_bit !=
             subghz_protocol_intertechno_v3_const.min_count_bit_for_found) &&
-           (instance->generic.data_count_bit != INTERTECHNO_V3_DIMMING_COUNT_BIT)) {
+           (subghz_block_generic.data_count_bit != INTERTECHNO_V3_DIMMING_COUNT_BIT)) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             ret = SubGhzProtocolStatusErrorValueBitCount;
             break;
@@ -441,36 +447,37 @@ SubGhzProtocolStatus subghz_protocol_decoder_intertechno_v3_deserialize(
 void subghz_protocol_decoder_intertechno_v3_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderIntertechno_V3* instance = context;
+    UNUSED(instance);
 
-    subghz_protocol_intertechno_v3_check_remote_controller(&instance->generic);
+    subghz_protocol_intertechno_v3_check_remote_controller(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
         "%.11s %db\r\n"
         "Key:0x%08llX\r\n"
         "Sn:%07lX\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        instance->generic.data,
-        instance->generic.serial);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        subghz_block_generic.data,
+        subghz_block_generic.serial);
 
-    if(instance->generic.data_count_bit ==
+    if(subghz_block_generic.data_count_bit ==
        subghz_protocol_intertechno_v3_const.min_count_bit_for_found) {
-        if(instance->generic.cnt >> 5) {
+        if(subghz_block_generic.cnt >> 5) {
             furi_string_cat_printf(
-                output, "Ch: All Btn:%s\r\n", (instance->generic.btn ? "On" : "Off"));
+                output, "Ch: All Btn:%s\r\n", (subghz_block_generic.btn ? "On" : "Off"));
         } else {
             furi_string_cat_printf(
                 output,
                 "Ch:" CH_PATTERN " Btn:%s\r\n",
-                CNT_TO_CH(instance->generic.cnt),
-                (instance->generic.btn ? "On" : "Off"));
+                CNT_TO_CH(subghz_block_generic.cnt),
+                (subghz_block_generic.btn ? "On" : "Off"));
         }
-    } else if(instance->generic.data_count_bit == INTERTECHNO_V3_DIMMING_COUNT_BIT) {
+    } else if(subghz_block_generic.data_count_bit == INTERTECHNO_V3_DIMMING_COUNT_BIT) {
         furi_string_cat_printf(
             output,
             "Ch:" CH_PATTERN " Dimm:%d%%\r\n",
-            CNT_TO_CH(instance->generic.cnt),
-            (int)(6.67f * (float)instance->generic.btn));
+            CNT_TO_CH(subghz_block_generic.cnt),
+            (int)(6.67f * (float)subghz_block_generic.btn));
     }
 }

--- a/lib/subghz/protocols/keeloq.c
+++ b/lib/subghz/protocols/keeloq.c
@@ -26,7 +26,6 @@ struct SubGhzProtocolDecoderKeeloq {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 
     uint16_t header_count;
     SubGhzKeystore* keystore;
@@ -39,7 +38,6 @@ struct SubGhzProtocolEncoderKeeloq {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 
     SubGhzKeystore* keystore;
     const char* manufacture_name;
@@ -104,7 +102,7 @@ void* subghz_protocol_encoder_keeloq_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderKeeloq* instance = malloc(sizeof(SubGhzProtocolEncoderKeeloq));
 
     instance->base.protocol = &subghz_protocol_keeloq;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->keystore = subghz_environment_get_keystore(environment);
 
     instance->encoder.repeat = 100;
@@ -135,7 +133,7 @@ static bool subghz_protocol_keeloq_gen_data(
     SubGhzProtocolEncoderKeeloq* instance,
     uint8_t btn,
     bool counter_up) {
-    uint32_t fix = (uint32_t)btn << 28 | instance->generic.serial;
+    uint32_t fix = (uint32_t)btn << 28 | subghz_block_generic.serial;
     uint32_t hop = 0;
     uint64_t man = 0;
     uint64_t code_found_reverse;
@@ -173,7 +171,7 @@ static bool subghz_protocol_keeloq_gen_data(
 
     // If we using BFT programming mode we will trasmit its seed in hop part like original remote
     if(prog_mode == PROG_MODE_KEELOQ_BFT) {
-        hop = instance->generic.seed;
+        hop = subghz_block_generic.seed;
     } else if(prog_mode == PROG_MODE_KEELOQ_APRIMATIC) {
         // If we using Aprimatic programming mode we will trasmit some strange looking hop value, why? cuz manufacturer did it this way :)
         hop = 0x1A2B3C4D;
@@ -187,68 +185,76 @@ static bool subghz_protocol_keeloq_gen_data(
         if(keeloq_counter_mode == 0) {
             // Check for OFEX (overflow experimental) mode
             if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-                if((instance->generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
-                    instance->generic.cnt = 0;
-                } else {
-                    instance->generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+                // standart counter mode. PULL data from subghz_block_generic_global variables
+                if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+                    // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+                    // so we increase counter by standart mult value
+                    if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) >
+                       0xFFFF) {
+                        subghz_block_generic.cnt = 0;
+                    } else {
+                        subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+                    }
                 }
+
             } else {
-                if((instance->generic.cnt + 0x1) > 0xFFFF) {
-                    instance->generic.cnt = 0;
-                } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-                    instance->generic.cnt = 0xFFFE;
+                //OFFEX mode
+                if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+                    subghz_block_generic.cnt = 0;
+                } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+                    subghz_block_generic.cnt = 0xFFFE;
                 } else {
-                    instance->generic.cnt++;
+                    subghz_block_generic.cnt++;
                 }
             }
         } else if(keeloq_counter_mode == 1) {
             // Mode 1
             // 0000 / 0001 / FFFE / FFFF
-            if((instance->generic.cnt + 0x1) > 0xFFFF) {
-                instance->generic.cnt = 0;
-            } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-                instance->generic.cnt = 0xFFFE;
+            if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+                subghz_block_generic.cnt = 0;
+            } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+                subghz_block_generic.cnt = 0xFFFE;
             } else {
-                instance->generic.cnt++;
+                subghz_block_generic.cnt++;
             }
         } else if(keeloq_counter_mode == 2) {
             // Mode 2
             // + 0x3333 each time
-            if((instance->generic.cnt + 0x3333) > 0xFFFF) {
-                instance->generic.cnt = 0;
+            if((subghz_block_generic.cnt + 0x3333) > 0xFFFF) {
+                subghz_block_generic.cnt = 0;
             } else {
-                instance->generic.cnt += 0x3333;
+                subghz_block_generic.cnt += 0x3333;
             }
         } else if(keeloq_counter_mode == 3) {
             // Mode 3
             // 0x8006 / 0x8007 / 0x0006 / 0x0007
-            if(instance->generic.cnt != 0x8006 && instance->generic.cnt != 0x8007 &&
-               instance->generic.cnt != 0x0006) {
-                instance->generic.cnt = 0x8006;
-            } else if(instance->generic.cnt == 0x8007) {
-                instance->generic.cnt = 0x0006;
+            if(subghz_block_generic.cnt != 0x8006 && subghz_block_generic.cnt != 0x8007 &&
+               subghz_block_generic.cnt != 0x0006) {
+                subghz_block_generic.cnt = 0x8006;
+            } else if(subghz_block_generic.cnt == 0x8007) {
+                subghz_block_generic.cnt = 0x0006;
             } else {
-                instance->generic.cnt++;
+                subghz_block_generic.cnt++;
             }
 
         } else if(keeloq_counter_mode == 4) {
             // Mode 4
             // 0x807B / 0x807C / 0x007B / 0x007C
-            if(instance->generic.cnt != 0x807B && instance->generic.cnt != 0x807C &&
-               instance->generic.cnt != 0x007B) {
-                instance->generic.cnt = 0x807B;
-            } else if(instance->generic.cnt == 0x807C) {
-                instance->generic.cnt = 0x007B;
+            if(subghz_block_generic.cnt != 0x807B && subghz_block_generic.cnt != 0x807C &&
+               subghz_block_generic.cnt != 0x007B) {
+                subghz_block_generic.cnt = 0x807B;
+            } else if(subghz_block_generic.cnt == 0x807C) {
+                subghz_block_generic.cnt = 0x007B;
             } else {
-                instance->generic.cnt++;
+                subghz_block_generic.cnt++;
             }
         } else if(keeloq_counter_mode == 5) {
             // Mode 5
             // 0000 / FFFF
-            if((instance->generic.cnt + 0x1) > 0xFFFF) {
-                instance->generic.cnt = 0;
+            if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+                subghz_block_generic.cnt = 0;
             } else {
-                instance->generic.cnt = 0xFFFF;
+                subghz_block_generic.cnt = 0xFFFF;
             }
         } else {
             // Mode 6 - Freeze counter
@@ -259,27 +265,27 @@ static bool subghz_protocol_keeloq_gen_data(
         if(strcmp(instance->manufacture_name, "Unknown") == 0) {
             // Simple Replay of received code
             code_found_reverse = subghz_protocol_blocks_reverse_key(
-                instance->generic.data, instance->generic.data_count_bit);
+                subghz_block_generic.data, subghz_block_generic.data_count_bit);
             hop = code_found_reverse & 0x00000000ffffffff;
         } else if(strcmp(instance->manufacture_name, "AN-Motors") == 0) {
             // An-Motors encode
-            hop = (instance->generic.cnt & 0xFF) << 24 | (instance->generic.cnt & 0xFF) << 16 |
-                  (btn & 0xF) << 12 | 0x404;
+            hop = (subghz_block_generic.cnt & 0xFF) << 24 |
+                  (subghz_block_generic.cnt & 0xFF) << 16 | (btn & 0xF) << 12 | 0x404;
         } else if(strcmp(instance->manufacture_name, "HCS101") == 0) {
             // HCS101 Encode
-            hop = instance->generic.cnt << 16 | (btn & 0xF) << 12 | 0x000;
+            hop = subghz_block_generic.cnt << 16 | (btn & 0xF) << 12 | 0x000;
         } else {
             // Protocols that use encryption
             uint32_t decrypt = (uint32_t)btn << 28 |
-                               (instance->generic.serial & 0x3FF)
+                               (subghz_block_generic.serial & 0x3FF)
                                    << 16 | //ToDo in some protocols the discriminator is 0
-                               instance->generic.cnt;
+                               subghz_block_generic.cnt;
 
             if(strcmp(instance->manufacture_name, "Aprimatic") == 0) {
                 // Aprimatic uses 12bit serial number + 2bit APR1 "parity" bit in front of it replacing first 2 bits of serial
                 // Thats in theory! We need to check if this is true for all Aprimatic remotes but we got only 3 recordings to test
                 // For now lets assume that this is true for all Aprimatic remotes, if not we will need to add some more code here
-                uint32_t apri_serial = instance->generic.serial;
+                uint32_t apri_serial = subghz_block_generic.serial;
                 uint8_t apr1 = 0;
                 for(uint16_t i = 1; i != 0b10000000000; i <<= 1) {
                     if(apri_serial & i) apr1++;
@@ -288,7 +294,7 @@ static bool subghz_protocol_keeloq_gen_data(
                 if(apr1 % 2 == 0) {
                     apri_serial |= 0b110000000000;
                 }
-                decrypt = btn << 28 | (apri_serial & 0xFFF) << 16 | instance->generic.cnt;
+                decrypt = btn << 28 | (apri_serial & 0xFFF) << 16 | subghz_block_generic.cnt;
             } else if(
                 (strcmp(instance->manufacture_name, "DTM_Neo") == 0) ||
                 (strcmp(instance->manufacture_name, "FAAC_RC,XT") == 0) ||
@@ -304,33 +310,33 @@ static bool subghz_protocol_keeloq_gen_data(
                 // FAAC_RC,XT , Mutanco_Mutancode, Genius_Bravo, GSN 12bit serial -> normal learning
                 // Rosh, Rossi, Pecinin -> 12bit serial - simple learning
                 // Steelmate -> 12bit serial - normal learning
-                decrypt = btn << 28 | (instance->generic.serial & 0xFFF) << 16 |
-                          instance->generic.cnt;
+                decrypt = btn << 28 | (subghz_block_generic.serial & 0xFFF) << 16 |
+                          subghz_block_generic.cnt;
             } else if(
                 (strcmp(instance->manufacture_name, "NICE_Smilo") == 0) ||
                 (strcmp(instance->manufacture_name, "NICE_MHOUSE") == 0) ||
                 (strcmp(instance->manufacture_name, "JCM_Tech") == 0)) {
                 // Nice Smilo, MHouse, JCM -> 8bit serial - simple learning
-                decrypt = btn << 28 | (instance->generic.serial & 0xFF) << 16 |
-                          instance->generic.cnt;
+                decrypt = btn << 28 | (subghz_block_generic.serial & 0xFF) << 16 |
+                          subghz_block_generic.cnt;
             } else if(
                 (strcmp(instance->manufacture_name, "Beninca") == 0) ||
                 (strcmp(instance->manufacture_name, "Merlin") == 0)) {
-                decrypt = btn << 28 | (0x000) << 16 | instance->generic.cnt;
+                decrypt = btn << 28 | (0x000) << 16 | subghz_block_generic.cnt;
                 // Beninca / Allmatic -> no serial - simple XOR
                 // Merlin -> no serial - simple XOR
             } else if(strcmp(instance->manufacture_name, "Centurion") == 0) {
-                decrypt = btn << 28 | (0x1CE) << 16 | instance->generic.cnt;
+                decrypt = btn << 28 | (0x1CE) << 16 | subghz_block_generic.cnt;
                 // Centurion -> no serial in hop, uses fixed value 0x1CE - normal learning
             } else if(strcmp(instance->manufacture_name, "Monarch") == 0) {
-                decrypt = btn << 28 | (0x100) << 16 | instance->generic.cnt;
+                decrypt = btn << 28 | (0x100) << 16 | subghz_block_generic.cnt;
                 // Monarch -> no serial in hop, uses fixed value 0x100 - normal learning
             } else if(strcmp(instance->manufacture_name, "Dea_Mio") == 0) {
-                uint8_t first_disc_num = (instance->generic.serial >> 8) & 0xF;
+                uint8_t first_disc_num = (subghz_block_generic.serial >> 8) & 0xF;
                 uint8_t result_disc = (0xC + (first_disc_num % 4));
-                uint32_t dea_serial = (instance->generic.serial & 0xFF) |
+                uint32_t dea_serial = (subghz_block_generic.serial & 0xFF) |
                                       (((uint32_t)result_disc) << 8);
-                decrypt = btn << 28 | (dea_serial & 0xFFF) << 16 | instance->generic.cnt;
+                decrypt = btn << 28 | (dea_serial & 0xFFF) << 16 | subghz_block_generic.cnt;
                 // Dea_Mio -> modified serial in hop, uses last 3 digits modifying first one (example - 419 -> C19)
                 // (see formula in result_disc var) - simple learning
             }
@@ -359,13 +365,13 @@ static bool subghz_protocol_keeloq_gen_data(
                         case KEELOQ_LEARNING_SECURE:
                             //Secure Learning
                             man = subghz_protocol_keeloq_common_secure_learning(
-                                fix, instance->generic.seed, manufacture_code->key);
+                                fix, subghz_block_generic.seed, manufacture_code->key);
                             hop = subghz_protocol_keeloq_common_encrypt(decrypt, man);
                             break;
                         case KEELOQ_LEARNING_MAGIC_XOR_TYPE_1:
                             //Magic XOR type-1 Learning
                             man = subghz_protocol_keeloq_common_magic_xor_type1_learning(
-                                instance->generic.serial, manufacture_code->key);
+                                subghz_block_generic.serial, manufacture_code->key);
                             hop = subghz_protocol_keeloq_common_encrypt(decrypt, man);
                             break;
                         case KEELOQ_LEARNING_MAGIC_SERIAL_TYPE_1:
@@ -386,12 +392,12 @@ static bool subghz_protocol_keeloq_gen_data(
                             }
                             if(kl_type_en == 3) {
                                 man = subghz_protocol_keeloq_common_secure_learning(
-                                    fix, instance->generic.seed, manufacture_code->key);
+                                    fix, subghz_block_generic.seed, manufacture_code->key);
                                 hop = subghz_protocol_keeloq_common_encrypt(decrypt, man);
                             }
                             if(kl_type_en == 4) {
                                 man = subghz_protocol_keeloq_common_magic_xor_type1_learning(
-                                    instance->generic.serial, manufacture_code->key);
+                                    subghz_block_generic.serial, manufacture_code->key);
                                 hop = subghz_protocol_keeloq_common_encrypt(decrypt, man);
                             }
                             break;
@@ -404,8 +410,8 @@ static bool subghz_protocol_keeloq_gen_data(
     if(hop || (prog_mode == PROG_MODE_KEELOQ_DEA_MIO) || (prog_mode == PROG_MODE_KEELOQ_BFT)) {
         // If we have hop - we will save it to generic data var that will be used later in transmission
         uint64_t yek = (uint64_t)fix << 32 | hop;
-        instance->generic.data =
-            subghz_protocol_blocks_reverse_key(yek, instance->generic.data_count_bit);
+        subghz_block_generic.data =
+            subghz_protocol_blocks_reverse_key(yek, subghz_block_generic.data_count_bit);
     } // What should happen if seed = 0 in bft programming mode -> collapse of the universe I think :)
     return true; // Always return true
 }
@@ -420,13 +426,13 @@ bool subghz_protocol_keeloq_create_data(
     SubGhzRadioPreset* preset) {
     furi_check(context);
     SubGhzProtocolEncoderKeeloq* instance = context;
-    instance->generic.serial = serial;
-    instance->generic.cnt = cnt;
+    subghz_block_generic.serial = serial;
+    subghz_block_generic.cnt = cnt;
     instance->manufacture_name = manufacture_name;
-    instance->generic.data_count_bit = 64;
+    subghz_block_generic.data_count_bit = 64;
     if(subghz_protocol_keeloq_gen_data(instance, btn, false)) {
         return (
-            subghz_block_generic_serialize(&instance->generic, flipper_format, preset) ==
+            subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset) ==
             SubGhzProtocolStatusOk);
     }
     return false;
@@ -443,16 +449,16 @@ bool subghz_protocol_keeloq_bft_create_data(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolEncoderKeeloq* instance = context;
-    instance->generic.serial = serial;
-    instance->generic.btn = btn;
-    instance->generic.cnt = cnt;
-    instance->generic.seed = seed;
+    subghz_block_generic.serial = serial;
+    subghz_block_generic.btn = btn;
+    subghz_block_generic.cnt = cnt;
+    subghz_block_generic.seed = seed;
     instance->manufacture_name = manufacture_name;
-    instance->generic.data_count_bit = 64;
+    subghz_block_generic.data_count_bit = 64;
     // hehehehe
     if(subghz_protocol_keeloq_gen_data(instance, btn, false)) {
         return (
-            subghz_block_generic_serialize(&instance->generic, flipper_format, preset) ==
+            subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset) ==
             SubGhzProtocolStatusOk);
     }
     return false;
@@ -523,7 +529,7 @@ static bool
     }
 
     size_t index = 0;
-    size_t size_upload = 11 * 2 + 2 + (instance->generic.data_count_bit * 2) + 4;
+    size_t size_upload = 11 * 2 + 2 + (subghz_block_generic.data_count_bit * 2) + 4;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -544,8 +550,8 @@ static bool
         level_duration_make(false, (uint32_t)subghz_protocol_keeloq_const.te_short * 10);
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_keeloq_const.te_short);
@@ -577,16 +583,17 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_keeloq_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderKeeloq* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_keeloq_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
-        if(instance->generic.data_count_bit !=
+        if(subghz_block_generic.data_count_bit !=
            subghz_protocol_keeloq_const.min_count_bit_for_found) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             break;
@@ -594,13 +601,13 @@ SubGhzProtocolStatus
 
         uint8_t seed_data[sizeof(uint32_t)] = {0};
         for(size_t i = 0; i < sizeof(uint32_t); i++) {
-            seed_data[sizeof(uint32_t) - i - 1] = (instance->generic.seed >> i * 8) & 0xFF;
+            seed_data[sizeof(uint32_t) - i - 1] = (subghz_block_generic.seed >> i * 8) & 0xFF;
         }
         if(!flipper_format_read_hex(flipper_format, "Seed", seed_data, sizeof(uint32_t))) {
             FURI_LOG_D(TAG, "ENCODER: Missing Seed");
         }
-        instance->generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
-                                 seed_data[3];
+        subghz_block_generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
+                                    seed_data[3];
 
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
@@ -633,13 +640,13 @@ SubGhzProtocolStatus
         }
 
         subghz_protocol_keeloq_check_remote_controller(
-            &instance->generic, instance->keystore, &instance->manufacture_name);
+            &subghz_block_generic, instance->keystore, &instance->manufacture_name);
 
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        if(!subghz_protocol_encoder_keeloq_get_upload(instance, instance->generic.btn)) {
+        if(!subghz_protocol_encoder_keeloq_get_upload(instance, subghz_block_generic.btn)) {
             ret = SubGhzProtocolStatusErrorEncoderGetUpload;
             break;
         }
@@ -650,7 +657,7 @@ SubGhzProtocolStatus
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> (i * 8)) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> (i * 8)) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -691,7 +698,7 @@ LevelDuration subghz_protocol_encoder_keeloq_yield(void* context) {
 void* subghz_protocol_decoder_keeloq_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolDecoderKeeloq* instance = malloc(sizeof(SubGhzProtocolDecoderKeeloq));
     instance->base.protocol = &subghz_protocol_keeloq;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->keystore = subghz_environment_get_keystore(environment);
     instance->manufacture_from_file = furi_string_alloc();
 
@@ -763,9 +770,9 @@ void subghz_protocol_decoder_keeloq_feed(void* context, bool level, uint32_t dur
                     subghz_protocol_keeloq_const.min_count_bit_for_found) &&
                    (instance->decoder.decode_count_bit <=
                     subghz_protocol_keeloq_const.min_count_bit_for_found + 2)) {
-                    if(instance->generic.data != instance->decoder.decode_data) {
-                        instance->generic.data = instance->decoder.decode_data;
-                        instance->generic.data_count_bit =
+                    if(subghz_block_generic.data != instance->decoder.decode_data) {
+                        subghz_block_generic.data = instance->decoder.decode_data;
+                        subghz_block_generic.data_count_bit =
                             subghz_protocol_keeloq_const.min_count_bit_for_found;
                         if(instance->base.callback)
                             instance->base.callback(&instance->base, instance->base.context);
@@ -1198,23 +1205,23 @@ SubGhzProtocolStatus subghz_protocol_decoder_keeloq_serialize(
     SubGhzProtocolDecoderKeeloq* instance = context;
 
     SubGhzProtocolStatus res =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 
     subghz_protocol_keeloq_check_remote_controller(
-        &instance->generic, instance->keystore, &instance->manufacture_name);
+        &subghz_block_generic, instance->keystore, &instance->manufacture_name);
 
     if(strcmp(instance->manufacture_name, "BFT") == 0) {
         uint8_t seed_data[sizeof(uint32_t)] = {0};
         for(size_t i = 0; i < sizeof(uint32_t); i++) {
-            seed_data[sizeof(uint32_t) - i - 1] = (instance->generic.seed >> i * 8) & 0xFF;
+            seed_data[sizeof(uint32_t) - i - 1] = (subghz_block_generic.seed >> i * 8) & 0xFF;
         }
         if((res == SubGhzProtocolStatusOk) &&
            !flipper_format_write_hex(flipper_format, "Seed", seed_data, sizeof(uint32_t))) {
             FURI_LOG_E(TAG, "DECODER Serialize: Unable to add Seed");
             res = SubGhzProtocolStatusError;
         }
-        instance->generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
-                                 seed_data[3];
+        subghz_block_generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
+                                    seed_data[3];
     }
 
     if((res == SubGhzProtocolStatusOk) &&
@@ -1233,11 +1240,11 @@ SubGhzProtocolStatus
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
-        if(instance->generic.data_count_bit !=
+        if(subghz_block_generic.data_count_bit !=
            subghz_protocol_keeloq_const.min_count_bit_for_found) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             break;
@@ -1245,13 +1252,13 @@ SubGhzProtocolStatus
 
         uint8_t seed_data[sizeof(uint32_t)] = {0};
         for(size_t i = 0; i < sizeof(uint32_t); i++) {
-            seed_data[sizeof(uint32_t) - i - 1] = (instance->generic.seed >> i * 8) & 0xFF;
+            seed_data[sizeof(uint32_t) - i - 1] = (subghz_block_generic.seed >> i * 8) & 0xFF;
         }
         if(!flipper_format_read_hex(flipper_format, "Seed", seed_data, sizeof(uint32_t))) {
             FURI_LOG_D(TAG, "DECODER: Missing Seed");
         }
-        instance->generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
-                                 seed_data[3];
+        subghz_block_generic.seed = seed_data[0] << 24 | seed_data[1] << 16 | seed_data[2] << 8 |
+                                    seed_data[3];
 
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
@@ -1413,17 +1420,21 @@ void subghz_protocol_decoder_keeloq_get_string(void* context, FuriString* output
     SubGhzProtocolDecoderKeeloq* instance = context;
 
     subghz_protocol_keeloq_check_remote_controller(
-        &instance->generic, instance->keystore, &instance->manufacture_name);
+        &subghz_block_generic, instance->keystore, &instance->manufacture_name);
 
-    uint32_t code_found_hi = instance->generic.data >> 32;
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+    uint32_t code_found_hi = subghz_block_generic.data >> 32;
+    uint32_t code_found_lo = subghz_block_generic.data & 0x00000000ffffffff;
 
     uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit);
     uint32_t code_found_reverse_hi = code_found_reverse >> 32;
     uint32_t code_found_reverse_lo = code_found_reverse & 0x00000000ffffffff;
 
     if(strcmp(instance->manufacture_name, "BFT") == 0) {
+        // push protocol data to global variable
+        subghz_block_generic.cnt_is_available = true;
+        subghz_block_generic.cnt_lenght_bit = 16;
+        //
         furi_string_cat_printf(
             output,
             "%s %dbit\r\n"
@@ -1431,18 +1442,22 @@ void subghz_protocol_decoder_keeloq_get_string(void* context, FuriString* output
             "Fix:0x%08lX    Cnt:%04lX\r\n"
             "Hop:0x%08lX    Btn:%01X\r\n"
             "MF:%s Sd:%08lX",
-            instance->generic.protocol_name,
-            instance->generic.data_count_bit,
+            subghz_block_generic.protocol_name,
+            subghz_block_generic.data_count_bit,
             code_found_hi,
             code_found_lo,
             code_found_reverse_hi,
-            instance->generic.cnt,
+            subghz_block_generic.cnt,
             code_found_reverse_lo,
-            instance->generic.btn,
+            subghz_block_generic.btn,
             instance->manufacture_name,
-            instance->generic.seed);
+            subghz_block_generic.seed);
     } else if(strcmp(instance->manufacture_name, "Unknown") == 0) {
-        instance->generic.cnt = 0x0;
+        // push protocol data to global variable
+        subghz_block_generic.cnt_is_available = false;
+        subghz_block_generic.cnt_lenght_bit = 0;
+        //
+        subghz_block_generic.cnt = 0x0;
         furi_string_cat_printf(
             output,
             "%s %dbit\r\n"
@@ -1450,15 +1465,19 @@ void subghz_protocol_decoder_keeloq_get_string(void* context, FuriString* output
             "Fix:0x%08lX    Cnt:????\r\n"
             "Hop:0x%08lX    Btn:%01X\r\n"
             "MF:%s",
-            instance->generic.protocol_name,
-            instance->generic.data_count_bit,
+            subghz_block_generic.protocol_name,
+            subghz_block_generic.data_count_bit,
             code_found_hi,
             code_found_lo,
             code_found_reverse_hi,
             code_found_reverse_lo,
-            instance->generic.btn,
+            subghz_block_generic.btn,
             instance->manufacture_name);
     } else {
+        // push protocol data to global variable
+        subghz_block_generic.cnt_is_available = true;
+        subghz_block_generic.cnt_lenght_bit = 16;
+        //
         furi_string_cat_printf(
             output,
             "%s %dbit\r\n"
@@ -1466,14 +1485,14 @@ void subghz_protocol_decoder_keeloq_get_string(void* context, FuriString* output
             "Fix:0x%08lX    Cnt:%04lX\r\n"
             "Hop:0x%08lX    Btn:%01X\r\n"
             "MF:%s",
-            instance->generic.protocol_name,
-            instance->generic.data_count_bit,
+            subghz_block_generic.protocol_name,
+            subghz_block_generic.data_count_bit,
             code_found_hi,
             code_found_lo,
             code_found_reverse_hi,
-            instance->generic.cnt,
+            subghz_block_generic.cnt,
             code_found_reverse_lo,
-            instance->generic.btn,
+            subghz_block_generic.btn,
             instance->manufacture_name);
     }
 }

--- a/lib/subghz/protocols/kia.c
+++ b/lib/subghz/protocols/kia.c
@@ -19,7 +19,7 @@ struct SubGhzProtocolDecoderKIA {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint16_t header_count;
 };
@@ -28,7 +28,7 @@ struct SubGhzProtocolEncoderKIA {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -74,7 +74,7 @@ void* subghz_protocol_decoder_kia_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderKIA* instance = malloc(sizeof(SubGhzProtocolDecoderKIA));
     instance->base.protocol = &subghz_protocol_kia;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     return instance;
 }
@@ -148,8 +148,8 @@ void subghz_protocol_decoder_kia_feed(void* context, bool level, uint32_t durati
                 instance->decoder.parser_step = KIADecoderStepReset;
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_kia_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -237,37 +237,46 @@ SubGhzProtocolStatus subghz_protocol_decoder_kia_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderKIA* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_kia_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderKIA* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_kia_const.min_count_bit_for_found);
+        &subghz_block_generic, flipper_format, subghz_protocol_kia_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_kia_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderKIA* instance = context;
+    UNUSED(instance);
 
-    subghz_protocol_kia_check_remote_controller(&instance->generic);
-    uint32_t code_found_hi = instance->generic.data >> 32;
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+    subghz_protocol_kia_check_remote_controller(&subghz_block_generic);
+    uint32_t code_found_hi = subghz_block_generic.data >> 32;
+    uint32_t code_found_lo = subghz_block_generic.data & 0x00000000ffffffff;
 
-    // use 'Cntr:' instead of 'Cnt:' to exclude this protocol counter from Counter edit
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = false;
+    subghz_block_generic.cnt_lenght_bit = 16;
+    //
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
         "Key:%08lX%08lX\r\n"
         "Sn:%07lX Btn:%X\r\n"
-        "Cntr:%04lX\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        "Cnt:%04lX\r\n",
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         code_found_hi,
         code_found_lo,
-        instance->generic.serial,
-        instance->generic.btn,
-        instance->generic.cnt);
+        subghz_block_generic.serial,
+        subghz_block_generic.btn,
+        subghz_block_generic.cnt);
 }

--- a/lib/subghz/protocols/kinggates_stylo_4k.c
+++ b/lib/subghz/protocols/kinggates_stylo_4k.c
@@ -21,7 +21,6 @@ struct SubGhzProtocolDecoderKingGates_stylo_4k {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 
     uint16_t header_count;
     SubGhzKeystore* keystore;
@@ -31,7 +30,7 @@ struct SubGhzProtocolEncoderKingGates_stylo_4k {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+
     SubGhzKeystore* keystore;
 };
 
@@ -89,7 +88,7 @@ void* subghz_protocol_encoder_kinggates_stylo_4k_alloc(SubGhzEnvironment* enviro
         malloc(sizeof(SubGhzProtocolEncoderKingGates_stylo_4k));
 
     instance->base.protocol = &subghz_protocol_kinggates_stylo_4k;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->keystore = subghz_environment_get_keystore(environment);
 
     instance->encoder.repeat = 10;
@@ -139,8 +138,8 @@ static bool subghz_protocol_kinggates_stylo_4k_gen_data(
     SubGhzProtocolEncoderKingGates_stylo_4k* instance,
     uint8_t btn) {
     UNUSED(btn);
-    uint32_t hop = subghz_protocol_blocks_reverse_key(instance->generic.data_2 >> 4, 32);
-    uint64_t fix = subghz_protocol_blocks_reverse_key(instance->generic.data, 53);
+    uint32_t hop = subghz_protocol_blocks_reverse_key(subghz_block_generic.data_2 >> 4, 32);
+    uint64_t fix = subghz_protocol_blocks_reverse_key(subghz_block_generic.data, 53);
     int res = 0;
     uint32_t decrypt = 0;
 
@@ -153,29 +152,36 @@ static bool subghz_protocol_kinggates_stylo_4k_gen_data(
                 break;
             }
         }
-    instance->generic.cnt = decrypt & 0xFFFF;
+    subghz_block_generic.cnt = decrypt & 0xFFFF;
 
     // Check for OFEX (overflow experimental) mode
     if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-        if((instance->generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else {
-            instance->generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+        // standart counter mode. PULL data from subghz_block_generic_global variables
+        if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+            // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+            // so we increase counter by standart mult value
+            if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
+                subghz_block_generic.cnt = 0;
+            } else {
+                subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+            }
         }
+
     } else {
-        if((instance->generic.cnt + 0x1) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-            instance->generic.cnt = 0xFFFE;
+        //OFFEX mode
+        if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+            subghz_block_generic.cnt = 0;
+        } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+            subghz_block_generic.cnt = 0xFFFE;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     }
 
-    instance->generic.btn = (fix >> 17) & 0x0F;
-    instance->generic.serial = ((fix >> 5) & 0xFFFF0000) | (fix & 0xFFFF);
+    subghz_block_generic.btn = (fix >> 17) & 0x0F;
+    subghz_block_generic.serial = ((fix >> 5) & 0xFFFF0000) | (fix & 0xFFFF);
 
-    uint32_t data = (decrypt & 0xFFFF0000) | instance->generic.cnt;
+    uint32_t data = (decrypt & 0xFFFF0000) | subghz_block_generic.cnt;
 
     uint64_t encrypt = 0;
     for
@@ -185,7 +191,7 @@ static bool subghz_protocol_kinggates_stylo_4k_gen_data(
                 //Simple Learning
                 encrypt = subghz_protocol_keeloq_common_encrypt(data, manufacture_code->key);
                 encrypt = subghz_protocol_blocks_reverse_key(encrypt, 32);
-                instance->generic.data_2 = encrypt << 4;
+                subghz_block_generic.data_2 = encrypt << 4;
                 return true;
             }
         }
@@ -229,7 +235,7 @@ static bool subghz_protocol_encoder_kinggates_stylo_4k_get_upload(
 
     // Send key fix
     for(uint8_t i = 53; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] = level_duration_make(
                 false, (uint32_t)subghz_protocol_kinggates_stylo_4k_const.te_short);
@@ -246,7 +252,7 @@ static bool subghz_protocol_encoder_kinggates_stylo_4k_get_upload(
 
     // Send key hop
     for(uint8_t i = 36; i > 0; i--) {
-        if(bit_read(instance->generic.data_2, i - 1)) {
+        if(bit_read(subghz_block_generic.data_2, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] = level_duration_make(
                 false, (uint32_t)subghz_protocol_kinggates_stylo_4k_const.te_short);
@@ -276,13 +282,13 @@ SubGhzProtocolStatus subghz_protocol_encoder_kinggates_stylo_4k_deserialize(
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
 
         subghz_protocol_kinggates_stylo_4k_remote_controller(
-            &instance->generic, instance->keystore);
+            &subghz_block_generic, instance->keystore);
 
         //optional parameter parameter
         flipper_format_read_uint32(
@@ -300,10 +306,10 @@ SubGhzProtocolStatus subghz_protocol_encoder_kinggates_stylo_4k_deserialize(
         }
 
         for(uint8_t i = 0; i < sizeof(uint64_t); i++) {
-            instance->generic.data_2 = instance->generic.data_2 << 8 | key_data[i];
+            subghz_block_generic.data_2 = subghz_block_generic.data_2 << 8 | key_data[i];
         }
 
-        subghz_protocol_encoder_kinggates_stylo_4k_get_upload(instance, instance->generic.btn);
+        subghz_protocol_encoder_kinggates_stylo_4k_get_upload(instance, subghz_block_generic.btn);
 
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
@@ -311,7 +317,7 @@ SubGhzProtocolStatus subghz_protocol_encoder_kinggates_stylo_4k_deserialize(
         }
 
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data_2 >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data_2 >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Data", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to update Data");
@@ -333,7 +339,7 @@ void* subghz_protocol_decoder_kinggates_stylo_4k_alloc(SubGhzEnvironment* enviro
     SubGhzProtocolDecoderKingGates_stylo_4k* instance =
         malloc(sizeof(SubGhzProtocolDecoderKingGates_stylo_4k));
     instance->base.protocol = &subghz_protocol_kinggates_stylo_4k;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->keystore = subghz_environment_get_keystore(environment);
     return instance;
 }
@@ -385,7 +391,7 @@ void subghz_protocol_decoder_kinggates_stylo_4k_feed(void* context, bool level, 
                subghz_protocol_kinggates_stylo_4k_const.te_delta * 2) {
             instance->decoder.parser_step = KingGates_stylo_4kDecoderStepSaveDuration;
             instance->decoder.decode_data = 0;
-            instance->generic.data_2 = 0;
+            subghz_block_generic.data_2 = 0;
             instance->decoder.decode_count_bit = 0;
             instance->header_count = 0;
         }
@@ -395,9 +401,9 @@ void subghz_protocol_decoder_kinggates_stylo_4k_feed(void* context, bool level, 
             if(duration >= ((uint32_t)subghz_protocol_kinggates_stylo_4k_const.te_long * 3)) {
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_kinggates_stylo_4k_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->generic.data_2;
-                    instance->generic.data_2 = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = subghz_block_generic.data_2;
+                    subghz_block_generic.data_2 = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -405,7 +411,7 @@ void subghz_protocol_decoder_kinggates_stylo_4k_feed(void* context, bool level, 
 
                 instance->decoder.parser_step = KingGates_stylo_4kDecoderStepReset;
                 instance->decoder.decode_data = 0;
-                instance->generic.data_2 = 0;
+                subghz_block_generic.data_2 = 0;
                 instance->decoder.decode_count_bit = 0;
                 instance->header_count = 0;
                 break;
@@ -440,7 +446,7 @@ void subghz_protocol_decoder_kinggates_stylo_4k_feed(void* context, bool level, 
                 instance->header_count = 0;
             }
             if(instance->decoder.decode_count_bit == 53) {
-                instance->generic.data_2 = instance->decoder.decode_data;
+                subghz_block_generic.data_2 = instance->decoder.decode_data;
                 instance->decoder.decode_data = 0;
             }
         } else {
@@ -521,12 +527,14 @@ SubGhzProtocolStatus subghz_protocol_decoder_kinggates_stylo_4k_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderKingGates_stylo_4k* instance = context;
+    UNUSED(instance);
+
     SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 
     uint8_t key_data[sizeof(uint64_t)] = {0};
     for(size_t i = 0; i < sizeof(uint64_t); i++) {
-        key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data_2 >> (i * 8)) & 0xFF;
+        key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data_2 >> (i * 8)) & 0xFF;
     }
 
     if(!flipper_format_rewind(flipper_format)) {
@@ -547,10 +555,14 @@ SubGhzProtocolStatus subghz_protocol_decoder_kinggates_stylo_4k_deserialize(
     FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderKingGates_stylo_4k* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_kinggates_stylo_4k_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -569,7 +581,7 @@ SubGhzProtocolStatus subghz_protocol_decoder_kinggates_stylo_4k_deserialize(
         }
 
         for(uint8_t i = 0; i < sizeof(uint64_t); i++) {
-            instance->generic.data_2 = instance->generic.data_2 << 8 | key_data[i];
+            subghz_block_generic.data_2 = subghz_block_generic.data_2 << 8 | key_data[i];
         }
     } while(false);
     return ret;
@@ -578,7 +590,13 @@ SubGhzProtocolStatus subghz_protocol_decoder_kinggates_stylo_4k_deserialize(
 void subghz_protocol_decoder_kinggates_stylo_4k_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderKingGates_stylo_4k* instance = context;
-    subghz_protocol_kinggates_stylo_4k_remote_controller(&instance->generic, instance->keystore);
+    subghz_protocol_kinggates_stylo_4k_remote_controller(
+        &subghz_block_generic, instance->keystore);
+
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = true;
+    subghz_block_generic.cnt_lenght_bit = 16;
+    //
 
     furi_string_cat_printf(
         output,
@@ -586,11 +604,11 @@ void subghz_protocol_decoder_kinggates_stylo_4k_get_string(void* context, FuriSt
         "Key:0x%llX%07llX  %dbit\r\n"
         "Sn:0x%08lX  Btn:0x%01X\r\n"
         "Cnt:%04lX\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data,
-        instance->generic.data_2,
-        instance->generic.data_count_bit,
-        instance->generic.serial,
-        instance->generic.btn,
-        instance->generic.cnt);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data,
+        subghz_block_generic.data_2,
+        subghz_block_generic.data_count_bit,
+        subghz_block_generic.serial,
+        subghz_block_generic.btn,
+        subghz_block_generic.cnt);
 }

--- a/lib/subghz/protocols/legrand.c
+++ b/lib/subghz/protocols/legrand.c
@@ -19,7 +19,7 @@ struct SubGhzProtocolDecoderLegrand {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint32_t te;
     uint32_t last_data;
@@ -29,7 +29,7 @@ struct SubGhzProtocolEncoderLegrand {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint32_t te;
 };
@@ -79,7 +79,7 @@ void* subghz_protocol_encoder_legrand_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderLegrand* instance = malloc(sizeof(SubGhzProtocolEncoderLegrand));
 
     instance->base.protocol = &subghz_protocol_legrand;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = subghz_protocol_legrand_const.min_count_bit_for_found * 2 + 1;
@@ -103,7 +103,7 @@ void subghz_protocol_encoder_legrand_free(void* context) {
 static bool subghz_protocol_encoder_legrand_get_upload(SubGhzProtocolEncoderLegrand* instance) {
     furi_assert(instance);
 
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 1;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 1;
     if(size_upload != instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Invalid data bit count");
         return false;
@@ -115,8 +115,8 @@ static bool subghz_protocol_encoder_legrand_get_upload(SubGhzProtocolEncoderLegr
     instance->encoder.upload[index++] = level_duration_make(false, (uint32_t)instance->te * 16);
 
     // Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             // send bit 1
             instance->encoder.upload[index++] = level_duration_make(false, (uint32_t)instance->te);
             instance->encoder.upload[index++] =
@@ -136,10 +136,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_legrand_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderLegrand* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_legrand_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -196,7 +197,7 @@ void* subghz_protocol_decoder_legrand_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderLegrand* instance = malloc(sizeof(SubGhzProtocolDecoderLegrand));
     instance->base.protocol = &subghz_protocol_legrand;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -294,8 +295,8 @@ void subghz_protocol_decoder_legrand_feed(void* context, bool level, uint32_t du
                 if(instance->last_data && (instance->last_data == instance->decoder.decode_data)) {
                     instance->te /= instance->decoder.decode_count_bit * 4;
 
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback) {
                         instance->base.callback(&instance->base, instance->base.context);
@@ -326,7 +327,7 @@ SubGhzProtocolStatus subghz_protocol_decoder_legrand_serialize(
     furi_assert(context);
     SubGhzProtocolDecoderLegrand* instance = context;
     SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
     if((ret == SubGhzProtocolStatusOk) &&
        !flipper_format_write_uint32(flipper_format, "TE", &instance->te, 1)) {
         FURI_LOG_E(TAG, "Unable to add TE");
@@ -339,10 +340,14 @@ SubGhzProtocolStatus
     subghz_protocol_decoder_legrand_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderLegrand* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_legrand_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -372,8 +377,8 @@ void subghz_protocol_decoder_legrand_get_string(void* context, FuriString* outpu
         "%s %dbit\r\n"
         "Key:0x%05lX\r\n"
         "Te:%luus\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0xFFFFFF),
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFF),
         instance->te);
 }

--- a/lib/subghz/protocols/linear.c
+++ b/lib/subghz/protocols/linear.c
@@ -26,14 +26,14 @@ struct SubGhzProtocolDecoderLinear {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 struct SubGhzProtocolEncoderLinear {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -79,7 +79,7 @@ void* subghz_protocol_encoder_linear_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderLinear* instance = malloc(sizeof(SubGhzProtocolEncoderLinear));
 
     instance->base.protocol = &subghz_protocol_linear;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 28; //max 10bit*2 + 2 (start, stop)
@@ -103,7 +103,7 @@ void subghz_protocol_encoder_linear_free(void* context) {
 static bool subghz_protocol_encoder_linear_get_upload(SubGhzProtocolEncoderLinear* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2);
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2);
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -112,8 +112,8 @@ static bool subghz_protocol_encoder_linear_get_upload(SubGhzProtocolEncoderLinea
     }
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 1; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 1; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_linear_const.te_long);
@@ -128,7 +128,7 @@ static bool subghz_protocol_encoder_linear_get_upload(SubGhzProtocolEncoderLinea
         }
     }
     //Send end bit
-    if(bit_read(instance->generic.data, 0)) {
+    if(bit_read(subghz_block_generic.data, 0)) {
         //send bit 1
         instance->encoder.upload[index++] =
             level_duration_make(true, (uint32_t)subghz_protocol_linear_const.te_long);
@@ -151,10 +151,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_linear_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderLinear* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_linear_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -201,7 +202,7 @@ void* subghz_protocol_decoder_linear_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderLinear* instance = malloc(sizeof(SubGhzProtocolDecoderLinear));
     instance->base.protocol = &subghz_protocol_linear;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -257,11 +258,11 @@ void subghz_protocol_decoder_linear_feed(void* context, bool level, uint32_t dur
                 }
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_linear_const.min_count_bit_for_found) {
-                    instance->generic.serial = 0x0;
-                    instance->generic.btn = 0x0;
+                    subghz_block_generic.serial = 0x0;
+                    subghz_block_generic.btn = 0x0;
 
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -306,28 +307,34 @@ SubGhzProtocolStatus subghz_protocol_decoder_linear_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderLinear* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_linear_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderLinear* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_linear_const.min_count_bit_for_found);
+        &subghz_block_generic, flipper_format, subghz_protocol_linear_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_linear_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderLinear* instance = context;
+    UNUSED(instance);
 
     // Protocol is actually implemented wrong way around, bits are inverted.
     // Instead of fixing it and breaking old saved remotes,
     // only the display here is inverted (~) to show correct values.
-    uint32_t code_found_lo = ~instance->generic.data & 0x00000000000003ff;
+    uint32_t code_found_lo = ~subghz_block_generic.data & 0x00000000000003ff;
 
     uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
-        ~instance->generic.data, instance->generic.data_count_bit);
+        ~subghz_block_generic.data, subghz_block_generic.data_count_bit);
 
     uint32_t code_found_reverse_lo = code_found_reverse & 0x00000000000003ff;
 
@@ -337,8 +344,8 @@ void subghz_protocol_decoder_linear_get_string(void* context, FuriString* output
         "Key:0x%03lX\r\n"
         "Yek:0x%03lX\r\n"
         "DIP:" DIP_PATTERN "\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         code_found_lo,
         code_found_reverse_lo,
         DATA_TO_DIP(code_found_lo));

--- a/lib/subghz/protocols/linear_delta3.c
+++ b/lib/subghz/protocols/linear_delta3.c
@@ -25,7 +25,7 @@ struct SubGhzProtocolDecoderLinearDelta3 {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint32_t last_data;
 };
@@ -34,7 +34,7 @@ struct SubGhzProtocolEncoderLinearDelta3 {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -81,7 +81,7 @@ void* subghz_protocol_encoder_linear_delta3_alloc(SubGhzEnvironment* environment
         malloc(sizeof(SubGhzProtocolEncoderLinearDelta3));
 
     instance->base.protocol = &subghz_protocol_linear_delta3;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 16;
@@ -106,7 +106,7 @@ static bool
     subghz_protocol_encoder_linear_delta3_get_upload(SubGhzProtocolEncoderLinearDelta3* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2);
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2);
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -115,8 +115,8 @@ static bool
     }
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 1; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 1; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_linear_delta3_const.te_short);
@@ -131,7 +131,7 @@ static bool
         }
     }
     //Send end bit
-    if(bit_read(instance->generic.data, 0)) {
+    if(bit_read(subghz_block_generic.data, 0)) {
         //send bit 1
         instance->encoder.upload[index++] =
             level_duration_make(true, (uint32_t)subghz_protocol_linear_delta3_const.te_short);
@@ -155,10 +155,11 @@ SubGhzProtocolStatus subghz_protocol_encoder_linear_delta3_deserialize(
     FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderLinearDelta3* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_linear_delta3_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -206,7 +207,7 @@ void* subghz_protocol_decoder_linear_delta3_alloc(SubGhzEnvironment* environment
     SubGhzProtocolDecoderLinearDelta3* instance =
         malloc(sizeof(SubGhzProtocolDecoderLinearDelta3));
     instance->base.protocol = &subghz_protocol_linear_delta3;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -263,11 +264,11 @@ void subghz_protocol_decoder_linear_delta3_feed(void* context, bool level, uint3
                    subghz_protocol_linear_delta3_const.min_count_bit_for_found) {
                     if((instance->last_data == instance->decoder.decode_data) &&
                        instance->last_data) {
-                        instance->generic.serial = 0x0;
-                        instance->generic.btn = 0x0;
+                        subghz_block_generic.serial = 0x0;
+                        subghz_block_generic.btn = 0x0;
 
-                        instance->generic.data = instance->decoder.decode_data;
-                        instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                        subghz_block_generic.data = instance->decoder.decode_data;
+                        subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                         if(instance->base.callback)
                             instance->base.callback(&instance->base, instance->base.context);
@@ -317,7 +318,8 @@ SubGhzProtocolStatus subghz_protocol_decoder_linear_delta3_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderLinearDelta3* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus subghz_protocol_decoder_linear_delta3_deserialize(
@@ -325,8 +327,12 @@ SubGhzProtocolStatus subghz_protocol_decoder_linear_delta3_deserialize(
     FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderLinearDelta3* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_linear_delta3_const.min_count_bit_for_found);
 }
@@ -334,16 +340,16 @@ SubGhzProtocolStatus subghz_protocol_decoder_linear_delta3_deserialize(
 void subghz_protocol_decoder_linear_delta3_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderLinearDelta3* instance = context;
-
-    uint32_t data = instance->generic.data & 0xFF;
+    UNUSED(instance);
+    uint32_t data = subghz_block_generic.data & 0xFF;
 
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
         "Key:0x%lX\r\n"
         "DIP:" DIP_PATTERN "\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         data,
         DATA_TO_DIP(data));
 }

--- a/lib/subghz/protocols/magellan.c
+++ b/lib/subghz/protocols/magellan.c
@@ -19,7 +19,7 @@ struct SubGhzProtocolDecoderMagellan {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
     uint16_t header_count;
 };
 
@@ -27,7 +27,7 @@ struct SubGhzProtocolEncoderMagellan {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -76,7 +76,7 @@ void* subghz_protocol_encoder_magellan_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderMagellan* instance = malloc(sizeof(SubGhzProtocolEncoderMagellan));
 
     instance->base.protocol = &subghz_protocol_magellan;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -125,8 +125,8 @@ static bool subghz_protocol_encoder_magellan_get_upload(SubGhzProtocolEncoderMag
         level_duration_make(false, (uint32_t)subghz_protocol_magellan_const.te_long);
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_magellan_const.te_short);
@@ -155,10 +155,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_magellan_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderMagellan* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_magellan_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -207,7 +208,7 @@ void* subghz_protocol_decoder_magellan_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderMagellan* instance = malloc(sizeof(SubGhzProtocolDecoderMagellan));
     instance->base.protocol = &subghz_protocol_magellan;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -331,8 +332,8 @@ void subghz_protocol_decoder_magellan_feed(void* context, bool level, uint32_t d
                 if((instance->decoder.decode_count_bit ==
                     subghz_protocol_magellan_const.min_count_bit_for_found) &&
                    subghz_protocol_magellan_check_crc(instance)) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -482,15 +483,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_magellan_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderMagellan* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_magellan_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderMagellan* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_magellan_const.min_count_bit_for_found);
 }
@@ -498,19 +504,20 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_magellan_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderMagellan* instance = context;
-    subghz_protocol_magellan_check_remote_controller(&instance->generic);
+    UNUSED(instance);
+    subghz_protocol_magellan_check_remote_controller(&subghz_block_generic);
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
         "Key:0x%08lX\r\n"
         "Sn:%03ld%03ld, Event:0x%02X\r\n"
         "Stat:",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        (instance->generic.serial >> 8) & 0xFF,
-        instance->generic.serial & 0xFF,
-        instance->generic.btn);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        (subghz_block_generic.serial >> 8) & 0xFF,
+        subghz_block_generic.serial & 0xFF,
+        subghz_block_generic.btn);
 
-    subghz_protocol_magellan_get_event_serialize(instance->generic.btn, output);
+    subghz_protocol_magellan_get_event_serialize(subghz_block_generic.btn, output);
 }

--- a/lib/subghz/protocols/marantec.c
+++ b/lib/subghz/protocols/marantec.c
@@ -20,7 +20,7 @@ struct SubGhzProtocolDecoderMarantec {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
     ManchesterState manchester_saved_state;
     uint16_t header_count;
 };
@@ -29,7 +29,7 @@ struct SubGhzProtocolEncoderMarantec {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -75,7 +75,7 @@ void* subghz_protocol_encoder_marantec_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderMarantec* instance = malloc(sizeof(SubGhzProtocolEncoderMarantec));
 
     instance->base.protocol = &subghz_protocol_marantec;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -133,25 +133,25 @@ static void subghz_protocol_encoder_marantec_get_upload(SubGhzProtocolEncoderMar
 
     if(!manchester_encoder_advance(
            &enc_state,
-           bit_read(instance->generic.data, instance->generic.data_count_bit - 1),
+           bit_read(subghz_block_generic.data, subghz_block_generic.data_count_bit - 1),
            &result)) {
         instance->encoder.upload[index++] =
             subghz_protocol_encoder_marantec_add_duration_to_upload(result);
         manchester_encoder_advance(
             &enc_state,
-            bit_read(instance->generic.data, instance->generic.data_count_bit - 1),
+            bit_read(subghz_block_generic.data, subghz_block_generic.data_count_bit - 1),
             &result);
     }
     instance->encoder.upload[index++] =
         level_duration_make(false, (uint32_t)subghz_protocol_marantec_const.te_long * 5);
 
-    for(uint8_t i = instance->generic.data_count_bit - 1; i > 0; i--) {
+    for(uint8_t i = subghz_block_generic.data_count_bit - 1; i > 0; i--) {
         if(!manchester_encoder_advance(
-               &enc_state, bit_read(instance->generic.data, i - 1), &result)) {
+               &enc_state, bit_read(subghz_block_generic.data, i - 1), &result)) {
             instance->encoder.upload[index++] =
                 subghz_protocol_encoder_marantec_add_duration_to_upload(result);
             manchester_encoder_advance(
-                &enc_state, bit_read(instance->generic.data, i - 1), &result);
+                &enc_state, bit_read(subghz_block_generic.data, i - 1), &result);
         }
         instance->encoder.upload[index++] =
             subghz_protocol_encoder_marantec_add_duration_to_upload(result);
@@ -204,10 +204,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_marantec_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderMarantec* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_marantec_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -217,7 +218,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_marantec_remote_controller(&instance->generic);
+        subghz_protocol_marantec_remote_controller(&subghz_block_generic);
         subghz_protocol_encoder_marantec_get_upload(instance);
         instance->encoder.front = 0;
         instance->encoder.is_running = true;
@@ -254,7 +255,7 @@ void* subghz_protocol_decoder_marantec_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderMarantec* instance = malloc(sizeof(SubGhzProtocolDecoderMarantec));
     instance->base.protocol = &subghz_protocol_marantec;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -309,8 +310,8 @@ void subghz_protocol_decoder_marantec_feed(void* context, bool level, volatile u
                              subghz_protocol_marantec_const.te_delta)) {
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_marantec_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -364,15 +365,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_marantec_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderMarantec* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_marantec_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderMarantec* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_marantec_const.min_count_bit_for_found);
 }
@@ -380,18 +386,19 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_marantec_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderMarantec* instance = context;
-    subghz_protocol_marantec_remote_controller(&instance->generic);
+    UNUSED(instance);
+    subghz_protocol_marantec_remote_controller(&subghz_block_generic);
 
     uint8_t tdata[6] = {
-        instance->generic.data >> 48,
-        instance->generic.data >> 40,
-        instance->generic.data >> 32,
-        instance->generic.data >> 24,
-        instance->generic.data >> 16,
-        instance->generic.data >> 8};
+        subghz_block_generic.data >> 48,
+        subghz_block_generic.data >> 40,
+        subghz_block_generic.data >> 32,
+        subghz_block_generic.data >> 24,
+        subghz_block_generic.data >> 16,
+        subghz_block_generic.data >> 8};
 
     uint8_t crc = subghz_protocol_marantec_crc8(tdata, sizeof(tdata));
-    bool crc_ok = (crc == (instance->generic.data & 0xFF));
+    bool crc_ok = (crc == (subghz_block_generic.data & 0xFF));
 
     furi_string_cat_printf(
         output,
@@ -400,12 +407,12 @@ void subghz_protocol_decoder_marantec_get_string(void* context, FuriString* outp
         "Sn: 0x%07lX \r\n"
         "CRC: 0x%02X - %s\r\n"
         "Btn: %X\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32),
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        instance->generic.serial,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32),
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        subghz_block_generic.serial,
         crc,
         crc_ok ? "Valid" : "Invalid",
-        instance->generic.btn);
+        subghz_block_generic.btn);
 }

--- a/lib/subghz/protocols/marantec24.c
+++ b/lib/subghz/protocols/marantec24.c
@@ -18,14 +18,14 @@ struct SubGhzProtocolDecoderMarantec24 {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 struct SubGhzProtocolEncoderMarantec24 {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -71,7 +71,7 @@ void* subghz_protocol_encoder_marantec24_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderMarantec24* instance = malloc(sizeof(SubGhzProtocolEncoderMarantec24));
 
     instance->base.protocol = &subghz_protocol_marantec24;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -97,8 +97,8 @@ static void
     size_t index = 0;
 
     // Send key and GAP
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             // Send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_marantec24_const.te_short);
@@ -146,10 +146,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_marantec24_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderMarantec24* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_marantec24_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -159,7 +160,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_marantec24_check_remote_controller(&instance->generic);
+        subghz_protocol_marantec24_check_remote_controller(&subghz_block_generic);
         subghz_protocol_encoder_marantec24_get_upload(instance);
         instance->encoder.is_running = true;
     } while(false);
@@ -194,7 +195,7 @@ void* subghz_protocol_decoder_marantec24_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderMarantec24* instance = malloc(sizeof(SubGhzProtocolDecoderMarantec24));
     instance->base.protocol = &subghz_protocol_marantec24;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -282,8 +283,8 @@ void subghz_protocol_decoder_marantec24_feed(void* context, bool level, volatile
                 // If got 24 bits key reading is finished
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_marantec24_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -313,15 +314,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_marantec24_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderMarantec24* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_marantec24_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderMarantec24* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_marantec24_const.min_count_bit_for_found);
 }
@@ -329,8 +335,9 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_marantec24_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderMarantec24* instance = context;
+    UNUSED(instance);
 
-    subghz_protocol_marantec24_check_remote_controller(&instance->generic);
+    subghz_protocol_marantec24_check_remote_controller(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
@@ -338,9 +345,9 @@ void subghz_protocol_decoder_marantec24_get_string(void* context, FuriString* ou
         "Key: 0x%06lX\r\n"
         "Serial: 0x%05lX\r\n"
         "Btn: %01X",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0xFFFFFF),
-        instance->generic.serial,
-        instance->generic.btn);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFF),
+        subghz_block_generic.serial,
+        subghz_block_generic.btn);
 }

--- a/lib/subghz/protocols/mastercode.c
+++ b/lib/subghz/protocols/mastercode.c
@@ -35,13 +35,13 @@ static const SubGhzBlockConst subghz_protocol_mastercode_const = {
 struct SubGhzProtocolDecoderMastercode {
     SubGhzProtocolDecoderBase base;
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 struct SubGhzProtocolEncoderMastercode {
     SubGhzProtocolEncoderBase base;
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -87,7 +87,7 @@ void* subghz_protocol_encoder_mastercode_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderMastercode* instance = malloc(sizeof(SubGhzProtocolEncoderMastercode));
 
     instance->base.protocol = &subghz_protocol_mastercode;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 72;
@@ -112,7 +112,7 @@ static bool
     subghz_protocol_encoder_mastercode_get_upload(SubGhzProtocolEncoderMastercode* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2);
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2);
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -120,8 +120,8 @@ static bool
         instance->encoder.size_upload = size_upload;
     }
 
-    for(uint8_t i = instance->generic.data_count_bit; i > 1; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 1; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_mastercode_const.te_long);
@@ -135,7 +135,7 @@ static bool
                 level_duration_make(false, (uint32_t)subghz_protocol_mastercode_const.te_long);
         }
     }
-    if(bit_read(instance->generic.data, 0)) {
+    if(bit_read(subghz_block_generic.data, 0)) {
         //send bit 1
         instance->encoder.upload[index++] =
             level_duration_make(true, (uint32_t)subghz_protocol_mastercode_const.te_long);
@@ -159,10 +159,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_mastercode_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderMastercode* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_mastercode_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -210,7 +211,7 @@ void* subghz_protocol_decoder_mastercode_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderMastercode* instance = malloc(sizeof(SubGhzProtocolDecoderMastercode));
     instance->base.protocol = &subghz_protocol_mastercode;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -284,8 +285,8 @@ void subghz_protocol_decoder_mastercode_feed(void* context, bool level, uint32_t
 
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_mastercode_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -326,15 +327,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_mastercode_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderMastercode* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_mastercode_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderMastercode* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_mastercode_const.min_count_bit_for_found);
 }
@@ -342,7 +348,8 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_mastercode_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderMastercode* instance = context;
-    subghz_protocol_mastercode_check_remote_controller(&instance->generic);
+    UNUSED(instance);
+    subghz_protocol_mastercode_check_remote_controller(&subghz_block_generic);
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
@@ -350,11 +357,11 @@ void subghz_protocol_decoder_mastercode_get_string(void* context, FuriString* ou
         "  +:   " DIP_PATTERN "\r\n"
         "  o:   " DIP_PATTERN "\r\n"
         "  -:   " DIP_PATTERN "\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint64_t)(instance->generic.data),
-        instance->generic.btn,
-        SHOW_DIP_P(instance->generic.serial, DIP_P),
-        SHOW_DIP_P(instance->generic.serial, DIP_O),
-        SHOW_DIP_P(instance->generic.serial, DIP_N));
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint64_t)(subghz_block_generic.data),
+        subghz_block_generic.btn,
+        SHOW_DIP_P(subghz_block_generic.serial, DIP_P),
+        SHOW_DIP_P(subghz_block_generic.serial, DIP_O),
+        SHOW_DIP_P(subghz_block_generic.serial, DIP_N));
 }

--- a/lib/subghz/protocols/megacode.c
+++ b/lib/subghz/protocols/megacode.c
@@ -30,7 +30,7 @@ struct SubGhzProtocolDecoderMegaCode {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
     uint8_t last_bit;
 };
 
@@ -38,7 +38,7 @@ struct SubGhzProtocolEncoderMegaCode {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -85,7 +85,7 @@ void* subghz_protocol_encoder_megacode_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderMegaCode* instance = malloc(sizeof(SubGhzProtocolEncoderMegaCode));
 
     instance->base.protocol = &subghz_protocol_megacode;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 52;
@@ -109,7 +109,7 @@ void subghz_protocol_encoder_megacode_free(void* context) {
 static bool subghz_protocol_encoder_megacode_get_upload(SubGhzProtocolEncoderMegaCode* instance) {
     furi_assert(instance);
     uint8_t last_bit = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2);
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2);
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -134,15 +134,15 @@ static bool subghz_protocol_encoder_megacode_get_upload(SubGhzProtocolEncoderMeg
     // Send end level
     instance->encoder.upload[index--] =
         level_duration_make(true, (uint32_t)subghz_protocol_megacode_const.te_short);
-    if(bit_read(instance->generic.data, 0)) {
+    if(bit_read(subghz_block_generic.data, 0)) {
         last_bit = 1;
     } else {
         last_bit = 0;
     }
 
     //Send key data
-    for(uint8_t i = 1; i < instance->generic.data_count_bit; i++) {
-        if(bit_read(instance->generic.data, i)) {
+    for(uint8_t i = 1; i < subghz_block_generic.data_count_bit; i++) {
+        if(bit_read(subghz_block_generic.data, i)) {
             //if bit 1
             instance->encoder.upload[index--] = level_duration_make(
                 false,
@@ -162,7 +162,7 @@ static bool subghz_protocol_encoder_megacode_get_upload(SubGhzProtocolEncoderMeg
     }
 
     //Send PT_GUARD
-    if(bit_read(instance->generic.data, 0)) {
+    if(bit_read(subghz_block_generic.data, 0)) {
         //if end bit 1
         instance->encoder.upload[index] =
             level_duration_make(false, (uint32_t)subghz_protocol_megacode_const.te_short * 11);
@@ -179,10 +179,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_megacode_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderMegaCode* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_megacode_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -229,7 +230,7 @@ void* subghz_protocol_decoder_megacode_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderMegaCode* instance = malloc(sizeof(SubGhzProtocolDecoderMegaCode));
     instance->base.protocol = &subghz_protocol_megacode;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -276,8 +277,8 @@ void subghz_protocol_decoder_megacode_feed(void* context, bool level, uint32_t d
                 instance->decoder.parser_step = MegaCodeDecoderStepReset;
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_megacode_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -387,15 +388,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_megacode_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderMegaCode* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_megacode_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderMegaCode* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_megacode_const.min_count_bit_for_found);
 }
@@ -403,7 +409,8 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_megacode_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderMegaCode* instance = context;
-    subghz_protocol_megacode_check_remote_controller(&instance->generic);
+    UNUSED(instance);
+    subghz_protocol_megacode_check_remote_controller(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
@@ -411,11 +418,11 @@ void subghz_protocol_decoder_megacode_get_string(void* context, FuriString* outp
         "Key:0x%06lX\r\n"
         "Sn:0x%04lX - %lu\r\n"
         "Facility:%lX Btn:%X\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)instance->generic.data,
-        instance->generic.serial,
-        instance->generic.serial,
-        instance->generic.cnt,
-        instance->generic.btn);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)subghz_block_generic.data,
+        subghz_block_generic.serial,
+        subghz_block_generic.serial,
+        subghz_block_generic.cnt,
+        subghz_block_generic.btn);
 }

--- a/lib/subghz/protocols/nero_radio.c
+++ b/lib/subghz/protocols/nero_radio.c
@@ -19,7 +19,7 @@ struct SubGhzProtocolDecoderNeroRadio {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint16_t header_count;
 };
@@ -28,7 +28,7 @@ struct SubGhzProtocolEncoderNeroRadio {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -75,7 +75,7 @@ void* subghz_protocol_encoder_nero_radio_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderNeroRadio* instance = malloc(sizeof(SubGhzProtocolEncoderNeroRadio));
 
     instance->base.protocol = &subghz_protocol_nero_radio;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -100,7 +100,7 @@ static bool
     subghz_protocol_encoder_nero_radio_get_upload(SubGhzProtocolEncoderNeroRadio* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = 49 * 2 + 2 + (instance->generic.data_count_bit * 2);
+    size_t size_upload = 49 * 2 + 2 + (subghz_block_generic.data_count_bit * 2);
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -122,8 +122,8 @@ static bool
         level_duration_make(false, (uint32_t)subghz_protocol_nero_radio_const.te_short);
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 1; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 1; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_nero_radio_const.te_long);
@@ -137,11 +137,11 @@ static bool
                 level_duration_make(false, (uint32_t)subghz_protocol_nero_radio_const.te_long);
         }
     }
-    if(bit_read(instance->generic.data, 0)) {
+    if(bit_read(subghz_block_generic.data, 0)) {
         //send bit 1
         instance->encoder.upload[index++] =
             level_duration_make(true, (uint32_t)subghz_protocol_nero_radio_const.te_long);
-        if(instance->generic.data_count_bit == 57) {
+        if(subghz_block_generic.data_count_bit == 57) {
             instance->encoder.upload[index++] = level_duration_make(false, (uint32_t)1300);
         } else {
             instance->encoder.upload[index++] = level_duration_make(
@@ -151,7 +151,7 @@ static bool
         //send bit 0
         instance->encoder.upload[index++] =
             level_duration_make(true, (uint32_t)subghz_protocol_nero_radio_const.te_short);
-        if(instance->generic.data_count_bit == 57) {
+        if(subghz_block_generic.data_count_bit == 57) {
             instance->encoder.upload[index++] = level_duration_make(false, (uint32_t)1300);
         } else {
             instance->encoder.upload[index++] = level_duration_make(
@@ -165,15 +165,16 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_nero_radio_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderNeroRadio* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_nero_radio_const.min_count_bit_for_found);
 
         if((ret == SubGhzProtocolStatusErrorValueBitCount) &&
-           (instance->generic.data_count_bit == 57)) {
+           (subghz_block_generic.data_count_bit == 57)) {
             ret = SubGhzProtocolStatusOk;
         } else {
             if(ret != SubGhzProtocolStatusOk) {
@@ -221,7 +222,7 @@ void* subghz_protocol_decoder_nero_radio_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderNeroRadio* instance = malloc(sizeof(SubGhzProtocolDecoderNeroRadio));
     instance->base.protocol = &subghz_protocol_nero_radio;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -314,8 +315,8 @@ void subghz_protocol_decoder_nero_radio_feed(void* context, bool level, uint32_t
                     subghz_protocol_nero_radio_const.min_count_bit_for_found) ||
                    (instance->decoder.decode_count_bit ==
                     subghz_protocol_nero_radio_const.min_count_bit_for_found + 1)) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -363,22 +364,25 @@ SubGhzProtocolStatus subghz_protocol_decoder_nero_radio_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderNeroRadio* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_nero_radio_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderNeroRadio* instance = context;
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     SubGhzProtocolStatus stat;
 
     stat = subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_nero_radio_const.min_count_bit_for_found);
 
     if((stat == SubGhzProtocolStatusErrorValueBitCount) &&
-       (instance->generic.data_count_bit == 57)) {
+       (subghz_block_generic.data_count_bit == 57)) {
         return SubGhzProtocolStatusOk;
     } else {
         return stat;
@@ -418,17 +422,18 @@ static void subghz_protocol_nero_radio_parse_data(SubGhzBlockGeneric* instance) 
 void subghz_protocol_decoder_nero_radio_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderNeroRadio* instance = context;
+    UNUSED(instance);
 
-    uint32_t code_found_hi = instance->generic.data >> 32;
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+    uint32_t code_found_hi = subghz_block_generic.data >> 32;
+    uint32_t code_found_lo = subghz_block_generic.data & 0x00000000ffffffff;
 
     uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit);
 
     uint32_t code_found_reverse_hi = code_found_reverse >> 32;
     uint32_t code_found_reverse_lo = code_found_reverse & 0x00000000ffffffff;
 
-    subghz_protocol_nero_radio_parse_data(&instance->generic);
+    subghz_protocol_nero_radio_parse_data(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
@@ -438,13 +443,13 @@ void subghz_protocol_decoder_nero_radio_get_string(void* context, FuriString* ou
         "Sn: 0x%llX \r\n"
         "CRC?: 0x%02X\r\n"
         "Btn: %X\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         code_found_hi,
         code_found_lo,
         code_found_reverse_hi,
         code_found_reverse_lo,
-        instance->generic.data_2,
-        (uint8_t)(instance->generic.data & 0xFF),
-        instance->generic.btn);
+        subghz_block_generic.data_2,
+        (uint8_t)(subghz_block_generic.data & 0xFF),
+        subghz_block_generic.btn);
 }

--- a/lib/subghz/protocols/nero_sketch.c
+++ b/lib/subghz/protocols/nero_sketch.c
@@ -19,7 +19,7 @@ struct SubGhzProtocolDecoderNeroSketch {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
     uint16_t header_count;
 };
 
@@ -27,7 +27,7 @@ struct SubGhzProtocolEncoderNeroSketch {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -74,7 +74,7 @@ void* subghz_protocol_encoder_nero_sketch_alloc(SubGhzEnvironment* environment) 
     SubGhzProtocolEncoderNeroSketch* instance = malloc(sizeof(SubGhzProtocolEncoderNeroSketch));
 
     instance->base.protocol = &subghz_protocol_nero_sketch;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -100,7 +100,7 @@ static bool
     furi_assert(instance);
 
     size_t index = 0;
-    size_t size_upload = 47 * 2 + 2 + (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = 47 * 2 + 2 + (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -123,8 +123,8 @@ static bool
         level_duration_make(false, (uint32_t)subghz_protocol_nero_sketch_const.te_short);
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_nero_sketch_const.te_long);
@@ -152,10 +152,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_nero_sketch_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderNeroSketch* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_nero_sketch_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -202,7 +203,7 @@ void* subghz_protocol_decoder_nero_sketch_alloc(SubGhzEnvironment* environment) 
     UNUSED(environment);
     SubGhzProtocolDecoderNeroSketch* instance = malloc(sizeof(SubGhzProtocolDecoderNeroSketch));
     instance->base.protocol = &subghz_protocol_nero_sketch;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -277,8 +278,8 @@ void subghz_protocol_decoder_nero_sketch_feed(void* context, bool level, uint32_
                 instance->decoder.parser_step = NeroSketchDecoderStepReset;
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_nero_sketch_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -334,15 +335,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_nero_sketch_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderNeroSketch* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_nero_sketch_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderNeroSketch* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_nero_sketch_const.min_count_bit_for_found);
 }
@@ -350,12 +356,13 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_nero_sketch_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderNeroSketch* instance = context;
+    UNUSED(instance);
 
-    uint32_t code_found_hi = instance->generic.data >> 32;
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+    uint32_t code_found_hi = subghz_block_generic.data >> 32;
+    uint32_t code_found_lo = subghz_block_generic.data & 0x00000000ffffffff;
 
     uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit);
 
     uint32_t code_found_reverse_hi = code_found_reverse >> 32;
     uint32_t code_found_reverse_lo = code_found_reverse & 0x00000000ffffffff;
@@ -365,8 +372,8 @@ void subghz_protocol_decoder_nero_sketch_get_string(void* context, FuriString* o
         "%s %dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Yek:0x%lX%08lX\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         code_found_hi,
         code_found_lo,
         code_found_reverse_hi,

--- a/lib/subghz/protocols/nice_flo.c
+++ b/lib/subghz/protocols/nice_flo.c
@@ -18,14 +18,14 @@ struct SubGhzProtocolDecoderNiceFlo {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 struct SubGhzProtocolEncoderNiceFlo {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -73,7 +73,7 @@ void* subghz_protocol_encoder_nice_flo_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderNiceFlo* instance = malloc(sizeof(SubGhzProtocolEncoderNiceFlo));
 
     instance->base.protocol = &subghz_protocol_nice_flo;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 52; //max 24bit*2 + 2 (start, stop)
@@ -97,7 +97,7 @@ void subghz_protocol_encoder_nice_flo_free(void* context) {
 static bool subghz_protocol_encoder_nice_flo_get_upload(SubGhzProtocolEncoderNiceFlo* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -111,8 +111,8 @@ static bool subghz_protocol_encoder_nice_flo_get_upload(SubGhzProtocolEncoderNic
     instance->encoder.upload[index++] =
         level_duration_make(true, (uint32_t)subghz_protocol_nice_flo_const.te_short);
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(false, (uint32_t)subghz_protocol_nice_flo_const.te_long);
@@ -133,15 +133,16 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_nice_flo_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderNiceFlo* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
-        ret = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+        ret = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
-        if((instance->generic.data_count_bit <
+        if((subghz_block_generic.data_count_bit <
             subghz_protocol_nice_flo_const.min_count_bit_for_found) ||
-           (instance->generic.data_count_bit >
+           (subghz_block_generic.data_count_bit >
             2 * subghz_protocol_nice_flo_const.min_count_bit_for_found)) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             ret = SubGhzProtocolStatusErrorValueBitCount;
@@ -188,7 +189,7 @@ void* subghz_protocol_decoder_nice_flo_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderNiceFlo* instance = malloc(sizeof(SubGhzProtocolDecoderNiceFlo));
     instance->base.protocol = &subghz_protocol_nice_flo;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -236,11 +237,11 @@ void subghz_protocol_decoder_nice_flo_feed(void* context, bool level, uint32_t d
                 instance->decoder.parser_step = NiceFloDecoderStepFoundStartBit;
                 if(instance->decoder.decode_count_bit >=
                    subghz_protocol_nice_flo_const.min_count_bit_for_found) {
-                    instance->generic.serial = 0x0;
-                    instance->generic.btn = 0x0;
+                    subghz_block_generic.serial = 0x0;
+                    subghz_block_generic.btn = 0x0;
 
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -289,22 +290,27 @@ SubGhzProtocolStatus subghz_protocol_decoder_nice_flo_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderNiceFlo* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_nice_flo_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderNiceFlo* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
-        ret = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+        ret = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
-        if((instance->generic.data_count_bit <
+        if((subghz_block_generic.data_count_bit <
             subghz_protocol_nice_flo_const.min_count_bit_for_found) ||
-           (instance->generic.data_count_bit >
+           (subghz_block_generic.data_count_bit >
             2 * subghz_protocol_nice_flo_const.min_count_bit_for_found)) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             ret = SubGhzProtocolStatusErrorValueBitCount;
@@ -317,10 +323,11 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_nice_flo_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderNiceFlo* instance = context;
-
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+    UNUSED (instance);
+    
+    uint32_t code_found_lo = subghz_block_generic.data & 0x00000000ffffffff;
     uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit);
     uint32_t code_found_reverse_lo = code_found_reverse & 0x00000000ffffffff;
 
     furi_string_cat_printf(
@@ -328,8 +335,8 @@ void subghz_protocol_decoder_nice_flo_get_string(void* context, FuriString* outp
         "%s %dbit\r\n"
         "Key:0x%08lX\r\n"
         "Yek:0x%08lX\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         code_found_lo,
         code_found_reverse_lo);
 }

--- a/lib/subghz/protocols/nice_flor_s.c
+++ b/lib/subghz/protocols/nice_flor_s.c
@@ -30,7 +30,6 @@ struct SubGhzProtocolDecoderNiceFlorS {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 
     const char* nice_flor_s_rainbow_table_file_name;
     uint64_t data;
@@ -40,7 +39,6 @@ struct SubGhzProtocolEncoderNiceFlorS {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 
     const char* nice_flor_s_rainbow_table_file_name;
 };
@@ -96,7 +94,7 @@ void* subghz_protocol_encoder_nice_flor_s_alloc(SubGhzEnvironment* environment) 
     SubGhzProtocolEncoderNiceFlorS* instance = malloc(sizeof(SubGhzProtocolEncoderNiceFlorS));
 
     instance->base.protocol = &subghz_protocol_nice_flor_s;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->nice_flor_s_rainbow_table_file_name =
         subghz_environment_get_nice_flor_s_rainbow_table_file_name(environment);
     if(instance->nice_flor_s_rainbow_table_file_name) {
@@ -137,7 +135,7 @@ static void subghz_protocol_encoder_nice_flor_s_get_upload(
     const char* file_name) {
     furi_assert(instance);
     size_t index = 0;
-    btn = instance->generic.btn;
+    btn = subghz_block_generic.btn;
 
     // Save original button for later use
     if(subghz_custom_btn_get_original() == 0) {
@@ -146,7 +144,7 @@ static void subghz_protocol_encoder_nice_flor_s_get_upload(
 
     btn = subghz_protocol_nice_flor_s_get_btn_code();
 
-    size_t size_upload = ((instance->generic.data_count_bit * 2) + ((37 + 2 + 2) * 2) * 16);
+    size_t size_upload = ((subghz_block_generic.data_count_bit * 2) + ((37 + 2 + 2) * 2) * 16);
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
     } else {
@@ -155,39 +153,47 @@ static void subghz_protocol_encoder_nice_flor_s_get_upload(
     if(nice_flors_counter_mode == 0) {
         // Check for OFEX (overflow experimental) mode
         if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-            if((instance->generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
-                instance->generic.cnt = 0;
-            } else {
-                instance->generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+            // standart counter mode. PULL data from subghz_block_generic_global variables
+            if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+                // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+                // so we increase counter by standart mult value
+                if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) >
+                   0xFFFF) {
+                    subghz_block_generic.cnt = 0;
+                } else {
+                    subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+                }
             }
+
         } else {
-            if((instance->generic.cnt + 0x1) > 0xFFFF) {
-                instance->generic.cnt = 0;
-            } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-                instance->generic.cnt = 0xFFFE;
+            //OFFEX mode
+            if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+                subghz_block_generic.cnt = 0;
+            } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+                subghz_block_generic.cnt = 0xFFFE;
             } else {
-                instance->generic.cnt++;
+                subghz_block_generic.cnt++;
             }
         }
     } else if(nice_flors_counter_mode == 1) {
         // Mode 1 (floxi2r)
         // 0001 / FFFE
-        if(instance->generic.cnt == 0xFFFE) {
-            instance->generic.cnt = 0x0001;
+        if(subghz_block_generic.cnt == 0xFFFE) {
+            subghz_block_generic.cnt = 0x0001;
         } else {
-            instance->generic.cnt = 0xFFFE;
+            subghz_block_generic.cnt = 0xFFFE;
         }
     } else {
         // Mode 2 (ox2)
         // 0x0000 / 0x0001
-        if(instance->generic.cnt >= 0x0001) {
-            instance->generic.cnt = 0;
+        if(subghz_block_generic.cnt >= 0x0001) {
+            subghz_block_generic.cnt = 0;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     }
 
-    uint64_t decrypt = ((uint64_t)instance->generic.serial << 16) | instance->generic.cnt;
+    uint64_t decrypt = ((uint64_t)subghz_block_generic.serial << 16) | subghz_block_generic.cnt;
     uint64_t enc_part = subghz_protocol_nice_flor_s_encrypt(decrypt, file_name);
 
     for(int i = 0; i < 16; i++) {
@@ -197,7 +203,7 @@ static void subghz_protocol_encoder_nice_flor_s_get_upload(
         uint8_t byte;
 
         byte = btn << 4 | (0xF ^ btn ^ loops[i]);
-        instance->generic.data = (uint64_t)byte << 44 | enc_part;
+        subghz_block_generic.data = (uint64_t)byte << 44 | enc_part;
 
         //Send header
         instance->encoder.upload[index++] =
@@ -210,7 +216,7 @@ static void subghz_protocol_encoder_nice_flor_s_get_upload(
 
         //Send key data
         for(uint8_t j = 52; j > 0; j--) {
-            if(bit_read(instance->generic.data, j - 1)) {
+            if(bit_read(subghz_block_generic.data, j - 1)) {
                 //send bit 1
                 instance->encoder.upload[index++] =
                     level_duration_make(true, (uint32_t)subghz_protocol_nice_flor_s_const.te_long);
@@ -224,21 +230,21 @@ static void subghz_protocol_encoder_nice_flor_s_get_upload(
                     false, (uint32_t)subghz_protocol_nice_flor_s_const.te_long);
             }
         }
-        if(instance->generic.data_count_bit == NICE_ONE_COUNT_BIT) {
+        if(subghz_block_generic.data_count_bit == NICE_ONE_COUNT_BIT) {
             uint8_t add_data[10] = {0};
             for(size_t i = 0; i < 7; i++) {
-                add_data[i] = (instance->generic.data >> (48 - i * 8)) & 0xFF;
+                add_data[i] = (subghz_block_generic.data >> (48 - i * 8)) & 0xFF;
             }
             subghz_protocol_nice_one_get_data(add_data, loops[i], loops[i]);
-            instance->generic.data_2 = 0;
+            subghz_block_generic.data_2 = 0;
             for(size_t j = 7; j < 10; j++) {
-                instance->generic.data_2 <<= 8;
-                instance->generic.data_2 += add_data[j];
+                subghz_block_generic.data_2 <<= 8;
+                subghz_block_generic.data_2 += add_data[j];
             }
 
             //Send key data
             for(uint8_t j = 24; j > 4; j--) {
-                if(bit_read(instance->generic.data_2, j - 1)) {
+                if(bit_read(subghz_block_generic.data_2, j - 1)) {
                     //send bit 1
                     instance->encoder.upload[index++] = level_duration_make(
                         true, (uint32_t)subghz_protocol_nice_flor_s_const.te_long);
@@ -269,7 +275,7 @@ SubGhzProtocolStatus
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
@@ -278,7 +284,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
         // flipper_format_read_uint32(
-        // flipper_format, "Data", (uint32_t*)&instance->generic.data_2, 1);
+        // flipper_format, "Data", (uint32_t*)&subghz_block_generic.data_2, 1);
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
             break;
@@ -292,9 +298,9 @@ SubGhzProtocolStatus
         }
 
         subghz_protocol_nice_flor_s_remote_controller(
-            &instance->generic, instance->nice_flor_s_rainbow_table_file_name);
+            &subghz_block_generic, instance->nice_flor_s_rainbow_table_file_name);
         subghz_protocol_encoder_nice_flor_s_get_upload(
-            instance, instance->generic.btn, instance->nice_flor_s_rainbow_table_file_name);
+            instance, subghz_block_generic.btn, instance->nice_flor_s_rainbow_table_file_name);
 
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
@@ -302,19 +308,19 @@ SubGhzProtocolStatus
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to update Key");
             break;
         }
 
-        if(instance->generic.data_count_bit == NICE_ONE_COUNT_BIT) {
+        if(subghz_block_generic.data_count_bit == NICE_ONE_COUNT_BIT) {
             if(!flipper_format_rewind(flipper_format)) {
                 FURI_LOG_E(TAG, "Rewind error");
                 break;
             }
-            uint32_t temp = (instance->generic.data_2 >> 4) & 0xFFFFF;
+            uint32_t temp = (subghz_block_generic.data_2 >> 4) & 0xFFFFF;
             if(!flipper_format_update_uint32(flipper_format, "Data", &temp, 1)) {
                 FURI_LOG_E(TAG, "Unable to update Data");
             }
@@ -516,34 +522,34 @@ bool subghz_protocol_nice_flor_s_create_data(
     bool nice_one) {
     furi_assert(context);
     SubGhzProtocolEncoderNiceFlorS* instance = context;
-    instance->generic.serial = serial;
-    instance->generic.cnt = cnt;
+    subghz_block_generic.serial = serial;
+    subghz_block_generic.cnt = cnt;
     if(nice_one) {
-        instance->generic.data_count_bit = NICE_ONE_COUNT_BIT;
+        subghz_block_generic.data_count_bit = NICE_ONE_COUNT_BIT;
     } else {
-        instance->generic.data_count_bit = 52;
+        subghz_block_generic.data_count_bit = 52;
     }
-    uint64_t decrypt = ((uint64_t)instance->generic.serial << 16) | instance->generic.cnt;
+    uint64_t decrypt = ((uint64_t)subghz_block_generic.serial << 16) | subghz_block_generic.cnt;
     uint64_t enc_part = subghz_protocol_nice_flor_s_encrypt(
         decrypt, instance->nice_flor_s_rainbow_table_file_name);
     uint8_t byte = btn << 4 | (0xF ^ btn ^ 0x3);
-    instance->generic.data = (uint64_t)byte << 44 | enc_part;
+    subghz_block_generic.data = (uint64_t)byte << 44 | enc_part;
 
-    if(instance->generic.data_count_bit == NICE_ONE_COUNT_BIT) {
+    if(subghz_block_generic.data_count_bit == NICE_ONE_COUNT_BIT) {
         uint8_t add_data[10] = {0};
         for(size_t i = 0; i < 7; i++) {
-            add_data[i] = (instance->generic.data >> (48 - i * 8)) & 0xFF;
+            add_data[i] = (subghz_block_generic.data >> (48 - i * 8)) & 0xFF;
         }
         subghz_protocol_nice_one_get_data(add_data, 0, 0);
-        instance->generic.data_2 = 0;
+        subghz_block_generic.data_2 = 0;
         for(size_t j = 7; j < 10; j++) {
-            instance->generic.data_2 <<= 8;
-            instance->generic.data_2 += add_data[j];
+            subghz_block_generic.data_2 <<= 8;
+            subghz_block_generic.data_2 += add_data[j];
         }
     }
 
     SubGhzProtocolStatus res =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 
     return res == SubGhzProtocolStatusOk;
 }
@@ -551,7 +557,7 @@ bool subghz_protocol_nice_flor_s_create_data(
 void* subghz_protocol_decoder_nice_flor_s_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolDecoderNiceFlorS* instance = malloc(sizeof(SubGhzProtocolDecoderNiceFlorS));
     instance->base.protocol = &subghz_protocol_nice_flor_s;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->nice_flor_s_rainbow_table_file_name =
         subghz_environment_get_nice_flor_s_rainbow_table_file_name(environment);
     if(instance->nice_flor_s_rainbow_table_file_name) {
@@ -615,10 +621,10 @@ void subghz_protocol_decoder_nice_flor_s_feed(void* context, bool level, uint32_
                 if((instance->decoder.decode_count_bit ==
                     subghz_protocol_nice_flor_s_const.min_count_bit_for_found) ||
                    (instance->decoder.decode_count_bit == NICE_ONE_COUNT_BIT)) {
-                    instance->generic.data = instance->data;
+                    subghz_block_generic.data = instance->data;
                     instance->data = instance->decoder.decode_data;
-                    instance->decoder.decode_data = instance->generic.data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    instance->decoder.decode_data = subghz_block_generic.data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -743,8 +749,8 @@ SubGhzProtocolStatus subghz_protocol_decoder_nice_flor_s_serialize(
     furi_assert(context);
     SubGhzProtocolDecoderNiceFlorS* instance = context;
     SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
-    if(instance->generic.data_count_bit == NICE_ONE_COUNT_BIT) {
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
+    if(subghz_block_generic.data_count_bit == NICE_ONE_COUNT_BIT) {
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
             ret = SubGhzProtocolStatusErrorParserOthers;
@@ -763,20 +769,24 @@ SubGhzProtocolStatus
     subghz_protocol_decoder_nice_flor_s_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderNiceFlorS* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
-        ret = subghz_block_generic_deserialize(&instance->generic, flipper_format);
+        ret = subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
         if(ret != SubGhzProtocolStatusOk) {
             break;
         }
-        if((instance->generic.data_count_bit !=
+        if((subghz_block_generic.data_count_bit !=
             subghz_protocol_nice_flor_s_const.min_count_bit_for_found) &&
-           (instance->generic.data_count_bit != NICE_ONE_COUNT_BIT)) {
+           (subghz_block_generic.data_count_bit != NICE_ONE_COUNT_BIT)) {
             FURI_LOG_E(TAG, "Wrong number of bits in key");
             ret = SubGhzProtocolStatusErrorValueBitCount;
             break;
         }
-        if(instance->generic.data_count_bit == NICE_ONE_COUNT_BIT) {
+        if(subghz_block_generic.data_count_bit == NICE_ONE_COUNT_BIT) {
             if(!flipper_format_rewind(flipper_format)) {
                 FURI_LOG_E(TAG, "Rewind error");
                 ret = SubGhzProtocolStatusErrorParserOthers;
@@ -908,9 +918,14 @@ void subghz_protocol_decoder_nice_flor_s_get_string(void* context, FuriString* o
     SubGhzProtocolDecoderNiceFlorS* instance = context;
 
     subghz_protocol_nice_flor_s_remote_controller(
-        &instance->generic, instance->nice_flor_s_rainbow_table_file_name);
+        &subghz_block_generic, instance->nice_flor_s_rainbow_table_file_name);
 
-    if(instance->generic.data_count_bit == NICE_ONE_COUNT_BIT) {
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = true;
+    subghz_block_generic.cnt_lenght_bit = 16;
+    //
+
+    if(subghz_block_generic.data_count_bit == NICE_ONE_COUNT_BIT) {
         furi_string_cat_printf(
             output,
             "%s %dbit\r\n"
@@ -918,12 +933,12 @@ void subghz_protocol_decoder_nice_flor_s_get_string(void* context, FuriString* o
             "Sn:%05lX\r\n"
             "Cnt:%04lX Btn:%02X\r\n",
             NICE_ONE_NAME,
-            instance->generic.data_count_bit,
-            instance->generic.data,
+            subghz_block_generic.data_count_bit,
+            subghz_block_generic.data,
             instance->data,
-            instance->generic.serial,
-            instance->generic.cnt,
-            instance->generic.btn);
+            subghz_block_generic.serial,
+            subghz_block_generic.cnt,
+            subghz_block_generic.btn);
     } else {
         furi_string_cat_printf(
             output,
@@ -931,11 +946,11 @@ void subghz_protocol_decoder_nice_flor_s_get_string(void* context, FuriString* o
             "Key:0x%013llX\r\n"
             "Sn:%05lX\r\n"
             "Cnt:%04lX Btn:%02X\r\n",
-            instance->generic.protocol_name,
-            instance->generic.data_count_bit,
-            instance->generic.data,
-            instance->generic.serial,
-            instance->generic.cnt,
-            instance->generic.btn);
+            subghz_block_generic.protocol_name,
+            subghz_block_generic.data_count_bit,
+            subghz_block_generic.data,
+            subghz_block_generic.serial,
+            subghz_block_generic.cnt,
+            subghz_block_generic.btn);
     }
 }

--- a/lib/subghz/protocols/phoenix_v2.c
+++ b/lib/subghz/protocols/phoenix_v2.c
@@ -21,14 +21,12 @@ struct SubGhzProtocolDecoderPhoenix_V2 {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 };
 
 struct SubGhzProtocolEncoderPhoenix_V2 {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -75,7 +73,7 @@ void* subghz_protocol_encoder_phoenix_v2_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderPhoenix_V2* instance = malloc(sizeof(SubGhzProtocolEncoderPhoenix_V2));
 
     instance->base.protocol = &subghz_protocol_phoenix_v2;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 128;
@@ -103,25 +101,27 @@ bool subghz_protocol_phoenix_v2_create_data(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolEncoderPhoenix_V2* instance = context;
-    instance->generic.btn = 0x1;
-    instance->generic.serial = serial;
-    instance->generic.cnt = cnt;
-    instance->generic.data_count_bit = 52;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.btn = 0x1;
+    subghz_block_generic.serial = serial;
+    subghz_block_generic.cnt = cnt;
+    subghz_block_generic.data_count_bit = 52;
 
-    uint64_t local_data_rev =
-        (uint64_t)(((uint64_t)instance->generic.cnt << 40) |
-                   ((uint64_t)instance->generic.btn << 32) | (uint64_t)instance->generic.serial);
+    uint64_t local_data_rev = (uint64_t)(((uint64_t)subghz_block_generic.cnt << 40) |
+                                         ((uint64_t)subghz_block_generic.btn << 32) |
+                                         (uint64_t)subghz_block_generic.serial);
 
     uint16_t encrypted_counter = (uint16_t)subghz_protocol_phoenix_v2_encrypt_counter(
-        local_data_rev, instance->generic.cnt);
+        local_data_rev, subghz_block_generic.cnt);
 
-    instance->generic.data = subghz_protocol_blocks_reverse_key(
-        (uint64_t)(((uint64_t)encrypted_counter << 40) | ((uint64_t)instance->generic.btn << 32) |
-                   (uint64_t)instance->generic.serial),
-        instance->generic.data_count_bit + 4);
+    subghz_block_generic.data = subghz_protocol_blocks_reverse_key(
+        (uint64_t)(((uint64_t)encrypted_counter << 40) |
+                   ((uint64_t)subghz_block_generic.btn << 32) |
+                   (uint64_t)subghz_block_generic.serial),
+        subghz_block_generic.data_count_bit + 4);
 
     return SubGhzProtocolStatusOk ==
-           subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+           subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 // Get custom button code
@@ -232,7 +232,7 @@ static bool
     subghz_protocol_encoder_phoenix_v2_get_upload(SubGhzProtocolEncoderPhoenix_V2* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -240,7 +240,7 @@ static bool
         instance->encoder.size_upload = size_upload;
     }
 
-    uint8_t btn = instance->generic.btn;
+    uint8_t btn = subghz_block_generic.btn;
 
     // Save original button for later use
     if(subghz_custom_btn_get_original() == 0) {
@@ -254,31 +254,38 @@ static bool
     // Reconstruction of the data
     // Check for OFEX (overflow experimental) mode
     if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-        if((instance->generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else {
-            instance->generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+        // standart counter mode. PULL data from subghz_block_generic_global variables
+        if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+            // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+            // so we increase counter by standart mult value
+            if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
+                subghz_block_generic.cnt = 0;
+            } else {
+                subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+            }
         }
+
     } else {
-        if((instance->generic.cnt + 0x1) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-            instance->generic.cnt = 0xFFFE;
+        //OFFEX mode
+        if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+            subghz_block_generic.cnt = 0;
+        } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+            subghz_block_generic.cnt = 0xFFFE;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     }
 
     uint64_t local_data_rev = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit + 4);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit + 4);
 
     uint16_t encrypted_counter = (uint16_t)subghz_protocol_phoenix_v2_encrypt_counter(
-        local_data_rev, instance->generic.cnt);
+        local_data_rev, subghz_block_generic.cnt);
 
-    instance->generic.data = subghz_protocol_blocks_reverse_key(
+    subghz_block_generic.data = subghz_protocol_blocks_reverse_key(
         (uint64_t)(((uint64_t)encrypted_counter << 40) | ((uint64_t)btn << 32) |
-                   (uint64_t)instance->generic.serial),
-        instance->generic.data_count_bit + 4);
+                   (uint64_t)subghz_block_generic.serial),
+        subghz_block_generic.data_count_bit + 4);
 
     //Send header
     instance->encoder.upload[index++] =
@@ -287,8 +294,8 @@ static bool
     instance->encoder.upload[index++] =
         level_duration_make(true, (uint32_t)subghz_protocol_phoenix_v2_const.te_short * 6);
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(!bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(!bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(false, (uint32_t)subghz_protocol_phoenix_v2_const.te_long);
@@ -309,10 +316,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_phoenix_v2_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderPhoenix_V2* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_phoenix_v2_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -322,7 +330,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_phoenix_v2_check_remote_controller(&instance->generic);
+        subghz_protocol_phoenix_v2_check_remote_controller(&subghz_block_generic);
 
         if(!subghz_protocol_encoder_phoenix_v2_get_upload(instance)) {
             ret = SubGhzProtocolStatusErrorEncoderGetUpload;
@@ -331,7 +339,7 @@ SubGhzProtocolStatus
 
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -371,7 +379,7 @@ void* subghz_protocol_decoder_phoenix_v2_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderPhoenix_V2* instance = malloc(sizeof(SubGhzProtocolDecoderPhoenix_V2));
     instance->base.protocol = &subghz_protocol_phoenix_v2;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -417,8 +425,8 @@ void subghz_protocol_decoder_phoenix_v2_feed(void* context, bool level, uint32_t
                 instance->decoder.parser_step = Phoenix_V2DecoderStepFoundStartBit;
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_phoenix_v2_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
@@ -571,15 +579,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_phoenix_v2_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderPhoenix_V2* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_phoenix_v2_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderPhoenix_V2* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_phoenix_v2_const.min_count_bit_for_found);
 }
@@ -587,7 +600,15 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_phoenix_v2_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderPhoenix_V2* instance = context;
-    subghz_protocol_phoenix_v2_check_remote_controller(&instance->generic);
+    UNUSED(instance);
+
+    subghz_protocol_phoenix_v2_check_remote_controller(&subghz_block_generic);
+
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = true;
+    subghz_block_generic.cnt_lenght_bit = 16;
+    //
+
     furi_string_cat_printf(
         output,
         "V2 Phoenix %dbit\r\n"
@@ -595,10 +616,10 @@ void subghz_protocol_decoder_phoenix_v2_get_string(void* context, FuriString* ou
         "Sn:0x%07lX \r\n"
         "Cnt:%04lX\r\n"
         "Btn:%X\r\n",
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32) & 0xFFFFFFFF,
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        instance->generic.serial,
-        instance->generic.cnt,
-        instance->generic.btn);
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32) & 0xFFFFFFFF,
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        subghz_block_generic.serial,
+        subghz_block_generic.cnt,
+        subghz_block_generic.btn);
 }

--- a/lib/subghz/protocols/power_smart.c
+++ b/lib/subghz/protocols/power_smart.c
@@ -28,7 +28,7 @@ struct SubGhzProtocolDecoderPowerSmart {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
     ManchesterState manchester_saved_state;
     uint16_t header_count;
 };
@@ -37,7 +37,7 @@ struct SubGhzProtocolEncoderPowerSmart {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -83,7 +83,7 @@ void* subghz_protocol_encoder_power_smart_alloc(SubGhzEnvironment* environment) 
     SubGhzProtocolEncoderPowerSmart* instance = malloc(sizeof(SubGhzProtocolEncoderPowerSmart));
 
     instance->base.protocol = &subghz_protocol_power_smart;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 1024;
@@ -141,13 +141,13 @@ static void
     ManchesterEncoderResult result;
 
     for(int i = 8; i > 0; i--) {
-        for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
+        for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
             if(!manchester_encoder_advance(
-                   &enc_state, !bit_read(instance->generic.data, i - 1), &result)) {
+                   &enc_state, !bit_read(subghz_block_generic.data, i - 1), &result)) {
                 instance->encoder.upload[index++] =
                     subghz_protocol_encoder_power_smart_add_duration_to_upload(result);
                 manchester_encoder_advance(
-                    &enc_state, !bit_read(instance->generic.data, i - 1), &result);
+                    &enc_state, !bit_read(subghz_block_generic.data, i - 1), &result);
             }
             instance->encoder.upload[index++] =
                 subghz_protocol_encoder_power_smart_add_duration_to_upload(result);
@@ -197,10 +197,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_power_smart_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderPowerSmart* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_power_smart_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -210,7 +211,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_power_smart_remote_controller(&instance->generic);
+        subghz_protocol_power_smart_remote_controller(&subghz_block_generic);
         subghz_protocol_encoder_power_smart_get_upload(instance);
         instance->encoder.front = 0; // reset before start
         instance->encoder.is_running = true;
@@ -247,7 +248,7 @@ void* subghz_protocol_decoder_power_smart_alloc(SubGhzEnvironment* environment) 
     UNUSED(environment);
     SubGhzProtocolDecoderPowerSmart* instance = malloc(sizeof(SubGhzProtocolDecoderPowerSmart));
     instance->base.protocol = &subghz_protocol_power_smart;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -312,8 +313,8 @@ void subghz_protocol_decoder_power_smart_feed(
         if((instance->decoder.decode_data & POWER_SMART_PACKET_HEADER_MASK) ==
            POWER_SMART_PACKET_HEADER) {
             if(subghz_protocol_power_smart_chek_valid(instance->decoder.decode_data)) {
-                instance->generic.data = instance->decoder.decode_data;
-                instance->generic.data_count_bit =
+                subghz_block_generic.data = instance->decoder.decode_data;
+                subghz_block_generic.data_count_bit =
                     subghz_protocol_power_smart_const.min_count_bit_for_found;
                 if(instance->base.callback)
                     instance->base.callback(&instance->base, instance->base.context);
@@ -351,15 +352,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_power_smart_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderPowerSmart* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_power_smart_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderPowerSmart* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_power_smart_const.min_count_bit_for_found);
 }
@@ -367,7 +373,8 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_power_smart_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderPowerSmart* instance = context;
-    subghz_protocol_power_smart_remote_controller(&instance->generic);
+    UNUSED(instance);
+    subghz_protocol_power_smart_remote_controller(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
@@ -376,11 +383,11 @@ void subghz_protocol_decoder_power_smart_get_string(void* context, FuriString* o
         "Sn:0x%07lX \r\n"
         "Btn:%s\r\n"
         "Channel:" CHANNEL_PATTERN "\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32),
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        instance->generic.serial,
-        subghz_protocol_power_smart_get_name_button(instance->generic.btn),
-        CNT_TO_CHANNEL(instance->generic.cnt));
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32),
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        subghz_block_generic.serial,
+        subghz_protocol_power_smart_get_name_button(subghz_block_generic.btn),
+        CNT_TO_CHANNEL(subghz_block_generic.cnt));
 }

--- a/lib/subghz/protocols/princeton.c
+++ b/lib/subghz/protocols/princeton.c
@@ -30,7 +30,7 @@ struct SubGhzProtocolDecoderPrinceton {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint32_t te;
     uint32_t last_data;
@@ -41,7 +41,7 @@ struct SubGhzProtocolEncoderPrinceton {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint32_t te;
     uint32_t guard_time;
@@ -91,7 +91,7 @@ void* subghz_protocol_encoder_princeton_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderPrinceton* instance = malloc(sizeof(SubGhzProtocolEncoderPrinceton));
 
     instance->base.protocol = &subghz_protocol_princeton;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 52; //max 24bit*2 + 2 (start, stop)
@@ -255,23 +255,23 @@ static bool
     furi_assert(instance);
 
     // Generate new key using custom or default button
-    instance->generic.btn = subghz_protocol_princeton_get_btn_code();
+    subghz_block_generic.btn = subghz_protocol_princeton_get_btn_code();
 
     // Reconstruction of the data
     // If we have 8bit button code move serial to left by 8 bits (and 4 if 4 bits)
-    if(instance->generic.btn == 0x30 || instance->generic.btn == 0xC0) {
-        instance->generic.data =
-            ((uint64_t)instance->generic.serial << 8 | (uint64_t)instance->generic.btn);
-    } else if(instance->generic.btn == 0xF3 || instance->generic.btn == 0xFC) {
-        instance->generic.data =
-            ((uint64_t)instance->generic.serial << 8 | (uint64_t)(instance->generic.btn & 0xF));
+    if(subghz_block_generic.btn == 0x30 || subghz_block_generic.btn == 0xC0) {
+        subghz_block_generic.data =
+            ((uint64_t)subghz_block_generic.serial << 8 | (uint64_t)subghz_block_generic.btn);
+    } else if(subghz_block_generic.btn == 0xF3 || subghz_block_generic.btn == 0xFC) {
+        subghz_block_generic.data =
+            ((uint64_t)subghz_block_generic.serial << 8 | (uint64_t)(subghz_block_generic.btn & 0xF));
     } else {
-        instance->generic.data =
-            ((uint64_t)instance->generic.serial << 4 | (uint64_t)instance->generic.btn);
+        subghz_block_generic.data =
+            ((uint64_t)subghz_block_generic.serial << 4 | (uint64_t)subghz_block_generic.btn);
     }
 
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -280,8 +280,8 @@ static bool
     }
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)instance->te * 3);
@@ -335,10 +335,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_princeton_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderPrinceton* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_princeton_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -369,7 +370,7 @@ SubGhzProtocolStatus
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
         // Get button and serial before calling get_upload
-        subghz_protocol_princeton_check_remote_controller(&instance->generic);
+        subghz_protocol_princeton_check_remote_controller(&subghz_block_generic);
 
         if(!subghz_protocol_encoder_princeton_get_upload(instance)) {
             ret = SubGhzProtocolStatusErrorEncoderGetUpload;
@@ -382,7 +383,7 @@ SubGhzProtocolStatus
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -421,7 +422,7 @@ void* subghz_protocol_decoder_princeton_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderPrinceton* instance = malloc(sizeof(SubGhzProtocolDecoderPrinceton));
     instance->base.protocol = &subghz_protocol_princeton;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -472,8 +473,8 @@ void subghz_protocol_decoder_princeton_feed(void* context, bool level, uint32_t 
                        instance->last_data) {
                         instance->te /= (instance->decoder.decode_count_bit * 4 + 1);
 
-                        instance->generic.data = instance->decoder.decode_data;
-                        instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                        subghz_block_generic.data = instance->decoder.decode_data;
+                        subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                         instance->guard_time = roundf((float)duration / instance->te);
                         // Guard Time value should be between 15 -> 72 otherwise default value will be used
                         if((instance->guard_time < 15) || (instance->guard_time > 72)) {
@@ -530,7 +531,7 @@ SubGhzProtocolStatus subghz_protocol_decoder_princeton_serialize(
     furi_assert(context);
     SubGhzProtocolDecoderPrinceton* instance = context;
     SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
     if((ret == SubGhzProtocolStatusOk) &&
        !flipper_format_write_uint32(flipper_format, "TE", &instance->te, 1)) {
         FURI_LOG_E(TAG, "Unable to add TE");
@@ -549,10 +550,14 @@ SubGhzProtocolStatus
     subghz_protocol_decoder_princeton_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderPrinceton* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_princeton_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -586,12 +591,12 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_princeton_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderPrinceton* instance = context;
-    subghz_protocol_princeton_check_remote_controller(&instance->generic);
+    subghz_protocol_princeton_check_remote_controller(&subghz_block_generic);
     uint32_t data_rev = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit);
 
-    if(instance->generic.btn == 0x30 || instance->generic.btn == 0xC0 ||
-       instance->generic.btn == 0xF3 || instance->generic.btn == 0xFC) {
+    if(subghz_block_generic.btn == 0x30 || subghz_block_generic.btn == 0xC0 ||
+       subghz_block_generic.btn == 0xF3 || subghz_block_generic.btn == 0xFC) {
         furi_string_cat_printf(
             output,
             "%s %dbit\r\n"
@@ -599,14 +604,14 @@ void subghz_protocol_decoder_princeton_get_string(void* context, FuriString* out
             "Yek:0x%08lX\r\n"
             "Sn:0x%05lX Btn:%02X (8b)\r\n"
             "Te:%luus  GT:Te*%lu\r\n",
-            instance->generic.protocol_name,
-            instance->generic.data_count_bit,
-            (uint32_t)(instance->generic.data & 0xFFFFFF),
+            subghz_block_generic.protocol_name,
+            subghz_block_generic.data_count_bit,
+            (uint32_t)(subghz_block_generic.data & 0xFFFFFF),
             data_rev,
-            instance->generic.serial,
-            (instance->generic.btn == 0xF3 || instance->generic.btn == 0xFC) ?
-                instance->generic.btn & 0xF :
-                instance->generic.btn,
+            subghz_block_generic.serial,
+            (subghz_block_generic.btn == 0xF3 || subghz_block_generic.btn == 0xFC) ?
+                subghz_block_generic.btn & 0xF :
+                subghz_block_generic.btn,
             instance->te,
             instance->guard_time);
     } else {
@@ -617,12 +622,12 @@ void subghz_protocol_decoder_princeton_get_string(void* context, FuriString* out
             "Yek:0x%08lX\r\n"
             "Sn:0x%05lX Btn:%01X (4b)\r\n"
             "Te:%luus  GT:Te*%lu\r\n",
-            instance->generic.protocol_name,
-            instance->generic.data_count_bit,
-            (uint32_t)(instance->generic.data & 0xFFFFFF),
+            subghz_block_generic.protocol_name,
+            subghz_block_generic.data_count_bit,
+            (uint32_t)(subghz_block_generic.data & 0xFFFFFF),
             data_rev,
-            instance->generic.serial,
-            instance->generic.btn,
+            subghz_block_generic.serial,
+            subghz_block_generic.btn,
             instance->te,
             instance->guard_time);
     }

--- a/lib/subghz/protocols/revers_rb2.c
+++ b/lib/subghz/protocols/revers_rb2.c
@@ -20,7 +20,7 @@ struct SubGhzProtocolDecoderRevers_RB2 {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
     ManchesterState manchester_saved_state;
     uint16_t header_count;
 };
@@ -29,7 +29,7 @@ struct SubGhzProtocolEncoderRevers_RB2 {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -75,7 +75,7 @@ void* subghz_protocol_encoder_revers_rb2_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderRevers_RB2* instance = malloc(sizeof(SubGhzProtocolEncoderRevers_RB2));
 
     instance->base.protocol = &subghz_protocol_revers_rb2;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -132,13 +132,13 @@ static void
     manchester_encoder_reset(&enc_state);
     ManchesterEncoderResult result;
 
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
         if(!manchester_encoder_advance(
-               &enc_state, bit_read(instance->generic.data, i - 1), &result)) {
+               &enc_state, bit_read(subghz_block_generic.data, i - 1), &result)) {
             instance->encoder.upload[index++] =
                 subghz_protocol_encoder_revers_rb2_add_duration_to_upload(result);
             manchester_encoder_advance(
-                &enc_state, bit_read(instance->generic.data, i - 1), &result);
+                &enc_state, bit_read(subghz_block_generic.data, i - 1), &result);
         }
         instance->encoder.upload[index++] =
             subghz_protocol_encoder_revers_rb2_add_duration_to_upload(result);
@@ -166,10 +166,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_revers_rb2_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderRevers_RB2* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_revers_rb2_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -179,7 +180,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_revers_rb2_remote_controller(&instance->generic);
+        subghz_protocol_revers_rb2_remote_controller(&subghz_block_generic);
         subghz_protocol_encoder_revers_rb2_get_upload(instance);
         instance->encoder.is_running = true;
     } while(false);
@@ -214,7 +215,7 @@ void* subghz_protocol_decoder_revers_rb2_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderRevers_RB2* instance = malloc(sizeof(SubGhzProtocolDecoderRevers_RB2));
     instance->base.protocol = &subghz_protocol_revers_rb2;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -260,8 +261,8 @@ void subghz_protocol_decoder_revers_rb2_addbit(void* context, bool data) {
 
     if(preamble == 0xFF && stop_code == 0x200) {
         //Found header and stop code
-        instance->generic.data = instance->decoder.decode_data;
-        instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+        subghz_block_generic.data = instance->decoder.decode_data;
+        subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
         if(instance->base.callback)
             instance->base.callback(&instance->base, instance->base.context);
@@ -379,15 +380,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_revers_rb2_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderRevers_RB2* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_revers_rb2_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderRevers_RB2* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_revers_rb2_const.min_count_bit_for_found);
 }
@@ -395,16 +401,17 @@ SubGhzProtocolStatus
 void subghz_protocol_decoder_revers_rb2_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderRevers_RB2* instance = context;
-    subghz_protocol_revers_rb2_remote_controller(&instance->generic);
+    UNUSED(instance);
+    subghz_protocol_revers_rb2_remote_controller(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
         "%s %db\r\n"
         "Key:%lX%08lX\r\n"
         "Sn:0x%08lX \r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32),
-        (uint32_t)(instance->generic.data & 0xFFFFFFFF),
-        instance->generic.serial);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32),
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFFF),
+        subghz_block_generic.serial);
 }

--- a/lib/subghz/protocols/roger.c
+++ b/lib/subghz/protocols/roger.c
@@ -20,14 +20,14 @@ struct SubGhzProtocolDecoderRoger {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 struct SubGhzProtocolEncoderRoger {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -74,7 +74,7 @@ void* subghz_protocol_encoder_roger_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderRoger* instance = malloc(sizeof(SubGhzProtocolEncoderRoger));
 
     instance->base.protocol = &subghz_protocol_roger;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -167,7 +167,7 @@ static void subghz_protocol_encoder_roger_get_upload(SubGhzProtocolEncoderRoger*
     furi_assert(instance);
     size_t index = 0;
 
-    uint8_t btn = instance->generic.btn;
+    uint8_t btn = subghz_block_generic.btn;
 
     // Save original button for later use
     if(subghz_custom_btn_get_original() == 0) {
@@ -180,20 +180,20 @@ static void subghz_protocol_encoder_roger_get_upload(SubGhzProtocolEncoderRoger*
 
     // If End is not == button - transmit as is, no custom button allowed
     // For "End" values 23 and 20 - transmit correct ending used for their buttons
-    if((instance->generic.data & 0xFF) == instance->generic.btn) {
-        instance->generic.data = (uint64_t)instance->generic.serial << 12 | ((uint64_t)btn << 8) |
+    if((subghz_block_generic.data & 0xFF) == subghz_block_generic.btn) {
+        subghz_block_generic.data = (uint64_t)subghz_block_generic.serial << 12 | ((uint64_t)btn << 8) |
                                  btn;
-    } else if(((instance->generic.data & 0xFF) == 0x23) && btn == 0x1) {
-        instance->generic.data = (uint64_t)instance->generic.serial << 12 | ((uint64_t)btn << 8) |
+    } else if(((subghz_block_generic.data & 0xFF) == 0x23) && btn == 0x1) {
+        subghz_block_generic.data = (uint64_t)subghz_block_generic.serial << 12 | ((uint64_t)btn << 8) |
                                  0x20;
-    } else if(((instance->generic.data & 0xFF) == 0x20) && btn == 0x2) {
-        instance->generic.data = (uint64_t)instance->generic.serial << 12 | ((uint64_t)btn << 8) |
+    } else if(((subghz_block_generic.data & 0xFF) == 0x20) && btn == 0x2) {
+        subghz_block_generic.data = (uint64_t)subghz_block_generic.serial << 12 | ((uint64_t)btn << 8) |
                                  0x23;
     }
 
     // Send key and GAP
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             // Send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_roger_const.te_long);
@@ -256,10 +256,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_roger_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderRoger* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_roger_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -269,12 +270,12 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_roger_check_remote_controller(&instance->generic);
+        subghz_protocol_roger_check_remote_controller(&subghz_block_generic);
         subghz_protocol_encoder_roger_get_upload(instance);
 
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -314,7 +315,7 @@ void* subghz_protocol_decoder_roger_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderRoger* instance = malloc(sizeof(SubGhzProtocolDecoderRoger));
     instance->base.protocol = &subghz_protocol_roger;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -385,8 +386,8 @@ void subghz_protocol_decoder_roger_feed(void* context, bool level, volatile uint
                 // If got full 28 bits key reading is finished
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_roger_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -416,22 +417,28 @@ SubGhzProtocolStatus subghz_protocol_decoder_roger_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderRoger* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_roger_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderRoger* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic, flipper_format, subghz_protocol_roger_const.min_count_bit_for_found);
+        &subghz_block_generic, flipper_format, subghz_protocol_roger_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_roger_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderRoger* instance = context;
+    UNUSED(instance);
 
-    subghz_protocol_roger_check_remote_controller(&instance->generic);
+    subghz_protocol_roger_check_remote_controller(&subghz_block_generic);
 
     furi_string_cat_printf(
         output,
@@ -440,10 +447,10 @@ void subghz_protocol_decoder_roger_get_string(void* context, FuriString* output)
         "Serial: 0x%04lX\r\n"
         "End: 0x%02lX\r\n"
         "Btn: %01X",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0xFFFFFFF),
-        instance->generic.serial,
-        (uint32_t)(instance->generic.data & 0xFF),
-        instance->generic.btn);
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0xFFFFFFF),
+        subghz_block_generic.serial,
+        (uint32_t)(subghz_block_generic.data & 0xFF),
+        subghz_block_generic.btn);
 }

--- a/lib/subghz/protocols/scher_khan.c
+++ b/lib/subghz/protocols/scher_khan.c
@@ -24,7 +24,7 @@ struct SubGhzProtocolDecoderScherKhan {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint16_t header_count;
     const char* protocol_name;
@@ -34,7 +34,7 @@ struct SubGhzProtocolEncoderScherKhan {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 };
 
 typedef enum {
@@ -80,7 +80,7 @@ void* subghz_protocol_decoder_scher_khan_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderScherKhan* instance = malloc(sizeof(SubGhzProtocolDecoderScherKhan));
     instance->base.protocol = &subghz_protocol_scher_khan;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     return instance;
 }
@@ -158,8 +158,8 @@ void subghz_protocol_decoder_scher_khan_feed(void* context, bool level, uint32_t
                 instance->decoder.parser_step = ScherKhanDecoderStepReset;
                 if(instance->decoder.decode_count_bit >=
                    subghz_protocol_scher_khan_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(instance->base.callback)
                         instance->base.callback(&instance->base, instance->base.context);
                 }
@@ -280,14 +280,16 @@ SubGhzProtocolStatus subghz_protocol_decoder_scher_khan_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderScherKhan* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED (instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_scher_khan_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderScherKhan* instance = context;
-    return subghz_block_generic_deserialize(&instance->generic, flipper_format);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+    return subghz_block_generic_deserialize(&subghz_block_generic, flipper_format);
 }
 
 void subghz_protocol_decoder_scher_khan_get_string(void* context, FuriString* output) {
@@ -295,22 +297,26 @@ void subghz_protocol_decoder_scher_khan_get_string(void* context, FuriString* ou
     SubGhzProtocolDecoderScherKhan* instance = context;
 
     subghz_protocol_scher_khan_check_remote_controller(
-        &instance->generic, &instance->protocol_name);
+        &subghz_block_generic, &instance->protocol_name);
 
-    // use 'Cntr:' instead of 'Cnt:' to exclude this protocol counter from Counter edit
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = false;
+    subghz_block_generic.cnt_lenght_bit = 16;
+    //
+    
     furi_string_cat_printf(
         output,
         "%s %dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:%07lX Btn:%X\r\n"
-        "Cntr:%04lX\r\n"
+        "Cnt:%04lX\r\n"
         "Pt: %s\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32),
-        (uint32_t)instance->generic.data,
-        instance->generic.serial,
-        instance->generic.btn,
-        instance->generic.cnt,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32),
+        (uint32_t)subghz_block_generic.data,
+        subghz_block_generic.serial,
+        subghz_block_generic.btn,
+        subghz_block_generic.cnt,
         instance->protocol_name);
 }

--- a/lib/subghz/protocols/secplus_v1.c
+++ b/lib/subghz/protocols/secplus_v1.c
@@ -36,7 +36,6 @@ struct SubGhzProtocolDecoderSecPlus_v1 {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 
     uint8_t packet_accepted;
     uint8_t base_packet_index;
@@ -47,7 +46,6 @@ struct SubGhzProtocolEncoderSecPlus_v1 {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 
     uint8_t data_array[44];
 };
@@ -96,7 +94,7 @@ void* subghz_protocol_encoder_secplus_v1_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderSecPlus_v1* instance = malloc(sizeof(SubGhzProtocolEncoderSecPlus_v1));
 
     instance->base.protocol = &subghz_protocol_secplus_v1;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 128;
@@ -121,7 +119,7 @@ static bool
     subghz_protocol_encoder_secplus_v1_get_upload(SubGhzProtocolEncoderSecPlus_v1* instance) {
     furi_assert(instance);
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2);
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2);
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Encoder size upload exceeds allocated encoder buffer.");
         return false;
@@ -210,8 +208,8 @@ static bool
  */
 
 static bool subghz_protocol_secplus_v1_encode(SubGhzProtocolEncoderSecPlus_v1* instance) {
-    uint32_t fixed = (instance->generic.data >> 32) & 0xFFFFFFFF;
-    uint32_t rolling = instance->generic.data & 0xFFFFFFFF;
+    uint32_t fixed = (subghz_block_generic.data >> 32) & 0xFFFFFFFF;
+    uint32_t rolling = subghz_block_generic.data & 0xFFFFFFFF;
 
     uint8_t rolling_array[20] = {0};
     uint8_t fixed_array[20] = {0};
@@ -220,43 +218,23 @@ static bool subghz_protocol_secplus_v1_encode(SubGhzProtocolEncoderSecPlus_v1* i
     //increment the counter
     //rolling += 2; - old way
     // Experemental case - we dont know counter size exactly, so just will be think that it is in range of 0xE6000000 - 0xFFFFFFFF
-    // one case when we have mult = 0xFFFFFFFF  - its when we reset counter before applying new cnt value
-    // so at first step we reset cnt to 0 and now we sure here will be second step (set new cnt value);
-    // at second step check what user set for new Cnt (and correct it if cnt less than 0xE6000000 or more than 0xFFFFFFFF)
-    int32_t multicntr = (furi_hal_subghz_get_rolling_counter_mult() & 0xFFFFFFF);
-    // Adjust for negative multiplier
-    if(furi_hal_subghz_get_rolling_counter_mult() < 0) {
-        multicntr = furi_hal_subghz_get_rolling_counter_mult();
-    }
-    if(multicntr == 1) {
-        multicntr = 2; // to keep old behaviour when mult = 1
-    }
+
     // Check for OFEX (overflow experimental) mode
     if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-        if((furi_hal_subghz_get_rolling_counter_mult() == (int32_t)0xFFFFFFF) & (rolling != 0)) {
-            rolling = 0;
-        } else {
-            // if cnt was reset to 0 on previous step and user want new Cnt then set it to 0xE6000000 or 0xFFFFFFFF or new user value
-            if(rolling == 0) {
-                if((furi_hal_subghz_get_rolling_counter_mult()) < (int32_t)0x6000000) {
-                    rolling = 0xE6000000;
-                } else {
-                    if((furi_hal_subghz_get_rolling_counter_mult()) >= (int32_t)0xFFFFFFF) {
-                        rolling = 0xFFFFFFFF;
-                    } else {
-                        rolling = 0xE0000000;
-                        rolling += multicntr;
-                    }
-                }
+        // standart counter mode. PULL data from subghz_block_generic_global variables
+        if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+            // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+            // so we increase counter by standart mult value
+            if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) >
+               0xFFFFFFF) {
+                subghz_block_generic.cnt = 0xE6000000;
             } else {
-                // if we have not special cases - so work as standart mode
-                if((rolling + multicntr) > 0xFFFFFFFF) {
-                    rolling = 0xE6000000;
-                } else {
-                    rolling += multicntr;
-                }
+                subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
             }
+        } else {
+            if(subghz_block_generic.cnt < 0xE6000000) subghz_block_generic.cnt = 0xE6000000;
         }
+
     } else {
         // OFEX (overflow experimental) mode
         if((rolling + 0x1) > 0xFFFFFFFF) {
@@ -269,8 +247,8 @@ static bool subghz_protocol_secplus_v1_encode(SubGhzProtocolEncoderSecPlus_v1* i
     }
 
     //update data
-    instance->generic.data &= 0xFFFFFFFF00000000;
-    instance->generic.data |= rolling;
+    subghz_block_generic.data &= 0xFFFFFFFF00000000;
+    subghz_block_generic.data |= rolling;
 
     if(fixed > 0xCFD41B90) {
         FURI_LOG_E(TAG, "Encode wrong fixed data");
@@ -313,10 +291,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_secplus_v1_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderSecPlus_v1* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             2 * subghz_protocol_secplus_v1_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -338,7 +317,7 @@ SubGhzProtocolStatus
 
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> (i * 8)) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> (i * 8)) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -379,7 +358,7 @@ void* subghz_protocol_decoder_secplus_v1_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderSecPlus_v1* instance = malloc(sizeof(SubGhzProtocolDecoderSecPlus_v1));
     instance->base.protocol = &subghz_protocol_secplus_v1;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     return instance;
 }
@@ -431,9 +410,9 @@ static void subghz_protocol_secplus_v1_decode(SubGhzProtocolDecoderSecPlus_v1* i
     }
 
     rolling = subghz_protocol_blocks_reverse_key(rolling, 32);
-    instance->generic.data = (uint64_t)fixed << 32 | rolling;
+    subghz_block_generic.data = (uint64_t)fixed << 32 | rolling;
 
-    instance->generic.data_count_bit =
+    subghz_block_generic.data_count_bit =
         subghz_protocol_secplus_v1_const.min_count_bit_for_found * 2;
 }
 
@@ -568,15 +547,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_secplus_v1_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderSecPlus_v1* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_secplus_v1_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderSecPlus_v1* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         2 * subghz_protocol_secplus_v1_const.min_count_bit_for_found);
 }
@@ -596,31 +580,37 @@ bool subghz_protocol_secplus_v1_check_fixed(uint32_t fixed) {
 void subghz_protocol_decoder_secplus_v1_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderSecPlus_v1* instance = context;
+    UNUSED(instance);
 
-    uint32_t fixed = (instance->generic.data >> 32) & 0xFFFFFFFF;
-    instance->generic.cnt = instance->generic.data & 0xFFFFFFFF;
+    uint32_t fixed = (subghz_block_generic.data >> 32) & 0xFFFFFFFF;
+    subghz_block_generic.cnt = subghz_block_generic.data & 0xFFFFFFFF;
 
-    instance->generic.btn = fixed % 3;
+    subghz_block_generic.btn = fixed % 3;
     uint8_t id0 = (fixed / 3) % 3;
     uint8_t id1 = (fixed / 9) % 3;
     uint16_t pin = 0;
+
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = true;
+    subghz_block_generic.cnt_lenght_bit = 32;
+    //
 
     furi_string_cat_printf(
         output,
         "%s %db\r\n"
         "Key:%lX%08lX\r\n"
         "id1:%d id0:%d",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32),
-        (uint32_t)instance->generic.data,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32),
+        (uint32_t)subghz_block_generic.data,
         id1,
         id0);
 
     if(id1 == 0) {
         // (fixed // 3**3) % (3**7)    3^3=27  3^73=72187
 
-        instance->generic.serial = (fixed / 27) % 2187;
+        subghz_block_generic.serial = (fixed / 27) % 2187;
         // pin = (fixed // 3**10) % (3**9)  3^10=59049 3^9=19683
         pin = (fixed / 59049) % 19683;
 
@@ -647,17 +637,17 @@ void subghz_protocol_decoder_secplus_v1_get_string(void* context, FuriString* ou
             "Sn:0x%08lX\r\n"
             "Cnt:%08lX "
             "SwID:0x%X\r\n",
-            instance->generic.serial,
-            instance->generic.cnt,
-            instance->generic.btn);
+            subghz_block_generic.serial,
+            subghz_block_generic.cnt,
+            subghz_block_generic.btn);
     } else {
         //id = fixed / 27;
-        instance->generic.serial = fixed / 27;
-        if(instance->generic.btn == 1) {
+        subghz_block_generic.serial = fixed / 27;
+        if(subghz_block_generic.btn == 1) {
             furi_string_cat_printf(output, " Btn:left\r\n");
-        } else if(instance->generic.btn == 0) {
+        } else if(subghz_block_generic.btn == 0) {
             furi_string_cat_printf(output, " Btn:middle\r\n");
-        } else if(instance->generic.btn == 2) { //-V547
+        } else if(subghz_block_generic.btn == 2) { //-V547
             furi_string_cat_printf(output, " Btn:right\r\n");
         }
 
@@ -666,8 +656,8 @@ void subghz_protocol_decoder_secplus_v1_get_string(void* context, FuriString* ou
             "Sn:0x%08lX\r\n"
             "Cnt:%08lX "
             "SwID:0x%X\r\n",
-            instance->generic.serial,
-            instance->generic.cnt,
-            instance->generic.btn);
+            subghz_block_generic.serial,
+            subghz_block_generic.cnt,
+            subghz_block_generic.btn);
     }
 }

--- a/lib/subghz/protocols/secplus_v2.c
+++ b/lib/subghz/protocols/secplus_v2.c
@@ -34,7 +34,6 @@ struct SubGhzProtocolDecoderSecPlus_v2 {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 
     ManchesterState manchester_saved_state;
     uint64_t secplus_packet_1;
@@ -44,7 +43,7 @@ struct SubGhzProtocolEncoderSecPlus_v2 {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+
     uint64_t secplus_packet_1;
 };
 
@@ -90,7 +89,7 @@ void* subghz_protocol_encoder_secplus_v2_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderSecPlus_v2* instance = malloc(sizeof(SubGhzProtocolEncoderSecPlus_v2));
 
     instance->base.protocol = &subghz_protocol_secplus_v2;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 256;
@@ -390,64 +389,46 @@ static uint8_t subghz_protocol_secplus_v2_get_btn_code(void);
 static void subghz_protocol_secplus_v2_encode(SubGhzProtocolEncoderSecPlus_v2* instance) {
     // Save original button for later use
     if(subghz_custom_btn_get_original() == 0) {
-        subghz_custom_btn_set_original(instance->generic.btn);
+        subghz_custom_btn_set_original(subghz_block_generic.btn);
     }
 
-    instance->generic.btn = subghz_protocol_secplus_v2_get_btn_code();
+    subghz_block_generic.btn = subghz_protocol_secplus_v2_get_btn_code();
 
-    uint32_t fixed_1[1] = {instance->generic.btn << 12 | instance->generic.serial >> 20};
-    uint32_t fixed_2[1] = {instance->generic.serial & 0xFFFFF};
+    uint32_t fixed_1[1] = {subghz_block_generic.btn << 12 | subghz_block_generic.serial >> 20};
+    uint32_t fixed_2[1] = {subghz_block_generic.serial & 0xFFFFF};
     uint8_t rolling_digits[18] = {0};
     uint8_t roll_1[9] = {0};
     uint8_t roll_2[9] = {0};
 
     // Experemental case - we dont know counter size exactly, so just will be think that it is in range of 0xE500000 - 0xFFFFFFF
-    // one case when we have mult = 0xFFFFFFFF  - its when we reset counter before applying new cnt value
-    // so at first step we reset cnt to 0 and now we sure here will be second step (set new cnt value);
-    // at second step check what user set for new Cnt (and correct it if cnt less than 0xE500000 or more than 0xFFFFFFF)
-    int32_t multicntr = (furi_hal_subghz_get_rolling_counter_mult() & 0xFFFFFFF);
-    // Adjust for negative multiplier
-    if(furi_hal_subghz_get_rolling_counter_mult() < 0) {
-        multicntr = furi_hal_subghz_get_rolling_counter_mult();
-    }
     // Check for OFEX (overflow experimental) mode
     if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-        if((furi_hal_subghz_get_rolling_counter_mult() == (int32_t)0xFFFFFFF) &
-           (instance->generic.cnt != 0)) {
-            instance->generic.cnt = 0;
-        } else {
-            // if cnt was reset to 0 on previous step and user want new Cnt then set it to 0xE500000 or 0xFFFFFFF or new user value
-            if(instance->generic.cnt == 0) {
-                if(furi_hal_subghz_get_rolling_counter_mult() < (int32_t)0xE500000) {
-                    instance->generic.cnt = 0xE500000;
-                } else {
-                    if(furi_hal_subghz_get_rolling_counter_mult() >= (int32_t)0xFFFFFFF) {
-                        instance->generic.cnt = 0xFFFFFFF;
-                    } else {
-                        instance->generic.cnt += multicntr;
-                    }
-                }
+        // standart counter mode. PULL data from subghz_block_generic_global variables
+        if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+            // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+            // so we increase counter by standart mult value
+            if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) >
+               0xFFFFFFF) {
+                subghz_block_generic.cnt = 0xE5000000;
             } else {
-                // if we have not special cases - so work as standart mode
-                if((instance->generic.cnt + multicntr) > 0xFFFFFFF) {
-                    instance->generic.cnt = 0xE500000;
-                } else {
-                    instance->generic.cnt += multicntr;
-                }
+                subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
             }
+        } else {
+            if(subghz_block_generic.cnt < 0xE5000000) subghz_block_generic.cnt = 0xE5000000;
         }
+
     } else {
         // OFEX (overflow experimental) mode
-        if((instance->generic.cnt + 0x1) > 0xFFFFFFF) {
-            instance->generic.cnt = 0xE500000;
-        } else if(instance->generic.cnt >= 0xE500000 && instance->generic.cnt != 0xFFFFFFE) {
-            instance->generic.cnt = 0xFFFFFFE;
+        if((subghz_block_generic.cnt + 0x1) > 0xFFFFFFF) {
+            subghz_block_generic.cnt = 0xE500000;
+        } else if(subghz_block_generic.cnt >= 0xE500000 && subghz_block_generic.cnt != 0xFFFFFFE) {
+            subghz_block_generic.cnt = 0xFFFFFFE;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     }
 
-    uint32_t rolling = subghz_protocol_blocks_reverse_key(instance->generic.cnt, 28);
+    uint32_t rolling = subghz_protocol_blocks_reverse_key(subghz_block_generic.cnt, 28);
 
     for(int8_t i = 17; i > -1; i--) {
         rolling_digits[i] = rolling % 3;
@@ -479,8 +460,8 @@ static void subghz_protocol_secplus_v2_encode(SubGhzProtocolEncoderSecPlus_v2* i
 
     instance->secplus_packet_1 = SECPLUS_V2_HEADER | SECPLUS_V2_PACKET_1 |
                                  subghz_protocol_secplus_v2_encode_half(roll_1, fixed_1[0]);
-    instance->generic.data = SECPLUS_V2_HEADER | SECPLUS_V2_PACKET_2 |
-                             subghz_protocol_secplus_v2_encode_half(roll_2, fixed_2[0]);
+    subghz_block_generic.data = SECPLUS_V2_HEADER | SECPLUS_V2_PACKET_2 |
+                                subghz_protocol_secplus_v2_encode_half(roll_2, fixed_2[0]);
 }
 
 static LevelDuration
@@ -525,7 +506,7 @@ static void
     ManchesterEncoderResult result;
 
     //Send data packet 1
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
         if(!manchester_encoder_advance(
                &enc_state, bit_read(instance->secplus_packet_1, i - 1), &result)) {
             instance->encoder.upload[index++] =
@@ -546,13 +527,13 @@ static void
 
     //Send data packet 2
     manchester_encoder_reset(&enc_state);
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
         if(!manchester_encoder_advance(
-               &enc_state, bit_read(instance->generic.data, i - 1), &result)) {
+               &enc_state, bit_read(subghz_block_generic.data, i - 1), &result)) {
             instance->encoder.upload[index++] =
                 subghz_protocol_encoder_secplus_v2_add_duration_to_upload(result);
             manchester_encoder_advance(
-                &enc_state, bit_read(instance->generic.data, i - 1), &result);
+                &enc_state, bit_read(subghz_block_generic.data, i - 1), &result);
         }
         instance->encoder.upload[index++] =
             subghz_protocol_encoder_secplus_v2_add_duration_to_upload(result);
@@ -572,10 +553,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_secplus_v2_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderSecPlus_v2* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_secplus_v2_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -593,7 +575,7 @@ SubGhzProtocolStatus
         }
 
         subghz_protocol_secplus_v2_remote_controller(
-            &instance->generic, instance->secplus_packet_1);
+            &subghz_block_generic, instance->secplus_packet_1);
         subghz_protocol_secplus_v2_encode(instance);
         //optional parameter parameter
         flipper_format_read_uint32(
@@ -602,7 +584,7 @@ SubGhzProtocolStatus
 
         //update data
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> (i * 8)) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> (i * 8)) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -661,14 +643,14 @@ bool subghz_protocol_secplus_v2_create_data(
     furi_check(context);
 
     SubGhzProtocolEncoderSecPlus_v2* instance = context;
-    instance->generic.serial = serial;
-    instance->generic.cnt = cnt;
-    instance->generic.btn = btn;
-    instance->generic.data_count_bit =
+    subghz_block_generic.serial = serial;
+    subghz_block_generic.cnt = cnt;
+    subghz_block_generic.btn = btn;
+    subghz_block_generic.data_count_bit =
         (uint8_t)subghz_protocol_secplus_v2_const.min_count_bit_for_found;
     subghz_protocol_secplus_v2_encode(instance);
     SubGhzProtocolStatus res =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 
     uint8_t key_data[sizeof(uint64_t)] = {0};
     for(size_t i = 0; i < sizeof(uint64_t); i++) {
@@ -687,7 +669,7 @@ void* subghz_protocol_decoder_secplus_v2_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderSecPlus_v2* instance = malloc(sizeof(SubGhzProtocolDecoderSecPlus_v2));
     instance->base.protocol = &subghz_protocol_secplus_v2;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     return instance;
 }
@@ -762,8 +744,8 @@ void subghz_protocol_decoder_secplus_v2_feed(void* context, bool level, uint32_t
                              subghz_protocol_secplus_v2_const.te_delta)) {
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_secplus_v2_const.min_count_bit_for_found) {
-                    instance->generic.data = instance->decoder.decode_data;
-                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    subghz_block_generic.data = instance->decoder.decode_data;
+                    subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
                     if(subghz_protocol_secplus_v2_check_packet(instance)) {
                         if(instance->base.callback)
                             instance->base.callback(&instance->base, instance->base.context);
@@ -830,7 +812,7 @@ SubGhzProtocolStatus subghz_protocol_decoder_secplus_v2_serialize(
     furi_assert(context);
     SubGhzProtocolDecoderSecPlus_v2* instance = context;
     SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 
     uint8_t key_data[sizeof(uint64_t)] = {0};
     for(size_t i = 0; i < sizeof(uint64_t); i++) {
@@ -849,10 +831,14 @@ SubGhzProtocolStatus
     subghz_protocol_decoder_secplus_v2_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderSecPlus_v2* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_secplus_v2_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -979,7 +965,13 @@ static uint8_t subghz_protocol_secplus_v2_get_btn_code(void) {
 void subghz_protocol_decoder_secplus_v2_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderSecPlus_v2* instance = context;
-    subghz_protocol_secplus_v2_remote_controller(&instance->generic, instance->secplus_packet_1);
+    subghz_protocol_secplus_v2_remote_controller(
+        &subghz_block_generic, instance->secplus_packet_1);
+
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = true;
+    subghz_block_generic.cnt_lenght_bit = 28;
+    //
 
     // need to research or practice check how much bits in counter
     furi_string_cat_printf(
@@ -990,13 +982,13 @@ void subghz_protocol_decoder_secplus_v2_get_string(void* context, FuriString* ou
         "Sn:0x%08lX  Btn:0x%01X\r\n"
         "Cnt:%07lX\r\n",
 
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         (uint32_t)(instance->secplus_packet_1 >> 32),
         (uint32_t)instance->secplus_packet_1,
-        (uint32_t)(instance->generic.data >> 32),
-        (uint32_t)instance->generic.data,
-        instance->generic.serial,
-        instance->generic.btn,
-        instance->generic.cnt);
+        (uint32_t)(subghz_block_generic.data >> 32),
+        (uint32_t)subghz_block_generic.data,
+        subghz_block_generic.serial,
+        subghz_block_generic.btn,
+        subghz_block_generic.cnt);
 }

--- a/lib/subghz/protocols/smc5326.c
+++ b/lib/subghz/protocols/smc5326.c
@@ -40,7 +40,7 @@ struct SubGhzProtocolDecoderSMC5326 {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint32_t te;
     uint32_t last_data;
@@ -50,7 +50,7 @@ struct SubGhzProtocolEncoderSMC5326 {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
+    
 
     uint32_t te;
 };
@@ -99,7 +99,7 @@ void* subghz_protocol_encoder_smc5326_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderSMC5326* instance = malloc(sizeof(SubGhzProtocolEncoderSMC5326));
 
     instance->base.protocol = &subghz_protocol_smc5326;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 128;
@@ -124,7 +124,7 @@ static bool subghz_protocol_encoder_smc5326_get_upload(SubGhzProtocolEncoderSMC5
     furi_assert(instance);
 
     size_t index = 0;
-    size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
+    size_t size_upload = (subghz_block_generic.data_count_bit * 2) + 2;
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -133,8 +133,8 @@ static bool subghz_protocol_encoder_smc5326_get_upload(SubGhzProtocolEncoderSMC5
     }
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)instance->te * 3);
@@ -159,10 +159,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_smc5326_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolEncoderSMC5326* instance = context;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_smc5326_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -219,7 +220,7 @@ void* subghz_protocol_decoder_smc5326_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolDecoderSMC5326* instance = malloc(sizeof(SubGhzProtocolDecoderSMC5326));
     instance->base.protocol = &subghz_protocol_smc5326;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     return instance;
 }
 
@@ -269,8 +270,8 @@ void subghz_protocol_decoder_smc5326_feed(void* context, bool level, uint32_t du
                        instance->last_data) {
                         instance->te /= (instance->decoder.decode_count_bit * 4 + 1);
 
-                        instance->generic.data = instance->decoder.decode_data;
-                        instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                        subghz_block_generic.data = instance->decoder.decode_data;
+                        subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                         if(instance->base.callback)
                             instance->base.callback(&instance->base, instance->base.context);
@@ -322,7 +323,7 @@ SubGhzProtocolStatus subghz_protocol_decoder_smc5326_serialize(
     furi_assert(context);
     SubGhzProtocolDecoderSMC5326* instance = context;
     SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
     if((ret == SubGhzProtocolStatusOk) &&
        !flipper_format_write_uint32(flipper_format, "TE", &instance->te, 1)) {
         FURI_LOG_E(TAG, "Unable to add TE");
@@ -335,10 +336,14 @@ SubGhzProtocolStatus
     subghz_protocol_decoder_smc5326_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderSMC5326* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_smc5326_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -372,7 +377,7 @@ static void subghz_protocol_smc5326_get_event_serialize(uint8_t event, FuriStrin
 void subghz_protocol_decoder_smc5326_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderSMC5326* instance = context;
-    uint32_t data = (uint32_t)((instance->generic.data >> 9) & 0xFFFF);
+    uint32_t data = (uint32_t)((subghz_block_generic.data >> 9) & 0xFFFF);
 
     furi_string_cat_printf(
         output,
@@ -380,12 +385,12 @@ void subghz_protocol_decoder_smc5326_get_string(void* context, FuriString* outpu
         "Key:%07lX         Te:%luus\r\n"
         "  +:   " DIP_PATTERN "\r\n"
         "  o:   " DIP_PATTERN "    ",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data & 0x1FFFFFF),
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data & 0x1FFFFFF),
         instance->te,
         SHOW_DIP_P(data, DIP_P),
         SHOW_DIP_P(data, DIP_O));
-    subghz_protocol_smc5326_get_event_serialize(instance->generic.data >> 1, output);
+    subghz_protocol_smc5326_get_event_serialize(subghz_block_generic.data >> 1, output);
     furi_string_cat_printf(output, "  -:   " DIP_PATTERN "\r\n", SHOW_DIP_P(data, DIP_N));
 }

--- a/lib/subghz/protocols/somfy_keytis.c
+++ b/lib/subghz/protocols/somfy_keytis.c
@@ -20,7 +20,6 @@ struct SubGhzProtocolDecoderSomfyKeytis {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 
     uint16_t header_count;
     ManchesterState manchester_saved_state;
@@ -31,7 +30,6 @@ struct SubGhzProtocolEncoderSomfyKeytis {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -79,7 +77,7 @@ void* subghz_protocol_encoder_somfy_keytis_alloc(SubGhzEnvironment* environment)
     SubGhzProtocolEncoderSomfyKeytis* instance = malloc(sizeof(SubGhzProtocolEncoderSomfyKeytis));
 
     instance->base.protocol = &subghz_protocol_somfy_keytis;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 512;
@@ -93,7 +91,7 @@ void* subghz_protocol_decoder_somfy_keytis_alloc(SubGhzEnvironment* environment)
     UNUSED(environment);
     SubGhzProtocolDecoderSomfyKeytis* instance = malloc(sizeof(SubGhzProtocolDecoderSomfyKeytis));
     instance->base.protocol = &subghz_protocol_somfy_keytis;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     return instance;
 }
@@ -125,36 +123,44 @@ void subghz_protocol_decoder_somfy_keytis_reset(void* context) {
 static bool
     subghz_protocol_somfy_keytis_gen_data(SubGhzProtocolEncoderSomfyKeytis* instance, uint8_t btn) {
     UNUSED(btn);
-    uint64_t data = instance->generic.data ^ (instance->generic.data >> 8);
-    instance->generic.btn = (data >> 48) & 0xF;
-    instance->generic.cnt = (data >> 24) & 0xFFFF;
-    instance->generic.serial = data & 0xFFFFFF;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+    uint64_t data = subghz_block_generic.data ^ (subghz_block_generic.data >> 8);
+    subghz_block_generic.btn = (data >> 48) & 0xF;
+    subghz_block_generic.cnt = (data >> 24) & 0xFFFF;
+    subghz_block_generic.serial = data & 0xFFFFFF;
 
     // Check for OFEX (overflow experimental) mode
     if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-        if((instance->generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else {
-            instance->generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+        // standart counter mode. PULL data from subghz_block_generic_global variables
+        if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+            // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+            // so we increase counter by standart mult value
+            if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
+                subghz_block_generic.cnt = 0;
+            } else {
+                subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+            }
         }
+
     } else {
-        if((instance->generic.cnt + 0x1) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-            instance->generic.cnt = 0xFFFE;
+        //OFFEX mode
+        if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+            subghz_block_generic.cnt = 0;
+        } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+            subghz_block_generic.cnt = 0xFFFE;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     }
 
     uint8_t frame[10];
-    frame[0] = (0xA << 4) | instance->generic.btn;
+    frame[0] = (0xA << 4) | subghz_block_generic.btn;
     frame[1] = 0xF << 4;
-    frame[2] = instance->generic.cnt >> 8;
-    frame[3] = instance->generic.cnt;
-    frame[4] = instance->generic.serial >> 16;
-    frame[5] = instance->generic.serial >> 8;
-    frame[6] = instance->generic.serial;
+    frame[2] = subghz_block_generic.cnt >> 8;
+    frame[3] = subghz_block_generic.cnt;
+    frame[4] = subghz_block_generic.serial >> 16;
+    frame[5] = subghz_block_generic.serial >> 8;
+    frame[6] = subghz_block_generic.serial;
     frame[7] = 0xC4;
     frame[8] = 0x00;
     frame[9] = 0x19;
@@ -175,13 +181,13 @@ static bool
         data <<= 8;
         data |= frame[i];
     }
-    instance->generic.data = data;
+    subghz_block_generic.data = data;
     data = 0;
     for(uint8_t i = 7; i < 10; ++i) {
         data <<= 8;
         data |= frame[i];
     }
-    instance->generic.data_2 = data;
+    subghz_block_generic.data_2 = data;
     return true;
 }
 
@@ -194,13 +200,13 @@ bool subghz_protocol_somfy_keytis_create_data(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolEncoderSomfyKeytis* instance = context;
-    instance->generic.serial = serial;
-    instance->generic.cnt = cnt;
-    instance->generic.data_count_bit = 80;
+    subghz_block_generic.serial = serial;
+    subghz_block_generic.cnt = cnt;
+    subghz_block_generic.data_count_bit = 80;
     bool res = subghz_protocol_somfy_keytis_gen_data(instance, btn);
     if(res) {
         return SubGhzProtocolStatusOk ==
-               subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+               subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
     }
     return res;
 }
@@ -240,8 +246,8 @@ static bool subghz_protocol_encoder_somfy_keytis_get_upload(
 
     //Send key data MSB manchester
 
-    for(uint8_t i = instance->generic.data_count_bit - 24; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit - 24; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             if(instance->encoder.upload[index - 1].level == LEVEL_DURATION_LEVEL_LOW) {
                 instance->encoder.upload[index - 1].duration *= 2; // 00
                 instance->encoder.upload[index++] = level_duration_make(
@@ -268,7 +274,7 @@ static bool subghz_protocol_encoder_somfy_keytis_get_upload(
     }
 
     for(uint8_t i = 24; i > 0; i--) {
-        if(bit_read(instance->generic.data_2, i - 1)) {
+        if(bit_read(subghz_block_generic.data_2, i - 1)) {
             if(instance->encoder.upload[index - 1].level == LEVEL_DURATION_LEVEL_LOW) {
                 instance->encoder.upload[index - 1].duration *= 2; // 00
                 instance->encoder.upload[index++] = level_duration_make(
@@ -318,8 +324,8 @@ static bool subghz_protocol_encoder_somfy_keytis_get_upload(
 
         //Send key data MSB manchester
 
-        for(uint8_t i = instance->generic.data_count_bit - 24; i > 0; i--) {
-            if(bit_read(instance->generic.data, i - 1)) {
+        for(uint8_t i = subghz_block_generic.data_count_bit - 24; i > 0; i--) {
+            if(bit_read(subghz_block_generic.data, i - 1)) {
                 if(instance->encoder.upload[index - 1].level == LEVEL_DURATION_LEVEL_LOW) {
                     instance->encoder.upload[index - 1].duration *= 2; // 00
                     instance->encoder.upload[index++] = level_duration_make(
@@ -346,7 +352,7 @@ static bool subghz_protocol_encoder_somfy_keytis_get_upload(
         }
 
         for(uint8_t i = 24; i > 0; i--) {
-            if(bit_read(instance->generic.data_2, i - 1)) {
+            if(bit_read(subghz_block_generic.data_2, i - 1)) {
                 if(instance->encoder.upload[index - 1].level == LEVEL_DURATION_LEVEL_LOW) {
                     instance->encoder.upload[index - 1].duration *= 2; // 00
                     instance->encoder.upload[index++] = level_duration_make(
@@ -403,7 +409,7 @@ SubGhzProtocolStatus
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
@@ -412,7 +418,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_encoder_somfy_keytis_get_upload(instance, instance->generic.btn);
+        subghz_protocol_encoder_somfy_keytis_get_upload(instance, subghz_block_generic.btn);
 
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
@@ -420,7 +426,7 @@ SubGhzProtocolStatus
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -538,10 +544,11 @@ void subghz_protocol_decoder_somfy_keytis_feed(void* context, bool level, uint32
                 if(instance->decoder.decode_count_bit ==
                    subghz_protocol_somfy_keytis_const.min_count_bit_for_found) {
                     //check crc
-                    uint64_t data_tmp = instance->generic.data ^ (instance->generic.data >> 8);
+                    uint64_t data_tmp = subghz_block_generic.data ^
+                                        (subghz_block_generic.data >> 8);
                     if(((data_tmp >> 40) & 0xF) == subghz_protocol_somfy_keytis_crc(data_tmp)) {
-                        instance->generic.data = instance->decoder.decode_data;
-                        instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                        subghz_block_generic.data = instance->decoder.decode_data;
+                        subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                         if(instance->base.callback)
                             instance->base.callback(&instance->base, instance->base.context);
@@ -744,7 +751,7 @@ SubGhzProtocolStatus subghz_protocol_decoder_somfy_keytis_serialize(
     furi_assert(context);
     SubGhzProtocolDecoderSomfyKeytis* instance = context;
     SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
     if((ret == SubGhzProtocolStatusOk) &&
        !flipper_format_write_uint32(
            flipper_format, "Duration_Counter", &instance->press_duration_counter, 1)) {
@@ -758,10 +765,14 @@ SubGhzProtocolStatus
     subghz_protocol_decoder_somfy_keytis_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderSomfyKeytis* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
     do {
         ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
+            &subghz_block_generic,
             flipper_format,
             subghz_protocol_somfy_keytis_const.min_count_bit_for_found);
         if(ret != SubGhzProtocolStatusOk) {
@@ -790,7 +801,12 @@ void subghz_protocol_decoder_somfy_keytis_get_string(void* context, FuriString* 
     furi_assert(context);
     SubGhzProtocolDecoderSomfyKeytis* instance = context;
 
-    subghz_protocol_somfy_keytis_check_remote_controller(&instance->generic);
+    subghz_protocol_somfy_keytis_check_remote_controller(&subghz_block_generic);
+
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = true;
+    subghz_block_generic.cnt_lenght_bit = 16;
+    //
 
     furi_string_cat_printf(
         output,
@@ -800,12 +816,12 @@ void subghz_protocol_decoder_somfy_keytis_get_string(void* context, FuriString* 
         "Cnt:%04lX\r\n"
         "Btn:%s\r\n",
 
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32),
-        (uint32_t)instance->generic.data,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32),
+        (uint32_t)subghz_block_generic.data,
         instance->press_duration_counter,
-        instance->generic.serial,
-        instance->generic.cnt,
-        subghz_protocol_somfy_keytis_get_name_button(instance->generic.btn));
+        subghz_block_generic.serial,
+        subghz_block_generic.cnt,
+        subghz_protocol_somfy_keytis_get_name_button(subghz_block_generic.btn));
 }

--- a/lib/subghz/protocols/somfy_telis.c
+++ b/lib/subghz/protocols/somfy_telis.c
@@ -22,7 +22,6 @@ struct SubGhzProtocolDecoderSomfyTelis {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 
     uint16_t header_count;
     ManchesterState manchester_saved_state;
@@ -32,7 +31,6 @@ struct SubGhzProtocolEncoderSomfyTelis {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 };
 
 typedef enum {
@@ -80,7 +78,7 @@ void* subghz_protocol_encoder_somfy_telis_alloc(SubGhzEnvironment* environment) 
     SubGhzProtocolEncoderSomfyTelis* instance = malloc(sizeof(SubGhzProtocolEncoderSomfyTelis));
 
     instance->base.protocol = &subghz_protocol_somfy_telis;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->encoder.repeat = 10;
     instance->encoder.size_upload = 512;
@@ -108,13 +106,14 @@ static bool subghz_protocol_somfy_telis_gen_data(
     SubGhzProtocolEncoderSomfyTelis* instance,
     uint8_t btn,
     bool new_remote) {
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     // If we doing a clone we will use its data
-    uint64_t data = instance->generic.data ^ (instance->generic.data >> 8);
+    uint64_t data = subghz_block_generic.data ^ (subghz_block_generic.data >> 8);
     if(!new_remote) {
-        instance->generic.btn = (data >> 44) & 0xF; // ctrl
-        btn = instance->generic.btn;
-        instance->generic.cnt = (data >> 24) & 0xFFFF; // rolling code
-        instance->generic.serial = data & 0xFFFFFF; // address
+        subghz_block_generic.btn = (data >> 44) & 0xF; // ctrl
+        btn = subghz_block_generic.btn;
+        subghz_block_generic.cnt = (data >> 24) & 0xFFFF; // rolling code
+        subghz_block_generic.serial = data & 0xFFFFFF; // address
     }
 
     // Save original button for later use
@@ -126,18 +125,25 @@ static bool subghz_protocol_somfy_telis_gen_data(
 
     // Check for OFEX (overflow experimental) mode
     if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-        if((instance->generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else {
-            instance->generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+        // standart counter mode. PULL data from subghz_block_generic_global variables
+        if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+            // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+            // so we increase counter by standart mult value
+            if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
+                subghz_block_generic.cnt = 0;
+            } else {
+                subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+            }
         }
+
     } else {
-        if((instance->generic.cnt + 0x1) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-            instance->generic.cnt = 0xFFFE;
+        //OFFEX mode
+        if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+            subghz_block_generic.cnt = 0;
+        } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+            subghz_block_generic.cnt = 0xFFFE;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     }
 
@@ -148,11 +154,11 @@ static bool subghz_protocol_somfy_telis_gen_data(
         frame[0] = 0xA7;
     }
     frame[1] = btn << 4;
-    frame[2] = instance->generic.cnt >> 8;
-    frame[3] = instance->generic.cnt;
-    frame[4] = instance->generic.serial >> 16;
-    frame[5] = instance->generic.serial >> 8;
-    frame[6] = instance->generic.serial;
+    frame[2] = subghz_block_generic.cnt >> 8;
+    frame[3] = subghz_block_generic.cnt;
+    frame[4] = subghz_block_generic.serial >> 16;
+    frame[5] = subghz_block_generic.serial >> 8;
+    frame[6] = subghz_block_generic.serial;
 
     uint8_t checksum = 0;
     for(uint8_t i = 0; i < 7; i++) {
@@ -170,7 +176,7 @@ static bool subghz_protocol_somfy_telis_gen_data(
         data <<= 8;
         data |= frame[i];
     }
-    instance->generic.data = data;
+    subghz_block_generic.data = data;
     return true;
 }
 
@@ -183,13 +189,13 @@ bool subghz_protocol_somfy_telis_create_data(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolEncoderSomfyTelis* instance = context;
-    instance->generic.serial = serial;
-    instance->generic.cnt = cnt;
-    instance->generic.data_count_bit = 56;
+    subghz_block_generic.serial = serial;
+    subghz_block_generic.cnt = cnt;
+    subghz_block_generic.data_count_bit = 56;
     bool res = subghz_protocol_somfy_telis_gen_data(instance, btn, true);
     if(res) {
         return SubGhzProtocolStatusOk ==
-               subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+               subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
     }
     return res;
 }
@@ -229,8 +235,8 @@ static bool subghz_protocol_encoder_somfy_telis_get_upload(
 
     //Send key data MSB manchester
 
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             if(instance->encoder.upload[index - 1].level == LEVEL_DURATION_LEVEL_LOW) {
                 instance->encoder.upload[index - 1].duration *= 2; // 00
                 instance->encoder.upload[index++] = level_duration_make(
@@ -279,8 +285,8 @@ static bool subghz_protocol_encoder_somfy_telis_get_upload(
 
         //Send key data MSB manchester
 
-        for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-            if(bit_read(instance->generic.data, i - 1)) {
+        for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+            if(bit_read(subghz_block_generic.data, i - 1)) {
                 if(instance->encoder.upload[index - 1].level == LEVEL_DURATION_LEVEL_LOW) {
                     instance->encoder.upload[index - 1].duration *= 2; // 00
                     instance->encoder.upload[index++] = level_duration_make(
@@ -332,7 +338,7 @@ SubGhzProtocolStatus
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
@@ -341,7 +347,7 @@ SubGhzProtocolStatus
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_encoder_somfy_telis_get_upload(instance, instance->generic.btn);
+        subghz_protocol_encoder_somfy_telis_get_upload(instance, subghz_block_generic.btn);
 
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
@@ -349,7 +355,7 @@ SubGhzProtocolStatus
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -391,7 +397,7 @@ void* subghz_protocol_decoder_somfy_telis_alloc(SubGhzEnvironment* environment) 
     UNUSED(environment);
     SubGhzProtocolDecoderSomfyTelis* instance = malloc(sizeof(SubGhzProtocolDecoderSomfyTelis));
     instance->base.protocol = &subghz_protocol_somfy_telis;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     return instance;
 }
@@ -496,8 +502,8 @@ void subghz_protocol_decoder_somfy_telis_feed(void* context, bool level, uint32_
                     uint64_t data_tmp = instance->decoder.decode_data ^
                                         (instance->decoder.decode_data >> 8);
                     if(((data_tmp >> 40) & 0xF) == subghz_protocol_somfy_telis_crc(data_tmp)) {
-                        instance->generic.data = instance->decoder.decode_data;
-                        instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                        subghz_block_generic.data = instance->decoder.decode_data;
+                        subghz_block_generic.data_count_bit = instance->decoder.decode_count_bit;
 
                         if(instance->base.callback)
                             instance->base.callback(&instance->base, instance->base.context);
@@ -662,15 +668,20 @@ SubGhzProtocolStatus subghz_protocol_decoder_somfy_telis_serialize(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolDecoderSomfyTelis* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    UNUSED(instance);
+    return subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_somfy_telis_deserialize(void* context, FlipperFormat* flipper_format) {
     furi_assert(context);
     SubGhzProtocolDecoderSomfyTelis* instance = context;
+
+    subghz_block_generic_reset(0);
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
+
     return subghz_block_generic_deserialize_check_count_bit(
-        &instance->generic,
+        &subghz_block_generic,
         flipper_format,
         subghz_protocol_somfy_telis_const.min_count_bit_for_found);
 }
@@ -746,8 +757,15 @@ static uint8_t subghz_protocol_somfy_telis_get_btn_code(void) {
 void subghz_protocol_decoder_somfy_telis_get_string(void* context, FuriString* output) {
     furi_assert(context);
     SubGhzProtocolDecoderSomfyTelis* instance = context;
+    UNUSED(instance);
 
-    subghz_protocol_somfy_telis_check_remote_controller(&instance->generic);
+    subghz_protocol_somfy_telis_check_remote_controller(&subghz_block_generic);
+
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = true;
+    subghz_block_generic.cnt_lenght_bit = 16;
+    //
+
     furi_string_cat_printf(
         output,
         "%s %db\r\n"
@@ -756,11 +774,11 @@ void subghz_protocol_decoder_somfy_telis_get_string(void* context, FuriString* o
         "Cnt:%04lX\r\n"
         "Btn:%s\r\n",
 
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
-        (uint32_t)(instance->generic.data >> 32),
-        (uint32_t)instance->generic.data,
-        instance->generic.serial,
-        instance->generic.cnt,
-        subghz_protocol_somfy_telis_get_name_button(instance->generic.btn));
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
+        (uint32_t)(subghz_block_generic.data >> 32),
+        (uint32_t)subghz_block_generic.data,
+        subghz_block_generic.serial,
+        subghz_block_generic.cnt,
+        subghz_protocol_somfy_telis_get_name_button(subghz_block_generic.btn));
 }

--- a/lib/subghz/protocols/star_line.c
+++ b/lib/subghz/protocols/star_line.c
@@ -25,7 +25,6 @@ struct SubGhzProtocolDecoderStarLine {
     SubGhzProtocolDecoderBase base;
 
     SubGhzBlockDecoder decoder;
-    SubGhzBlockGeneric generic;
 
     uint16_t header_count;
     SubGhzKeystore* keystore;
@@ -38,7 +37,6 @@ struct SubGhzProtocolEncoderStarLine {
     SubGhzProtocolEncoderBase base;
 
     SubGhzProtocolBlockEncoder encoder;
-    SubGhzBlockGeneric generic;
 
     SubGhzKeystore* keystore;
     const char* manufacture_name;
@@ -101,7 +99,7 @@ void* subghz_protocol_encoder_star_line_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolEncoderStarLine* instance = malloc(sizeof(SubGhzProtocolEncoderStarLine));
 
     instance->base.protocol = &subghz_protocol_star_line;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
     instance->keystore = subghz_environment_get_keystore(environment);
 
     instance->manufacture_from_file = furi_string_alloc();
@@ -131,22 +129,30 @@ static bool
     subghz_protocol_star_line_gen_data(SubGhzProtocolEncoderStarLine* instance, uint8_t btn) {
     // Check for OFEX (overflow experimental) mode
     if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
-        if((instance->generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else {
-            instance->generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+        // standart counter mode. PULL data from subghz_block_generic_global variables
+        if(!subghz_block_generic_counter_is_overrided(&subghz_block_generic.cnt)) {
+            // if subghz_block_generic_counter_is_overrided return FALSE then counter was not changed
+            // so we increase counter by standart mult value
+            if((subghz_block_generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFF) {
+                subghz_block_generic.cnt = 0;
+            } else {
+                subghz_block_generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+            }
         }
+
     } else {
-        if((instance->generic.cnt + 0x1) > 0xFFFF) {
-            instance->generic.cnt = 0;
-        } else if(instance->generic.cnt >= 0x1 && instance->generic.cnt != 0xFFFE) {
-            instance->generic.cnt = 0xFFFE;
+        //OFFEX mode
+        if((subghz_block_generic.cnt + 0x1) > 0xFFFF) {
+            subghz_block_generic.cnt = 0;
+        } else if(subghz_block_generic.cnt >= 0x1 && subghz_block_generic.cnt != 0xFFFE) {
+            subghz_block_generic.cnt = 0xFFFE;
         } else {
-            instance->generic.cnt++;
+            subghz_block_generic.cnt++;
         }
     }
-    uint32_t fix = btn << 24 | instance->generic.serial;
-    uint32_t decrypt = btn << 24 | (instance->generic.serial & 0xFF) << 16 | instance->generic.cnt;
+    uint32_t fix = btn << 24 | subghz_block_generic.serial;
+    uint32_t decrypt = btn << 24 | (subghz_block_generic.serial & 0xFF) << 16 |
+                       subghz_block_generic.cnt;
     uint32_t hop = 0;
     uint64_t man = 0;
     uint64_t code_found_reverse;
@@ -158,7 +164,7 @@ static bool
 
     if(strcmp(instance->manufacture_name, "Unknown") == 0) {
         code_found_reverse = subghz_protocol_blocks_reverse_key(
-            instance->generic.data, instance->generic.data_count_bit);
+            subghz_block_generic.data, subghz_block_generic.data_count_bit);
         hop = code_found_reverse & 0x00000000ffffffff;
     } else {
         uint8_t kl_type_en = instance->keystore->kl_type;
@@ -200,8 +206,8 @@ static bool
     }
     if(hop) {
         uint64_t yek = (uint64_t)fix << 32 | hop;
-        instance->generic.data =
-            subghz_protocol_blocks_reverse_key(yek, instance->generic.data_count_bit);
+        subghz_block_generic.data =
+            subghz_protocol_blocks_reverse_key(yek, subghz_block_generic.data_count_bit);
         return true;
     } else {
         instance->manufacture_name = "Unknown";
@@ -219,14 +225,14 @@ bool subghz_protocol_star_line_create_data(
     SubGhzRadioPreset* preset) {
     furi_assert(context);
     SubGhzProtocolEncoderStarLine* instance = context;
-    instance->generic.serial = serial;
-    instance->generic.cnt = cnt;
+    subghz_block_generic.serial = serial;
+    subghz_block_generic.cnt = cnt;
     instance->manufacture_name = manufacture_name;
-    instance->generic.data_count_bit = 64;
+    subghz_block_generic.data_count_bit = 64;
     bool res = subghz_protocol_star_line_gen_data(instance, btn);
     if(res) {
         return SubGhzProtocolStatusOk ==
-               subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+               subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
     }
     return res;
 }
@@ -247,7 +253,7 @@ static bool subghz_protocol_encoder_star_line_get_upload(
     }
 
     size_t index = 0;
-    size_t size_upload = 6 * 2 + (instance->generic.data_count_bit * 2);
+    size_t size_upload = 6 * 2 + (subghz_block_generic.data_count_bit * 2);
     if(size_upload > instance->encoder.size_upload) {
         FURI_LOG_E(TAG, "Size upload exceeds allocated encoder buffer.");
         return false;
@@ -264,8 +270,8 @@ static bool subghz_protocol_encoder_star_line_get_upload(
     }
 
     //Send key data
-    for(uint8_t i = instance->generic.data_count_bit; i > 0; i--) {
-        if(bit_read(instance->generic.data, i - 1)) {
+    for(uint8_t i = subghz_block_generic.data_count_bit; i > 0; i--) {
+        if(bit_read(subghz_block_generic.data, i - 1)) {
             //send bit 1
             instance->encoder.upload[index++] =
                 level_duration_make(true, (uint32_t)subghz_protocol_star_line_const.te_long);
@@ -290,7 +296,7 @@ SubGhzProtocolStatus
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
@@ -305,13 +311,13 @@ SubGhzProtocolStatus
         }
 
         subghz_protocol_star_line_check_remote_controller(
-            &instance->generic, instance->keystore, &instance->manufacture_name);
+            &subghz_block_generic, instance->keystore, &instance->manufacture_name);
 
         //optional parameter parameter
         flipper_format_read_uint32(
             flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
 
-        subghz_protocol_encoder_star_line_get_upload(instance, instance->generic.btn);
+        subghz_protocol_encoder_star_line_get_upload(instance, subghz_block_generic.btn);
 
         if(!flipper_format_rewind(flipper_format)) {
             FURI_LOG_E(TAG, "Rewind error");
@@ -319,7 +325,7 @@ SubGhzProtocolStatus
         }
         uint8_t key_data[sizeof(uint64_t)] = {0};
         for(size_t i = 0; i < sizeof(uint64_t); i++) {
-            key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data >> i * 8) & 0xFF;
+            key_data[sizeof(uint64_t) - i - 1] = (subghz_block_generic.data >> i * 8) & 0xFF;
         }
         if(!flipper_format_update_hex(flipper_format, "Key", key_data, sizeof(uint64_t))) {
             FURI_LOG_E(TAG, "Unable to add Key");
@@ -360,7 +366,7 @@ LevelDuration subghz_protocol_encoder_star_line_yield(void* context) {
 void* subghz_protocol_decoder_star_line_alloc(SubGhzEnvironment* environment) {
     SubGhzProtocolDecoderStarLine* instance = malloc(sizeof(SubGhzProtocolDecoderStarLine));
     instance->base.protocol = &subghz_protocol_star_line;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    subghz_block_generic.protocol_name = instance->base.protocol->name;
 
     instance->manufacture_from_file = furi_string_alloc();
 
@@ -426,9 +432,9 @@ void subghz_protocol_decoder_star_line_feed(void* context, bool level, uint32_t 
                     subghz_protocol_star_line_const.min_count_bit_for_found) &&
                    (instance->decoder.decode_count_bit <=
                     subghz_protocol_star_line_const.min_count_bit_for_found + 2)) {
-                    if(instance->generic.data != instance->decoder.decode_data) {
-                        instance->generic.data = instance->decoder.decode_data;
-                        instance->generic.data_count_bit =
+                    if(subghz_block_generic.data != instance->decoder.decode_data) {
+                        subghz_block_generic.data = instance->decoder.decode_data;
+                        subghz_block_generic.data_count_bit =
                             subghz_protocol_star_line_const.min_count_bit_for_found;
                         if(instance->base.callback)
                             instance->base.callback(&instance->base, instance->base.context);
@@ -658,9 +664,9 @@ SubGhzProtocolStatus subghz_protocol_decoder_star_line_serialize(
     furi_assert(context);
     SubGhzProtocolDecoderStarLine* instance = context;
     subghz_protocol_star_line_check_remote_controller(
-        &instance->generic, instance->keystore, &instance->manufacture_name);
+        &subghz_block_generic, instance->keystore, &instance->manufacture_name);
     SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+        subghz_block_generic_serialize(&subghz_block_generic, flipper_format, preset);
 
     if((ret == SubGhzProtocolStatusOk) &&
        !flipper_format_write_string_cstr(
@@ -669,7 +675,7 @@ SubGhzProtocolStatus subghz_protocol_decoder_star_line_serialize(
         ret = SubGhzProtocolStatusErrorParserOthers;
     }
     if((ret == SubGhzProtocolStatusOk) &&
-       instance->generic.data_count_bit !=
+       subghz_block_generic.data_count_bit !=
            subghz_protocol_star_line_const.min_count_bit_for_found) {
         FURI_LOG_E(TAG, "Wrong number of bits in key");
         ret = SubGhzProtocolStatusErrorParserOthers;
@@ -684,7 +690,7 @@ SubGhzProtocolStatus
     SubGhzProtocolStatus res = SubGhzProtocolStatusError;
     do {
         if(SubGhzProtocolStatusOk !=
-           subghz_block_generic_deserialize(&instance->generic, flipper_format)) {
+           subghz_block_generic_deserialize(&subghz_block_generic, flipper_format)) {
             FURI_LOG_E(TAG, "Deserialize error");
             break;
         }
@@ -709,15 +715,20 @@ void subghz_protocol_decoder_star_line_get_string(void* context, FuriString* out
     SubGhzProtocolDecoderStarLine* instance = context;
 
     subghz_protocol_star_line_check_remote_controller(
-        &instance->generic, instance->keystore, &instance->manufacture_name);
+        &subghz_block_generic, instance->keystore, &instance->manufacture_name);
 
-    uint32_t code_found_hi = instance->generic.data >> 32;
-    uint32_t code_found_lo = instance->generic.data & 0x00000000ffffffff;
+    uint32_t code_found_hi = subghz_block_generic.data >> 32;
+    uint32_t code_found_lo = subghz_block_generic.data & 0x00000000ffffffff;
 
     uint64_t code_found_reverse = subghz_protocol_blocks_reverse_key(
-        instance->generic.data, instance->generic.data_count_bit);
+        subghz_block_generic.data, subghz_block_generic.data_count_bit);
     uint32_t code_found_reverse_hi = code_found_reverse >> 32;
     uint32_t code_found_reverse_lo = code_found_reverse & 0x00000000ffffffff;
+
+    // push protocol data to global variable
+    subghz_block_generic.cnt_is_available = true;
+    subghz_block_generic.cnt_lenght_bit = 16;
+    //
 
     furi_string_cat_printf(
         output,
@@ -726,13 +737,13 @@ void subghz_protocol_decoder_star_line_get_string(void* context, FuriString* out
         "Fix:0x%08lX    Cnt:%04lX\r\n"
         "Hop:0x%08lX    Btn:%02X\r\n"
         "MF:%s\r\n",
-        instance->generic.protocol_name,
-        instance->generic.data_count_bit,
+        subghz_block_generic.protocol_name,
+        subghz_block_generic.data_count_bit,
         code_found_hi,
         code_found_lo,
         code_found_reverse_hi,
-        instance->generic.cnt,
+        subghz_block_generic.cnt,
         code_found_reverse_lo,
-        instance->generic.btn,
+        subghz_block_generic.btn,
         instance->manufacture_name);
 }

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,87.1,,
+Version,+,87.2,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -3561,9 +3561,12 @@ Function,-,strupr,char*,char*
 Function,-,strverscmp,int,"const char*, const char*"
 Function,-,strxfrm,size_t,"char*, const char*, size_t"
 Function,-,strxfrm_l,size_t,"char*, const char*, size_t, locale_t"
+Function,+,subghz_block_generic_counter_is_overrided,_Bool,uint32_t*
+Function,+,subghz_block_generic_counter_set_for_override,void,uint32_t
 Function,+,subghz_block_generic_deserialize,SubGhzProtocolStatus,"SubGhzBlockGeneric*, FlipperFormat*"
 Function,+,subghz_block_generic_deserialize_check_count_bit,SubGhzProtocolStatus,"SubGhzBlockGeneric*, FlipperFormat*, uint16_t"
 Function,+,subghz_block_generic_get_preset_name,void,"const char*, FuriString*"
+Function,+,subghz_block_generic_reset,void,void*
 Function,+,subghz_block_generic_serialize,SubGhzProtocolStatus,"SubGhzBlockGeneric*, FlipperFormat*, SubGhzRadioPreset*"
 Function,+,subghz_custom_btn_get,uint8_t,
 Function,+,subghz_custom_btn_get_original,uint8_t,
@@ -4273,6 +4276,7 @@ Variable,+,sequence_single_vibro,const NotificationSequence,
 Variable,+,sequence_solid_yellow,const NotificationSequence,
 Variable,+,sequence_success,const NotificationSequence,
 Variable,+,simple_array_config_uint8_t,const SimpleArrayConfig,
+Variable,+,subghz_block_generic,SubGhzBlockGeneric,
 Variable,-,subghz_device_cc1101_int,const SubGhzDevice,
 Variable,+,subghz_device_cc1101_preset_2fsk_dev2_38khz_async_regs,const uint8_t[],
 Variable,+,subghz_device_cc1101_preset_2fsk_dev47_6khz_async_regs,const uint8_t[],


### PR DESCRIPTION
1. Reduce memory usage from 2 x (number of protocols) x sizeof (subghz_generic) to 1 x  sizeof (subghz_generic) bytes. Transfer subghz_generic from protocols encoders/decoders outside to global variable structure - one global available variable to all protocols;

2. API to fast and simple push/pull some variable (counter) to subghz.

3. Rewrite subghz signal settings editor to new generic structure.
