### PR TITLE
Subghz Signal Settings Improvements

### DIFF
--- a/applications/main/subghz/scenes/subghz_scene_signal_settings.c
+++ b/applications/main/subghz/scenes/subghz_scene_signal_settings.c
@@ -65,6 +65,38 @@ void subghz_scene_signal_settings_counter_mode_changed(VariableItem* item) {
     uint8_t index = variable_item_get_current_value_index(item);
     variable_item_set_current_value_text(item, counter_mode_text[index]);
     counter_mode = counter_mode_value[index];
+
+    SubGhz* subghz = variable_item_get_context(item);
+    const char* file_path = furi_string_get_cstr(subghz->file_path);
+
+    furi_assert(subghz);
+    furi_assert(file_path);
+
+    // update file every time when we change mode
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
+
+    // check is the file available for update/insert CounterMode value
+    if(flipper_format_file_open_existing(fff_data_file, file_path)) {
+        if(flipper_format_insert_or_update_uint32(fff_data_file, "CounterMode", &counter_mode, 1)) {
+            FURI_LOG_D(TAG, "Successfully updated/inserted CounterMode value %li", counter_mode);
+        } else {
+            FURI_LOG_E(TAG, "Error update/insert CounterMode value");
+        }
+    } else {
+        FURI_LOG_E(TAG, "Error open file %s for writing", file_path);
+    }
+
+    flipper_format_file_close(fff_data_file);
+    flipper_format_free(fff_data_file);
+    furi_record_close(RECORD_STORAGE);
+
+    // we need to reload file after editing it
+    if(subghz_key_load(subghz, file_path, false)) {
+        FURI_LOG_D(TAG, "Subghz file was successfully reloaded");
+    } else {
+        FURI_LOG_E(TAG, "Error reloading subghz file");
+    }
 }
 
 void subghz_scene_signal_settings_byte_input_callback(void* context) {
@@ -311,40 +343,8 @@ bool subghz_scene_signal_settings_on_event(void* context, SceneManagerEvent even
 
 void subghz_scene_signal_settings_on_exit(void* context) {
     SubGhz* subghz = context;
-    const char* file_path = furi_string_get_cstr(subghz->file_path);
 
     furi_assert(subghz);
-    furi_assert(file_path);
-
-    // if ConterMode was changed from 0xff then we must update or write new value to file
-    if(counter_mode != 0xff) {
-        Storage* storage = furi_record_open(RECORD_STORAGE);
-        FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
-
-        // check is the file available for update/insert CounterMode value
-        if(flipper_format_file_open_existing(fff_data_file, file_path)) {
-            if(flipper_format_insert_or_update_uint32(
-                   fff_data_file, "CounterMode", &counter_mode, 1)) {
-                FURI_LOG_D(
-                    TAG, "Successfully updated/inserted CounterMode value %li", counter_mode);
-            } else {
-                FURI_LOG_E(TAG, "Error update/insert CounterMode value");
-            }
-        } else {
-            FURI_LOG_E(TAG, "Error open file %s for writing", file_path);
-        }
-
-        flipper_format_file_close(fff_data_file);
-        flipper_format_free(fff_data_file);
-        furi_record_close(RECORD_STORAGE);
-
-        // we need to reload file after editing when we exit from Signal Settings menu.
-        if(subghz_key_load(subghz, file_path, false)) {
-            FURI_LOG_D(TAG, "Subghz file was successfully reloaded");
-        } else {
-            FURI_LOG_E(TAG, "Error reloading subghz file");
-        }
-    }
 
     // Clear views
     variable_item_list_set_selected_item(subghz->variable_item_list, 0);

--- a/lib/subghz/protocols/alutech_at_4n.c
+++ b/lib/subghz/protocols/alutech_at_4n.c
@@ -12,6 +12,9 @@
 #define SUBGHZ_NO_ALUTECH_AT_4N_RAINBOW_TABLE         0xFFFFFFFFFFFFFFFF
 #define SUBGHZ_ALUTECH_AT_4N_RAINBOW_TABLE_SIZE_BYTES 32
 
+//variable used to bypass CounterMode settings if user just change Counter or Button
+static bool bypass = false;
+
 static const SubGhzBlockConst subghz_protocol_alutech_at_4n_const = {
     .te_short = 400,
     .te_long = 800,
@@ -293,11 +296,13 @@ static bool subghz_protocol_alutech_at_4n_gen_data(
         instance->generic.serial = (uint32_t)(data >> 24) & 0xFFFFFFFF;
     }
 
-    // if we change counter in SignalSettings menu then we must passthru counter_modes, just gen and save signal file.
-    if((alutech_at4n_counter_mode == 0) || subghz_block_generic_global.cnt_need_override) {
+    // if we change counter/button in SignalSettings menu then we must bypass counter_modes, just gen and save signal file.
+    if(subghz_block_generic_global.cnt_need_override) bypass = true;
+
+    if((alutech_at4n_counter_mode == 0) || bypass) {
         // Check for OFEX (overflow experimental) mode
-        if((furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) ||
-           subghz_block_generic_global.cnt_need_override) {
+        if((furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) || bypass) {
+            bypass = false;
             // standart counter mode. PULL data from subghz_block_generic_global variables
             if(!subghz_block_generic_global_counter_override_get(&instance->generic.cnt)) {
                 // if counter_override_get return FALSE then counter was not changed and we increase counter by standart mult value
@@ -403,8 +408,10 @@ static bool subghz_protocol_encoder_alutech_at_4n_get_upload(
     btn = subghz_protocol_alutech_at_4n_get_btn_code();
 
     // override button if we change it with signal settings button editor
-    if(subghz_block_generic_global_button_override_get(&btn))
+    if(subghz_block_generic_global_button_override_get(&btn)) {
+        bypass = true;
         FURI_LOG_D(TAG, "Button sucessfully changed to 0x%X", btn);
+    }
 
     // Gen new key
     if(!subghz_protocol_alutech_at_4n_gen_data(instance, btn)) {

--- a/lib/subghz/protocols/alutech_at_4n.c
+++ b/lib/subghz/protocols/alutech_at_4n.c
@@ -293,9 +293,11 @@ static bool subghz_protocol_alutech_at_4n_gen_data(
         instance->generic.serial = (uint32_t)(data >> 24) & 0xFFFFFFFF;
     }
 
-    if(alutech_at4n_counter_mode == 0) {
+    // if we change counter in SignalSettings menu then we must passthru counter_modes, just gen and save signal file.
+    if((alutech_at4n_counter_mode == 0) || subghz_block_generic_global.cnt_need_override) {
         // Check for OFEX (overflow experimental) mode
-        if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
+        if((furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) ||
+           subghz_block_generic_global.cnt_need_override) {
             // standart counter mode. PULL data from subghz_block_generic_global variables
             if(!subghz_block_generic_global_counter_override_get(&instance->generic.cnt)) {
                 // if counter_override_get return FALSE then counter was not changed and we increase counter by standart mult value

--- a/lib/subghz/protocols/came_atomo.c
+++ b/lib/subghz/protocols/came_atomo.c
@@ -11,6 +11,9 @@
 
 #define TAG "SubGhzProtocoCameAtomo"
 
+//variable used to bypass CounterMode settings if user just change Counter or Button
+static bool bypass = false;
+
 static const SubGhzBlockConst subghz_protocol_came_atomo_const = {
     .te_short = 600,
     .te_long = 1200,
@@ -187,9 +190,15 @@ static void subghz_protocol_encoder_came_atomo_get_upload(
 
     uint8_t pack[8] = {};
 
-    if(came_atomo_counter_mode == 0) {
+    // if we change counter/button in SignalSettings menu then we must bypass counter_modes, just gen and save signal file.
+    if(subghz_block_generic_global.cnt_need_override ||
+       subghz_block_generic_global.btn_need_override)
+        bypass = true;
+
+    if(came_atomo_counter_mode == 0 || bypass) {
         // Check for OFEX (overflow experimental) mode
-        if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
+        if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF || bypass) {
+            bypass = false;
             // standart counter mode. PULL data from subghz_block_generic_global variables
             if(!subghz_block_generic_global_counter_override_get(&instance->generic.cnt)) {
                 // if counter_override_get return FALSE then counter was not changed and we increase counter by standart mult value

--- a/lib/subghz/protocols/keeloq.c
+++ b/lib/subghz/protocols/keeloq.c
@@ -15,6 +15,9 @@
 
 #define TAG "SubGhzProtocolKeeloq"
 
+//variable used to bypass CounterMode settings if user just change Counter or Button
+static bool bypass = false;
+
 static const SubGhzBlockConst subghz_protocol_keeloq_const = {
     .te_short = 400,
     .te_long = 800,
@@ -241,9 +244,10 @@ static bool subghz_protocol_keeloq_gen_data(
     if(counter_up && prog_mode == PROG_MODE_OFF) {
         // Counter increment conditions
 
-        if(keeloq_counter_mode == 0) {
+        if(keeloq_counter_mode == 0 || bypass) {
             // Check for OFEX (overflow experimental) mode
-            if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
+            if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF || bypass) {
+                bypass = false;
                 // standart counter mode. PULL data from subghz_block_generic_global variables
                 if(!subghz_block_generic_global_counter_override_get(&instance->generic.cnt)) {
                     // if counter_override_get return FALSE then counter was not changed and we increase counter by standart mult value
@@ -601,7 +605,13 @@ static bool
     instance->encoder.size_upload = 0;
     size_t upindex = 0;
 
-    if(keeloq_counter_mode == 7) {
+    // if we change counter/button in SignalSettings menu then we must bypass counter_modes, just gen and save signal file.
+    if(subghz_block_generic_global.cnt_need_override ||
+       subghz_block_generic_global.btn_need_override)
+        bypass = true;
+
+    // Create mode7 upload only if counter and button was not changed by SignalSettings menu
+    if(keeloq_counter_mode == 7 && !bypass) {
         uint16_t temp_cnt = instance->generic.cnt;
         instance->encoder.repeat = 1;
         for(uint8_t i = 7; i > 0; i--) {

--- a/lib/subghz/protocols/nice_flor_s.c
+++ b/lib/subghz/protocols/nice_flor_s.c
@@ -21,6 +21,9 @@
 #define SUBGHZ_NICE_FLOR_S_RAINBOW_TABLE_SIZE_BYTES 32
 #define SUBGHZ_NO_NICE_FLOR_S_RAINBOW_TABLE         0
 
+//variable used to bypass CounterMode settings if user just change Counter or Button
+static bool bypass = false;
+
 static const SubGhzBlockConst subghz_protocol_nice_flor_s_const = {
     .te_short = 500,
     .te_long = 1000,
@@ -148,8 +151,10 @@ static void subghz_protocol_encoder_nice_flor_s_get_upload(
     btn = subghz_protocol_nice_flor_s_get_btn_code();
 
     // override button if we change it with signal settings button editor
-    if(subghz_block_generic_global_button_override_get(&btn))
+    if(subghz_block_generic_global_button_override_get(&btn)) {
+        bypass = true;
         FURI_LOG_D(TAG, "Button sucessfully changed to 0x%X", btn);
+    }
 
     size_t size_upload = ((instance->generic.data_count_bit * 2) + ((37 + 2 + 2) * 2) * 16);
     if(size_upload > instance->encoder.size_upload) {
@@ -157,9 +162,14 @@ static void subghz_protocol_encoder_nice_flor_s_get_upload(
     } else {
         instance->encoder.size_upload = size_upload;
     }
-    if(nice_flors_counter_mode == 0) {
+
+    // if we change counter/button in SignalSettings menu then we must bypass counter_modes, just gen and save signal file.
+    if(subghz_block_generic_global.cnt_need_override) bypass = true;
+
+    if(nice_flors_counter_mode == 0 || bypass) {
         // Check for OFEX (overflow experimental) mode
-        if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
+        if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF || bypass) {
+            bypass = false;
             // standart counter mode. PULL data from subghz_block_generic_global variables
             if(!subghz_block_generic_global_counter_override_get(&instance->generic.cnt)) {
                 // if counter_override_get return FALSE then counter was not changed and we increase counter by standart mult value

--- a/lib/subghz/protocols/phoenix_v2.c
+++ b/lib/subghz/protocols/phoenix_v2.c
@@ -10,6 +10,9 @@
 
 #define TAG "SubGhzProtocolPhoenixV2"
 
+//variable used to bypass CounterMode settings if user just change Counter or Button
+static bool bypass = false;
+
 static const SubGhzBlockConst subghz_protocol_phoenix_v2_const = {
     .te_short = 427,
     .te_long = 853,
@@ -256,13 +259,19 @@ static bool
     btn = subghz_protocol_phoenix_v2_get_btn_code();
 
     // override button if we change it with signal settings button editor
-    if(subghz_block_generic_global_button_override_get(&btn))
+    if(subghz_block_generic_global_button_override_get(&btn)) {
+        bypass = true;
         FURI_LOG_D(TAG, "Button sucessfully changed to 0x%X", btn);
+    }
 
     // Reconstruction of the data
-    if(v2_phoenix_counter_mode == 0) {
+    // if we change counter/button in SignalSettings menu then we must bypass counter_modes, just gen and save signal file.
+    if(subghz_block_generic_global.cnt_need_override) bypass = true;
+
+    if(v2_phoenix_counter_mode == 0 || bypass) {
         // Check for OFEX (overflow experimental) mode
-        if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
+        if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF || bypass) {
+            bypass = false;
             // standart counter mode. PULL data from subghz_block_generic_global variables
             if(!subghz_block_generic_global_counter_override_get(&instance->generic.cnt)) {
                 // if counter_override_get return FALSE then counter was not changed and we increase counter by standart mult value


### PR DESCRIPTION
1. Counter mode save immediately when changed instead of exit from Signal Settings menu.
2. Counter and Button editing bypass non standard (mode=0) Counter Modes to save signal and save it using standard mode.