### PR TITLE
Added Autosave feature

### DIFF
--- a/applications/main/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver.c
@@ -1,6 +1,7 @@
 #include "../subghz_i.h"
 #include <dolphin/dolphin.h>
 #include <lib/subghz/protocols/bin_raw.h>
+#include <toolbox/name_generator.h>
 
 #define TAG "SubGhzSceneReceiver"
 
@@ -141,6 +142,32 @@ static void subghz_scene_add_to_history_callback(
                 furi_string_get_cstr(item_name),
                 furi_string_get_cstr(item_time),
                 subghz_history_get_type_protocol(history, idx));
+
+            if(decoder_base->protocol->flag & SubGhzProtocolFlag_Save &&
+               subghz->last_settings->autosave) {
+                // File name
+                char file[SUBGHZ_MAX_LEN_NAME] = {0};
+                const char* prefix = subghz->last_settings->protocol_file_names ?
+                                         decoder_base->protocol->name :
+                                         SUBGHZ_APP_FILENAME_PREFIX;
+                DateTime time = subghz_history_get_datetime(history, idx);
+                name_generator_make_detailed_datetime(file, sizeof(file), prefix, &time);
+                // Directory to save
+                FuriString* path = furi_string_alloc_set(SUBGHZ_APP_FOLDER "/autosave");
+                char* dir = strdup(furi_string_get_cstr(path));
+                // Find non-existent path
+                const char* ext = SUBGHZ_APP_FILENAME_EXTENSION;
+                Storage* storage = furi_record_open(RECORD_STORAGE);
+                storage_get_next_filename(storage, dir, file, ext, path, sizeof(file));
+                strlcpy(file, furi_string_get_cstr(path), sizeof(file));
+                furi_string_printf(path, "%s/%s%s", dir, file, ext);
+                furi_record_close(RECORD_STORAGE);
+                free(dir);
+                // Save
+                subghz_save_protocol_to_file(
+                    subghz, subghz_history_get_raw_data(history, idx), furi_string_get_cstr(path));
+                furi_string_free(path);
+            }
 
             subghz_scene_receiver_update_statusbar(subghz);
             if(subghz_history_get_text_space_left(subghz->history, NULL)) {

--- a/applications/main/subghz/scenes/subghz_scene_receiver_config.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver_config.c
@@ -8,6 +8,7 @@ enum SubGhzSettingIndex {
     SubGhzSettingIndexHopping,
     SubGhzSettingIndexModulation,
     SubGhzSettingIndexBinRAW,
+    SubGhzSettingIndexAutosave,
     SubGhzSettingIndexIgnoreReversRB2,
     SubGhzSettingIndexIgnoreAlarms,
     SubGhzSettingIndexIgnoreSensors,
@@ -340,6 +341,15 @@ static void subghz_scene_receiver_config_set_delete_old_signals(VariableItem* it
     subghz->last_settings->delete_old_signals = index == 1;
 }
 
+static void subghz_scene_receiver_config_set_autosave(VariableItem* item) {
+    SubGhz* subghz = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+
+    variable_item_set_current_value_text(item, combobox_text[index]);
+
+    subghz->last_settings->autosave = index == 1;
+}
+
 static void subghz_scene_receiver_config_var_list_enter_callback(void* context, uint32_t index) {
     furi_assert(context);
     SubGhz* subghz = context;
@@ -371,6 +381,8 @@ static void subghz_scene_receiver_config_var_list_enter_callback(void* context, 
         subghz->last_settings->filter = subghz->filter;
         subghz->last_settings->delete_old_signals = false;
         subghz->last_settings->tx_power = subghz->tx_power = 0;
+        subghz->last_settings->autosave = false;
+
         subghz_txrx_speaker_set_state(subghz->txrx, speaker_value[default_index]);
 
         subghz_txrx_hopper_set_state(subghz->txrx, hopping_value[default_index]);
@@ -450,6 +462,17 @@ void subghz_scene_receiver_config_on_enter(void* context) {
             subghz);
 
         value_index = value_index_uint32(subghz->filter, bin_raw_value, COMBO_BOX_COUNT);
+        variable_item_set_current_value_index(item, value_index);
+        variable_item_set_current_value_text(item, combobox_text[value_index]);
+
+        item = variable_item_list_add(
+            subghz->variable_item_list,
+            "Autosave",
+            COMBO_BOX_COUNT,
+            subghz_scene_receiver_config_set_autosave,
+            subghz);
+
+        value_index = subghz->last_settings->autosave;
         variable_item_set_current_value_index(item, value_index);
         variable_item_set_current_value_text(item, combobox_text[value_index]);
     }

--- a/applications/main/subghz/subghz_last_settings.c
+++ b/applications/main/subghz/subghz_last_settings.c
@@ -20,6 +20,7 @@
 #define SUBGHZ_LAST_SETTING_FIELD_HOPPING_THRESHOLD                 "HoppingThreshold"
 #define SUBGHZ_LAST_SETTING_FIELD_LED_AND_POWER_AMP                 "LedAndPowerAmp"
 #define SUBGHZ_LAST_SETTING_FIELD_TX_POWER                          "TXPower"
+#define SUBGHZ_LAST_SETTING_FIELD_AUTOSAVE                          "Autosave"
 
 SubGhzLastSettings* subghz_last_settings_alloc(void) {
     SubGhzLastSettings* instance = malloc(sizeof(SubGhzLastSettings));
@@ -46,6 +47,7 @@ void subghz_last_settings_load(SubGhzLastSettings* instance, size_t preset_count
     instance->rssi = SUBGHZ_RAW_THRESHOLD_MIN;
     instance->hopping_threshold = -90.0f;
     instance->leds_and_amp = true;
+    instance->autosave = false;
 
     Storage* storage = furi_record_open(RECORD_STORAGE);
     FlipperFormat* fff_data_file = flipper_format_file_alloc(storage);
@@ -137,6 +139,13 @@ void subghz_last_settings_load(SubGhzLastSettings* instance, size_t preset_count
                    fff_data_file,
                    SUBGHZ_LAST_SETTING_FIELD_LED_AND_POWER_AMP,
                    &instance->leds_and_amp,
+                   1)) {
+                flipper_format_rewind(fff_data_file);
+            }
+            if(!flipper_format_read_bool(
+                   fff_data_file,
+                   SUBGHZ_LAST_SETTING_FIELD_AUTOSAVE,
+                   &instance->autosave,
                    1)) {
                 flipper_format_rewind(fff_data_file);
             }
@@ -244,7 +253,10 @@ bool subghz_last_settings_save(SubGhzLastSettings* instance) {
                file, SUBGHZ_LAST_SETTING_FIELD_LED_AND_POWER_AMP, &instance->leds_and_amp, 1)) {
             break;
         }
-
+        if(!flipper_format_write_bool(
+               file, SUBGHZ_LAST_SETTING_FIELD_AUTOSAVE, &instance->autosave, 1)) {
+            break;
+        }
         saved = true;
     } while(0);
 

--- a/applications/main/subghz/subghz_last_settings.h
+++ b/applications/main/subghz/subghz_last_settings.h
@@ -27,6 +27,7 @@ typedef struct {
     float hopping_threshold;
     bool leds_and_amp;
     uint8_t tx_power;
+    bool autosave;
 } SubGhzLastSettings;
 
 SubGhzLastSettings* subghz_last_settings_alloc(void);


### PR DESCRIPTION
# What's new

- Added Auto Save SubGhz recordings as asked in https://github.com/DarkFlippers/unleashed-firmware/issues/109 .
- You just keep reading, and it keeps recording in "autosave" folder.
-   Co-authored-by: WillyJL <me@willyjl.dev>

# Verification 

- Go to Sub-GHz app
- Click Read
- Select Config
- Make sure "Autosave" is ON
- Return back
- Keep reading Sub-GHZ signals.
- Return back and ignore loss warning.
- Click on "saved"
- Check the contents of "Autosave" folder.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
