### PR TITLE
Update furi_hal_nfc_iso15693.c

### DIFF
--- a/targets/f7/furi_hal/furi_hal_nfc_iso15693.c
+++ b/targets/f7/furi_hal/furi_hal_nfc_iso15693.c
@@ -8,6 +8,7 @@
 
 #define FURI_HAL_NFC_ISO15693_MAX_FRAME_SIZE         (1024U)
 #define FURI_HAL_NFC_ISO15693_POLLER_MAX_BUFFER_SIZE (64)
+#define FURI_HAL_NFC_ISO15693_BIT_LEN                (4)
 
 #define FURI_HAL_NFC_ISO15693_RESP_SOF_SIZE    (5)
 #define FURI_HAL_NFC_ISO15693_RESP_EOF_SIZE    (5)
@@ -34,9 +35,9 @@ typedef struct {
 
 typedef struct {
     // 4 bits per data bit on transmit
-    uint8_t fifo_buf[FURI_HAL_NFC_ISO15693_POLLER_MAX_BUFFER_SIZE * 4];
+    uint8_t fifo_buf[FURI_HAL_NFC_ISO15693_POLLER_MAX_BUFFER_SIZE * FURI_HAL_NFC_ISO15693_BIT_LEN];
     size_t fifo_buf_bits;
-    uint8_t frame_buf[FURI_HAL_NFC_ISO15693_POLLER_MAX_BUFFER_SIZE * 2];
+    uint8_t frame_buf[FURI_HAL_NFC_ISO15693_POLLER_MAX_BUFFER_SIZE * FURI_HAL_NFC_ISO15693_BIT_LEN];
     size_t frame_buf_bits;
 } FuriHalNfcIso15693Poller;
 


### PR DESCRIPTION
fixes sending 32+ byte ISO 15693-3 commands, now allows up to 64 bytes all other layers aim for a max of 64 bytes, this was a small mistake multiplying the byte count by 2 instead of by 4: as stated by the nearby comment too, each data bit encodes to 4 bits, not 2

# What's new

- [ Describe changes here ]

# Verification 

- [ Describe how to verify changes ]

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
