### PR TITLE
UI wording changes to be more clear

### DIFF
--- a/applications/services/desktop/views/desktop_view_lock_menu.c
+++ b/applications/services/desktop/views/desktop_view_lock_menu.c
@@ -65,9 +65,9 @@ void desktop_lock_menu_draw_callback(Canvas* canvas, void* model) {
         //if(i == DesktopLockMenuIndexLock) {
         if(i == DesktopLockMenuIndexBt) {
             if(m->bt_mode) {
-                str = "Bluetooth Off";
+                str = "Turn Bluetooth Off";
             } else {
-                str = "Bluetooth On";
+                str = "Turn Bluetooth On";
             }
         } else if(i == DesktopLockMenuIndexStealth) {
             if(m->stealth_mode) {

--- a/applications/settings/power_settings_app/scenes/power_settings_scene_power_off.c
+++ b/applications/settings/power_settings_app/scenes/power_settings_scene_power_off.c
@@ -27,7 +27,7 @@ void power_settings_scene_power_off_on_enter(void* context) {
             dialog, "   I will be\nwaiting for\n you here...", 78, 14, AlignLeft, AlignTop);
         dialog_ex_set_icon(dialog, 24, 10, &I_dolph_cry_49x54);
     }
-    dialog_ex_set_left_button_text(dialog, "Settings");
+    dialog_ex_set_left_button_text(dialog, "Battery");
     dialog_ex_set_right_button_text(dialog, "Power Off");
     dialog_ex_set_result_callback(dialog, power_settings_scene_power_off_dialog_callback);
     dialog_ex_set_context(dialog, app);


### PR DESCRIPTION
# What's new

- Made Bluetooth toggle more clear that it is a toggle and isn't telling you Bluetooth **is** on or off by adding the word "Turn"
- Change "Settings" to "Battery" in Power Off menu per Dezedrix's suggestion

# Verification 

- Press UP from the Desktop
- Hold BACK from the desktop

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- [ Describe how AI was used in this PR if it was used ]

# Checklist (For Reviewer) (Don't fill this out!):

- [x] PR has proper description of new feature/bugfix
- [x] Description contains actions to verify feature/bugfix on the hardware
- [x] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
