### PR TITLE
UNLEASHED:: TX Power setting to SubGhz App

### DIFF
--- a/applications/main/subghz/helpers/subghz_txrx.c
+++ b/applications/main/subghz/helpers/subghz_txrx.c
@@ -101,10 +101,37 @@ void subghz_txrx_set_preset(
     size_t preset_data_size) {
     furi_assert(instance);
     furi_string_set(instance->preset->name, preset_name);
+
     SubGhzRadioPreset* preset = instance->preset;
     preset->frequency = frequency;
     preset->data = preset_data;
     preset->data_size = preset_data_size;
+}
+
+uint8_t*
+    subghz_txrx_set_tx_power(uint8_t* preset_data, size_t preset_data_size, uint32_t tx_power) {
+#define TX_POWER_OFFSET       7
+#define TX_PRESET_POWER_COUNT 11
+    const uint32_t tx_power_value[TX_PRESET_POWER_COUNT] = {
+        0,
+        0xC0,
+        0xC5,
+        0xCD,
+        0x86,
+        0x50,
+        0x37,
+        0x26,
+        0x1D,
+        0x17,
+        0x03,
+    };
+
+    //Set the TX Power Here in the CC1101 register...
+    if(tx_power)
+        preset_data[preset_data_size - TX_POWER_OFFSET] = (uint8_t)tx_power_value[tx_power];
+
+    //Pass back the preset_so we can call one liners.
+    return preset_data;
 }
 
 const char* subghz_txrx_get_preset_name(SubGhzTxRx* instance, const char* preset) {
@@ -677,20 +704,27 @@ void subghz_txrx_set_default_preset(SubGhzTxRx* instance, uint32_t frequency) {
     subghz_txrx_set_preset(instance, default_modulation, frequency, NULL, 0);
 }
 
-const char*
-    subghz_txrx_set_preset_internal(SubGhzTxRx* instance, uint32_t frequency, uint8_t index) {
+const char* subghz_txrx_set_preset_internal(
+    SubGhzTxRx* instance,
+    uint32_t frequency,
+    uint8_t index,
+    uint32_t tx_power) {
     furi_assert(instance);
 
+    //Grab the prset name.
     SubGhzSetting* setting = subghz_txrx_get_setting(instance);
     const char* preset_name = subghz_setting_get_preset_name(setting, index);
     subghz_setting_set_default_frequency(setting, frequency);
 
-    subghz_txrx_set_preset(
-        instance,
-        preset_name,
-        frequency,
-        subghz_setting_get_preset_data(setting, index),
-        subghz_setting_get_preset_data_size(setting, index));
+    //Get the preset data now so we can set TX power.
+    uint8_t* preset_data = subghz_setting_get_preset_data(setting, index);
+    size_t preset_data_size = subghz_setting_get_preset_data_size(setting, index);
+
+    //Edit TX power, if necessary.
+    subghz_txrx_set_tx_power(preset_data, preset_data_size, tx_power);
+
+    //Set the Updated Preset.
+    subghz_txrx_set_preset(instance, preset_name, frequency, preset_data, preset_data_size);
 
     return preset_name;
 }

--- a/applications/main/subghz/helpers/subghz_txrx.h
+++ b/applications/main/subghz/helpers/subghz_txrx.h
@@ -58,6 +58,16 @@ void subghz_txrx_set_preset(
     size_t preset_data_size);
 
 /**
+ * Set TX Power
+ * 
+ * @param preset_data Data of preset
+ * @param preset_data_size Size of preset data
+ * @param tx_power Menu Index of TX Power Setting. (Saves iterating in Config enter)
+ */
+uint8_t*
+    subghz_txrx_set_tx_power(uint8_t* preset_data, size_t preset_data_size, uint32_t tx_power);
+
+/**
  * Get name of preset
  * 
  * @param instance Pointer to a SubGhzTxRx
@@ -360,7 +370,11 @@ void subghz_txrx_set_default_preset(SubGhzTxRx* instance, uint32_t frequency);
  * @param instance  - instance Pointer to a SubGhzTxRx
  * @param frequency - frequency of new preset
  * @param index - index of preset taken from SubGhzSetting
+ * @param tx_power - index of TX Power menu index option to use.
  * @return const char* -  name of preset
  */
-const char*
-    subghz_txrx_set_preset_internal(SubGhzTxRx* instance, uint32_t frequency, uint8_t index);
+const char* subghz_txrx_set_preset_internal(
+    SubGhzTxRx* instance,
+    uint32_t frequency,
+    uint8_t index,
+    uint32_t tx_power);

--- a/applications/main/subghz/scenes/subghz_scene_radio_settings.c
+++ b/applications/main/subghz/scenes/subghz_scene_radio_settings.c
@@ -66,6 +66,22 @@ const int32_t debug_counter_val[DEBUG_COUNTER_COUNT] = {
     -50,
 };
 
+//TX Power
+#define TX_POWER_COUNT 11
+const char* const tx_power_text[TX_POWER_COUNT] = {
+    "Preset",
+    "12dBm",
+    "10dBm",
+    "7dBm",
+    "5dBm",
+    "0dBm",
+    "-6dBm",
+    "-10dBm",
+    "-15dBm",
+    "-20dBm",
+    "-30dBm",
+};
+
 static void subghz_scene_radio_settings_set_device(VariableItem* item) {
     SubGhz* subghz = variable_item_get_context(item);
     uint8_t index = variable_item_get_current_value_index(item);
@@ -78,6 +94,20 @@ static void subghz_scene_radio_settings_set_device(VariableItem* item) {
     }
     variable_item_set_current_value_text(item, radio_device_text[index]);
     subghz_txrx_radio_device_set(subghz->txrx, radio_device_value[index]);
+}
+
+static void subghz_scene_radio_settings_set_tx_power(VariableItem* item) {
+    SubGhz* subghz = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+
+    //Update the Menu Item on screen
+    variable_item_set_current_value_text(item, tx_power_text[index]);
+
+    //Set TX power and remember setting
+    subghz->last_settings->tx_power = subghz->tx_power = index;
+
+    //Save the settings now, this is the convention here!
+    subghz_last_settings_save(subghz->last_settings);
 }
 
 static void subghz_scene_receiver_config_set_debug_pin(VariableItem* item) {
@@ -143,6 +173,18 @@ void subghz_scene_radio_settings_on_enter(void* context) {
         subghz_txrx_radio_device_get(subghz->txrx), radio_device_value, value_count_device);
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, radio_device_text[value_index]);
+
+    //Add TX Power
+    item = variable_item_list_add(
+        subghz->variable_item_list,
+        "TX Power",
+        TX_POWER_COUNT,
+        subghz_scene_radio_settings_set_tx_power,
+        subghz);
+
+    value_index = subghz->tx_power;
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, tx_power_text[value_index]);
 
     item = variable_item_list_add(
         variable_item_list,

--- a/applications/main/subghz/scenes/subghz_scene_read_raw.c
+++ b/applications/main/subghz/scenes/subghz_scene_read_raw.c
@@ -110,7 +110,8 @@ void subghz_scene_read_raw_on_enter(void* context) {
             subghz_txrx_set_preset_internal(
                 subghz->txrx,
                 subghz->last_settings->frequency,
-                subghz->last_settings->preset_index);
+                subghz->last_settings->preset_index,
+                subghz->last_settings->tx_power);
         }
     }
     subghz_scene_read_raw_update_statusbar(subghz);

--- a/applications/main/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver.c
@@ -165,11 +165,15 @@ void subghz_scene_receiver_on_enter(void* context) {
 
     if(subghz_rx_key_state_get(subghz) == SubGhzRxKeyStateIDLE) {
         subghz_txrx_set_preset_internal(
-            subghz->txrx, subghz->last_settings->frequency, subghz->last_settings->preset_index);
+            subghz->txrx,
+            subghz->last_settings->frequency,
+            subghz->last_settings->preset_index,
+            subghz->last_settings->tx_power);
 
         subghz->filter = subghz->last_settings->filter;
         subghz_txrx_receiver_set_filter(subghz->txrx, subghz->filter);
         subghz->ignore_filter = subghz->last_settings->ignore_filter;
+        subghz->tx_power = subghz->last_settings->tx_power;
 
         subghz_history_reset(history);
         subghz_rx_key_state_set(subghz, SubGhzRxKeyStateStart);

--- a/applications/main/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver_config.c
@@ -7,7 +7,6 @@ enum SubGhzSettingIndex {
     SubGhzSettingIndexFrequency,
     SubGhzSettingIndexHopping,
     SubGhzSettingIndexModulation,
-    SubGhzSettingIndexTXPower,
     SubGhzSettingIndexBinRAW,
     SubGhzSettingIndexIgnoreReversRB2,
     SubGhzSettingIndexIgnoreAlarms,
@@ -101,22 +100,6 @@ const uint32_t bin_raw_value[COMBO_BOX_COUNT] = {
 const char* const combobox_text[COMBO_BOX_COUNT] = {
     "OFF",
     "ON",
-};
-
-//TX Power
-#define TX_POWER_COUNT 11
-const char* const tx_power_text[TX_POWER_COUNT] = {
-    "Preset",
-    "12dBm",
-    "10dBm",
-    "7dBm",
-    "5dBm",
-    "0dBm",
-    "-6dBm",
-    "-10dBm",
-    "-15dBm",
-    "-20dBm",
-    "-30dBm",
 };
 
 static void
@@ -300,29 +283,6 @@ static void subghz_scene_receiver_config_set_speaker(VariableItem* item) {
     subghz_txrx_speaker_set_state(subghz->txrx, speaker_value[index]);
 }
 
-static void subghz_scene_receiver_config_set_tx_power(VariableItem* item) {
-    SubGhz* subghz = variable_item_get_context(item);
-    uint8_t index = variable_item_get_current_value_index(item);
-
-    //Update the Menu Item on screen
-    variable_item_set_current_value_text(item, tx_power_text[index]);
-
-    //Set TX power and remember setting
-    subghz->last_settings->tx_power = subghz->tx_power = index;
-
-    //Get current preset and frequency so I can update preset wit TX power.
-    SubGhzSetting* setting = subghz_txrx_get_setting(subghz->txrx);
-    uint32_t frequency = subghz_setting_get_default_frequency(setting);
-    SubGhzRadioPreset preset = subghz_txrx_get_preset(subghz->txrx);
-
-    //Edit TX power, if necessary.
-    subghz_txrx_set_tx_power(preset.data, preset.data_size, subghz->tx_power);
-
-    // Maybe better add one more function with only with the frequency argument?
-    subghz_txrx_set_preset(
-        subghz->txrx, furi_string_get_cstr(preset.name), frequency, preset.data, preset.data_size);
-}
-
 static void subghz_scene_receiver_config_set_bin_raw(VariableItem* item) {
     SubGhz* subghz = variable_item_get_context(item);
     uint8_t index = variable_item_get_current_value_index(item);
@@ -392,7 +352,7 @@ static void subghz_scene_receiver_config_var_list_enter_callback(void* context, 
             subghz->txrx,
             SUBGHZ_LAST_SETTING_DEFAULT_FREQUENCY,
             SUBGHZ_LAST_SETTING_DEFAULT_PRESET,
-            0);
+            subghz->tx_power);
 
         SubGhzSetting* setting = subghz_txrx_get_setting(subghz->txrx);
         SubGhzRadioPreset preset = subghz_txrx_get_preset(subghz->txrx);
@@ -479,18 +439,6 @@ void subghz_scene_receiver_config_on_enter(void* context) {
         variable_item_set_current_value_index(item, value_index);
         variable_item_set_current_value_text(item, hopping_mode_text[value_index]);
     }
-
-    //Add TX Power
-    item = variable_item_list_add(
-        subghz->variable_item_list,
-        "TX Power",
-        TX_POWER_COUNT,
-        subghz_scene_receiver_config_set_tx_power,
-        subghz);
-
-    value_index = subghz->tx_power;
-    variable_item_set_current_value_index(item, value_index);
-    variable_item_set_current_value_text(item, tx_power_text[value_index]);
 
     if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) !=
        SubGhzCustomEventManagerSet) {

--- a/applications/main/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver_config.c
@@ -7,6 +7,7 @@ enum SubGhzSettingIndex {
     SubGhzSettingIndexFrequency,
     SubGhzSettingIndexHopping,
     SubGhzSettingIndexModulation,
+    SubGhzSettingIndexTXPower,
     SubGhzSettingIndexBinRAW,
     SubGhzSettingIndexIgnoreReversRB2,
     SubGhzSettingIndexIgnoreAlarms,
@@ -102,6 +103,22 @@ const char* const combobox_text[COMBO_BOX_COUNT] = {
     "ON",
 };
 
+//TX Power
+#define TX_POWER_COUNT 11
+const char* const tx_power_text[TX_POWER_COUNT] = {
+    "Preset",
+    "12dBm",
+    "10dBm",
+    "7dBm",
+    "5dBm",
+    "0dBm",
+    "-6dBm",
+    "-10dBm",
+    "-15dBm",
+    "-20dBm",
+    "-30dBm",
+};
+
 static void
     subghz_scene_receiver_config_set_ignore_filter(VariableItem* item, SubGhzProtocolFlag filter) {
     SubGhz* subghz = variable_item_get_context(item);
@@ -185,6 +202,11 @@ static void subghz_scene_receiver_config_set_frequency(VariableItem* item) {
             frequency / 1000000,
             (frequency % 1000000) / 10000);
         variable_item_set_current_value_text(item, text_buf);
+
+        //Set TX Power
+        subghz_txrx_set_tx_power(preset.data, preset.data_size, subghz->tx_power);
+
+        //Set the preset now.
         subghz_txrx_set_preset(
             subghz->txrx,
             furi_string_get_cstr(preset.name),
@@ -211,12 +233,14 @@ static void subghz_scene_receiver_config_set_preset(VariableItem* item) {
     variable_item_set_current_value_text(item, preset_name);
     //subghz->last_settings->preset = index;
     SubGhzRadioPreset preset = subghz_txrx_get_preset(subghz->txrx);
+    uint8_t* preset_data = subghz_setting_get_preset_data(setting, index);
+    size_t preset_data_size = subghz_setting_get_preset_data_size(setting, index);
+
+    //Edit TX power, if necessary.
+    subghz_txrx_set_tx_power(preset_data, preset_data_size, subghz->tx_power);
+
     subghz_txrx_set_preset(
-        subghz->txrx,
-        preset_name,
-        preset.frequency,
-        subghz_setting_get_preset_data(setting, index),
-        subghz_setting_get_preset_data_size(setting, index));
+        subghz->txrx, preset_name, preset.frequency, preset_data, preset_data_size);
     subghz->last_settings->preset_index = index;
 }
 
@@ -241,6 +265,9 @@ static void subghz_scene_receiver_config_set_hopping(VariableItem* item) {
             frequency / 1000000,
             (frequency % 1000000) / 10000);
         variable_item_set_current_value_text(frequency_item, text_buf);
+
+        //Edit TX power, if necessary.
+        subghz_txrx_set_tx_power(preset.data, preset.data_size, subghz->tx_power);
 
         // Maybe better add one more function with only with the frequency argument?
         subghz_txrx_set_preset(
@@ -271,6 +298,30 @@ static void subghz_scene_receiver_config_set_speaker(VariableItem* item) {
 
     variable_item_set_current_value_text(item, combobox_text[index]);
     subghz_txrx_speaker_set_state(subghz->txrx, speaker_value[index]);
+}
+
+static void subghz_scene_receiver_config_set_tx_power(VariableItem* item) {
+    SubGhz* subghz = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+
+    //Update the Menu Item on screen
+    variable_item_set_current_value_text(item, tx_power_text[index]);
+
+    //Set TX power and remember setting
+    subghz->tx_power = index;
+    subghz->last_settings->tx_power = subghz->tx_power;
+
+    //Get current preset and frequency so I can update preset wit TX power.
+    SubGhzSetting* setting = subghz_txrx_get_setting(subghz->txrx);
+    uint32_t frequency = subghz_setting_get_default_frequency(setting);
+    SubGhzRadioPreset preset = subghz_txrx_get_preset(subghz->txrx);
+
+    //Edit TX power, if necessary.
+    subghz_txrx_set_tx_power(preset.data, preset.data_size, subghz->tx_power);
+
+    // Maybe better add one more function with only with the frequency argument?
+    subghz_txrx_set_preset(
+        subghz->txrx, furi_string_get_cstr(preset.name), frequency, preset.data, preset.data_size);
 }
 
 static void subghz_scene_receiver_config_set_bin_raw(VariableItem* item) {
@@ -341,7 +392,8 @@ static void subghz_scene_receiver_config_var_list_enter_callback(void* context, 
         subghz_txrx_set_preset_internal(
             subghz->txrx,
             SUBGHZ_LAST_SETTING_DEFAULT_FREQUENCY,
-            SUBGHZ_LAST_SETTING_DEFAULT_PRESET);
+            SUBGHZ_LAST_SETTING_DEFAULT_PRESET,
+            0);
 
         SubGhzSetting* setting = subghz_txrx_get_setting(subghz->txrx);
         SubGhzRadioPreset preset = subghz_txrx_get_preset(subghz->txrx);
@@ -359,7 +411,7 @@ static void subghz_scene_receiver_config_var_list_enter_callback(void* context, 
         subghz->last_settings->ignore_filter = subghz->ignore_filter;
         subghz->last_settings->filter = subghz->filter;
         subghz->last_settings->delete_old_signals = false;
-
+        subghz->last_settings->tx_power = subghz->tx_power = 0;
         subghz_txrx_speaker_set_state(subghz->txrx, speaker_value[default_index]);
 
         subghz_txrx_hopper_set_state(subghz->txrx, hopping_value[default_index]);
@@ -428,6 +480,18 @@ void subghz_scene_receiver_config_on_enter(void* context) {
         variable_item_set_current_value_index(item, value_index);
         variable_item_set_current_value_text(item, hopping_mode_text[value_index]);
     }
+
+    //Add TX Power
+    item = variable_item_list_add(
+        subghz->variable_item_list,
+        "TX Power",
+        TX_POWER_COUNT,
+        subghz_scene_receiver_config_set_tx_power,
+        subghz);
+
+    value_index = subghz->tx_power;
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, tx_power_text[value_index]);
 
     if(scene_manager_get_scene_state(subghz->scene_manager, SubGhzSceneReadRAW) !=
        SubGhzCustomEventManagerSet) {

--- a/applications/main/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver_config.c
@@ -308,8 +308,7 @@ static void subghz_scene_receiver_config_set_tx_power(VariableItem* item) {
     variable_item_set_current_value_text(item, tx_power_text[index]);
 
     //Set TX power and remember setting
-    subghz->tx_power = index;
-    subghz->last_settings->tx_power = subghz->tx_power;
+    subghz->last_settings->tx_power = subghz->tx_power = index;
 
     //Get current preset and frequency so I can update preset wit TX power.
     SubGhzSetting* setting = subghz_txrx_get_setting(subghz->txrx);

--- a/applications/main/subghz/scenes/subghz_scene_receiver_info.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver_info.c
@@ -36,6 +36,10 @@ static bool subghz_scene_receiver_info_update_parser(void* context) {
 
         SubGhzRadioPreset* preset =
             subghz_history_get_radio_preset(subghz->history, subghz->idx_menu_chosen);
+
+        //Edit TX power, if necessary.
+        subghz_txrx_set_tx_power(preset->data, preset->data_size, subghz->tx_power);
+
         subghz_txrx_set_preset(
             subghz->txrx,
             furi_string_get_cstr(preset->name),

--- a/applications/main/subghz/subghz.c
+++ b/applications/main/subghz/subghz.c
@@ -207,7 +207,10 @@ SubGhz* subghz_alloc(bool alloc_for_tx_only) {
 
     if(!alloc_for_tx_only) {
         subghz_txrx_set_preset_internal(
-            subghz->txrx, subghz->last_settings->frequency, subghz->last_settings->preset_index);
+            subghz->txrx,
+            subghz->last_settings->frequency,
+            subghz->last_settings->preset_index,
+            subghz->tx_power);
         subghz->history = subghz_history_alloc();
     }
 
@@ -218,10 +221,13 @@ SubGhz* subghz_alloc(bool alloc_for_tx_only) {
     if(!alloc_for_tx_only) {
         subghz->ignore_filter = subghz->last_settings->ignore_filter;
         subghz->filter = subghz->last_settings->filter;
+        subghz->tx_power = subghz->last_settings->tx_power;
     } else {
         subghz->filter = SubGhzProtocolFlag_Decodable;
         subghz->ignore_filter = 0x0;
+        subghz->tx_power = 0;
     }
+
     subghz_txrx_receiver_set_filter(subghz->txrx, subghz->filter);
     subghz_txrx_set_need_save_callback(subghz->txrx, subghz_save_to_file, subghz);
 

--- a/applications/main/subghz/subghz_i.c
+++ b/applications/main/subghz/subghz_i.c
@@ -137,12 +137,19 @@ bool subghz_key_load(SubGhz* subghz, const char* file_path, bool show_dialog) {
         }
         size_t preset_index =
             subghz_setting_get_inx_preset_by_name(setting, furi_string_get_cstr(temp_str));
+
+        //Edit TX power, if necessary.
+        uint8_t* preset_data = subghz_setting_get_preset_data(setting, preset_index);
+        size_t preset_data_size = subghz_setting_get_preset_data_size(setting, preset_index);
+        subghz_txrx_set_tx_power(preset_data, preset_data_size, subghz->tx_power);
+
+        //Set the Updated Preset.
         subghz_txrx_set_preset(
             subghz->txrx,
             furi_string_get_cstr(temp_str),
             temp_data32,
-            subghz_setting_get_preset_data(setting, preset_index),
-            subghz_setting_get_preset_data_size(setting, preset_index));
+            preset_data,
+            preset_data_size);
 
         //Load protocol
         if(!flipper_format_read_string(fff_data_file, "Protocol", temp_str)) {

--- a/applications/main/subghz/subghz_i.h
+++ b/applications/main/subghz/subghz_i.h
@@ -93,7 +93,7 @@ struct SubGhz {
 
     uint16_t idx_menu_chosen;
     SubGhzLoadTypeFile load_type_file;
-
+    uint32_t tx_power;
     void* rpc_ctx;
 };
 

--- a/applications/main/subghz/subghz_last_settings.c
+++ b/applications/main/subghz/subghz_last_settings.c
@@ -19,6 +19,7 @@
 #define SUBGHZ_LAST_SETTING_FIELD_DELETE_OLD                        "DelOldSignals"
 #define SUBGHZ_LAST_SETTING_FIELD_HOPPING_THRESHOLD                 "HoppingThreshold"
 #define SUBGHZ_LAST_SETTING_FIELD_LED_AND_POWER_AMP                 "LedAndPowerAmp"
+#define SUBGHZ_LAST_SETTING_FIELD_TX_POWER                          "TXPower"
 
 SubGhzLastSettings* subghz_last_settings_alloc(void) {
     SubGhzLastSettings* instance = malloc(sizeof(SubGhzLastSettings));
@@ -117,6 +118,10 @@ void subghz_last_settings_load(SubGhzLastSettings* instance, size_t preset_count
                    SUBGHZ_LAST_SETTING_FIELD_DELETE_OLD,
                    &instance->delete_old_signals,
                    1)) {
+                flipper_format_rewind(fff_data_file);
+            }
+            if(!flipper_format_read_uint32(
+                   fff_data_file, SUBGHZ_LAST_SETTING_FIELD_TX_POWER, &instance->tx_power, 1)) {
                 flipper_format_rewind(fff_data_file);
             }
             if(!flipper_format_read_float(
@@ -220,6 +225,10 @@ bool subghz_last_settings_save(SubGhzLastSettings* instance) {
         }
         if(!flipper_format_write_bool(
                file, SUBGHZ_LAST_SETTING_FIELD_DELETE_OLD, &instance->delete_old_signals, 1)) {
+            break;
+        }
+        if(!flipper_format_write_uint32(
+               file, SUBGHZ_LAST_SETTING_FIELD_TX_POWER, &instance->tx_power, 1)) {
             break;
         }
         if(!flipper_format_write_float(

--- a/applications/main/subghz/subghz_last_settings.h
+++ b/applications/main/subghz/subghz_last_settings.h
@@ -26,6 +26,7 @@ typedef struct {
     bool delete_old_signals;
     float hopping_threshold;
     bool leds_and_amp;
+    uint32_t tx_power;
 } SubGhzLastSettings;
 
 SubGhzLastSettings* subghz_last_settings_alloc(void);


### PR DESCRIPTION
# What's new

***  TX Power setting to SubGhz App ****
Works in Read, and Read RAW.
You can now adjust the TX power for testing devices without desyncing them from inside
Lets you do RTL testing etc on very low power.
CODE REFACTORED, subghz_txrx_set_tx_power added.

# Verification 

Open SubGhz App, go to Read or Read RAW. Enter Config, and you can now adjust TX Power.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
