### PR TITLE
Make Bluetooth toggle more obvious

### DIFF
--- a/applications/services/desktop/views/desktop_view_lock_menu.c
+++ b/applications/services/desktop/views/desktop_view_lock_menu.c
@@ -65,9 +65,9 @@ void desktop_lock_menu_draw_callback(Canvas* canvas, void* model) {
         //if(i == DesktopLockMenuIndexLock) {
         if(i == DesktopLockMenuIndexBt) {
             if(m->bt_mode) {
-                str = "Bluetooth Off";
+                str = "Turn Bluetooth Off";
             } else {
-                str = "Bluetooth On";
+                str = "Turn Bluetooth On";
             }
         } else if(i == DesktopLockMenuIndexStealth) {
             if(m->stealth_mode) {


### PR DESCRIPTION
# What's new

- Made Bluetooth toggle more obvious that it is a toggle and isn't telling you Bluetooth **is** on or off

# Verification 

- Press UP on desktop

# Author Checklist (Fill this out):

- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- [ Describe how AI was used in this PR if it was used ]

# Checklist (For Reviewer) (Don't fill this out!):

- [ ] PR has proper description of new feature/bugfix
- [ ] Description contains actions to verify feature/bugfix on the hardware
- [ ] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
