### PR TITLE
[RFID]: Support of Hitag Micro chips (8265/8210/H5.5)

### DIFF
--- a/applications/main/lfrfid/lfrfid_i.h
+++ b/applications/main/lfrfid/lfrfid_i.h
@@ -63,6 +63,7 @@ enum LfRfidCustomEvent {
     LfRfidEventWriteProtocolCannotBeWritten,
     LfRfidEventWriteFobCannotBeWritten,
     LfRfidEventWriteTooLongToWrite,
+    LfRfidEventWriteProgress,
     LfRfidEventRpcLoadFile,
     LfRfidEventRpcSessionClose,
 };

--- a/applications/main/lfrfid/scenes/lfrfid_scene_write.c
+++ b/applications/main/lfrfid/scenes/lfrfid_scene_write.c
@@ -1,5 +1,9 @@
 #include "../lfrfid_i.h"
 
+// Set once a warning popup (cannot-write / still-trying) is shown, so later write-progress
+// events stop overwriting its message and layout.
+static bool lfrfid_write_warning_shown;
+
 static void lfrfid_write_callback(LFRFIDWorkerWriteResult result, void* context) {
     LfRfid* app = context;
     uint32_t event = 0;
@@ -22,6 +26,8 @@ static void lfrfid_write_callback(LFRFIDWorkerWriteResult result, void* context)
 void lfrfid_scene_write_on_enter(void* context) {
     LfRfid* app = context;
     Popup* popup = app->popup;
+
+    lfrfid_write_warning_shown = false;
 
     popup_set_icon(popup, 0, 8, &I_NFC_manual_60x50);
     popup_set_header(popup, "Writing", 94, 16, AlignCenter, AlignTop);
@@ -62,27 +68,35 @@ bool lfrfid_scene_write_on_event(void* context, SceneManagerEvent event) {
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == LfRfidEventWriteProgress) {
             // Show which chip/protocol is currently being attempted, under the source line.
-            const char* target = lfrfid_worker_get_write_chip_name(app->lfworker);
-            const char* protocol_name = protocol_dict_get_name(app->dict, app->protocol_id);
-            if(!furi_string_empty(app->file_name)) {
-                snprintf(
-                    app->text_store,
-                    LFRFID_TEXT_STORE_SIZE,
-                    "[%s]\n%s\n(%s)",
-                    protocol_name,
-                    furi_string_get_cstr(app->file_name),
-                    target);
-            } else {
-                snprintf(
-                    app->text_store, LFRFID_TEXT_STORE_SIZE, "[%s]\n(%s)", protocol_name, target);
+            // Never override a warning popup once it is up.
+            if(!lfrfid_write_warning_shown) {
+                const char* target = lfrfid_worker_get_write_chip_name(app->lfworker);
+                const char* protocol_name = protocol_dict_get_name(app->dict, app->protocol_id);
+                if(!furi_string_empty(app->file_name)) {
+                    snprintf(
+                        app->text_store,
+                        LFRFID_TEXT_STORE_SIZE,
+                        "[%s]\n%s\n(%s)",
+                        protocol_name,
+                        furi_string_get_cstr(app->file_name),
+                        target);
+                } else {
+                    snprintf(
+                        app->text_store,
+                        LFRFID_TEXT_STORE_SIZE,
+                        "[%s]\n(%s)",
+                        protocol_name,
+                        target);
+                }
+                popup_set_text(popup, app->text_store, 94, 29, AlignCenter, AlignTop);
             }
-            popup_set_text(popup, app->text_store, 94, 29, AlignCenter, AlignTop);
             consumed = true;
         } else if(event.event == LfRfidEventWriteOK) {
             notification_message(app->notifications, &sequence_success);
             scene_manager_next_scene(app->scene_manager, LfRfidSceneWriteSuccess);
             consumed = true;
         } else if(event.event == LfRfidEventWriteProtocolCannotBeWritten) {
+            lfrfid_write_warning_shown = true;
             popup_set_icon(popup, 83, 22, &I_WarningDolphinFlip_45x42);
             popup_set_header(popup, "Error", 64, 3, AlignCenter, AlignTop);
             popup_set_text(popup, "This protocol\ncannot be written", 3, 17, AlignLeft, AlignTop);
@@ -91,6 +105,7 @@ bool lfrfid_scene_write_on_event(void* context, SceneManagerEvent event) {
         } else if(
             (event.event == LfRfidEventWriteFobCannotBeWritten) ||
             (event.event == LfRfidEventWriteTooLongToWrite)) {
+            lfrfid_write_warning_shown = true;
             popup_set_icon(popup, 83, 22, &I_WarningDolphinFlip_45x42);
             popup_set_header(popup, "Still Trying to Write...", 64, 0, AlignCenter, AlignTop);
             popup_set_text(

--- a/applications/main/lfrfid/scenes/lfrfid_scene_write.c
+++ b/applications/main/lfrfid/scenes/lfrfid_scene_write.c
@@ -23,6 +23,25 @@ static void lfrfid_write_callback(LFRFIDWorkerWriteResult result, void* context)
     view_dispatcher_send_custom_event(app->view_dispatcher, event);
 }
 
+// Compose the "Writing" popup text: "[<proto>]\n<source>", with "\n(<target>)" appended while a
+// specific chip is being attempted. <source> is the file name, or "Unsaved Tag" when there is no
+// file (mid-attempt with no file, only the protocol and target are shown - no source line).
+static void lfrfid_scene_write_set_status(LfRfid* app, const char* target) {
+    const char* proto = protocol_dict_get_name(app->dict, app->protocol_id);
+    const char* file =
+        furi_string_empty(app->file_name) ? NULL : furi_string_get_cstr(app->file_name);
+    if(file && target) {
+        snprintf(app->text_store, LFRFID_TEXT_STORE_SIZE, "[%s]\n%s\n(%s)", proto, file, target);
+    } else if(file) {
+        snprintf(app->text_store, LFRFID_TEXT_STORE_SIZE, "[%s]\n%s", proto, file);
+    } else if(target) {
+        snprintf(app->text_store, LFRFID_TEXT_STORE_SIZE, "[%s]\n(%s)", proto, target);
+    } else {
+        snprintf(app->text_store, LFRFID_TEXT_STORE_SIZE, "[%s]\nUnsaved Tag", proto);
+    }
+    popup_set_text(app->popup, app->text_store, 94, 29, AlignCenter, AlignTop);
+}
+
 void lfrfid_scene_write_on_enter(void* context) {
     LfRfid* app = context;
     Popup* popup = app->popup;
@@ -32,22 +51,7 @@ void lfrfid_scene_write_on_enter(void* context) {
     popup_set_icon(popup, 0, 8, &I_NFC_manual_60x50);
     popup_set_header(popup, "Writing", 94, 16, AlignCenter, AlignTop);
 
-    if(!furi_string_empty(app->file_name)) {
-        snprintf(
-            app->text_store,
-            LFRFID_TEXT_STORE_SIZE,
-            "[%s]\n%s",
-            protocol_dict_get_name(app->dict, app->protocol_id),
-            furi_string_get_cstr(app->file_name));
-        popup_set_text(popup, app->text_store, 94, 29, AlignCenter, AlignTop);
-    } else {
-        snprintf(
-            app->text_store,
-            LFRFID_TEXT_STORE_SIZE,
-            "[%s]\nUnsaved Tag",
-            protocol_dict_get_name(app->dict, app->protocol_id));
-        popup_set_text(popup, app->text_store, 94, 29, AlignCenter, AlignTop);
-    }
+    lfrfid_scene_write_set_status(app, NULL);
 
     view_dispatcher_switch_to_view(app->view_dispatcher, LfRfidViewPopup);
 
@@ -70,25 +74,8 @@ bool lfrfid_scene_write_on_event(void* context, SceneManagerEvent event) {
             // Show which chip/protocol is currently being attempted, under the source line.
             // Never override a warning popup once it is up.
             if(!lfrfid_write_warning_shown) {
-                const char* target = lfrfid_worker_get_write_chip_name(app->lfworker);
-                const char* protocol_name = protocol_dict_get_name(app->dict, app->protocol_id);
-                if(!furi_string_empty(app->file_name)) {
-                    snprintf(
-                        app->text_store,
-                        LFRFID_TEXT_STORE_SIZE,
-                        "[%s]\n%s\n(%s)",
-                        protocol_name,
-                        furi_string_get_cstr(app->file_name),
-                        target);
-                } else {
-                    snprintf(
-                        app->text_store,
-                        LFRFID_TEXT_STORE_SIZE,
-                        "[%s]\n(%s)",
-                        protocol_name,
-                        target);
-                }
-                popup_set_text(popup, app->text_store, 94, 29, AlignCenter, AlignTop);
+                lfrfid_scene_write_set_status(
+                    app, lfrfid_worker_get_write_chip_name(app->lfworker));
             }
             consumed = true;
         } else if(event.event == LfRfidEventWriteOK) {

--- a/applications/main/lfrfid/scenes/lfrfid_scene_write.c
+++ b/applications/main/lfrfid/scenes/lfrfid_scene_write.c
@@ -28,8 +28,8 @@ static void lfrfid_write_callback(LFRFIDWorkerWriteResult result, void* context)
 // file (mid-attempt with no file, only the protocol and target are shown - no source line).
 static void lfrfid_scene_write_set_status(LfRfid* app, const char* target) {
     const char* proto = protocol_dict_get_name(app->dict, app->protocol_id);
-    const char* file =
-        furi_string_empty(app->file_name) ? NULL : furi_string_get_cstr(app->file_name);
+    const char* file = furi_string_empty(app->file_name) ? NULL :
+                                                           furi_string_get_cstr(app->file_name);
     if(file && target) {
         snprintf(app->text_store, LFRFID_TEXT_STORE_SIZE, "[%s]\n%s\n(%s)", proto, file, target);
     } else if(file) {

--- a/applications/main/lfrfid/scenes/lfrfid_scene_write.c
+++ b/applications/main/lfrfid/scenes/lfrfid_scene_write.c
@@ -12,6 +12,8 @@ static void lfrfid_write_callback(LFRFIDWorkerWriteResult result, void* context)
         event = LfRfidEventWriteFobCannotBeWritten;
     } else if(result == LFRFIDWorkerWriteTooLongToWrite) {
         event = LfRfidEventWriteTooLongToWrite;
+    } else if(result == LFRFIDWorkerWriteStartTarget) {
+        event = LfRfidEventWriteProgress;
     }
 
     view_dispatcher_send_custom_event(app->view_dispatcher, event);
@@ -58,7 +60,25 @@ bool lfrfid_scene_write_on_event(void* context, SceneManagerEvent event) {
     bool consumed = false;
 
     if(event.type == SceneManagerEventTypeCustom) {
-        if(event.event == LfRfidEventWriteOK) {
+        if(event.event == LfRfidEventWriteProgress) {
+            // Show which chip/protocol is currently being attempted, under the source line.
+            const char* target = lfrfid_worker_get_write_chip_name(app->lfworker);
+            const char* protocol_name = protocol_dict_get_name(app->dict, app->protocol_id);
+            if(!furi_string_empty(app->file_name)) {
+                snprintf(
+                    app->text_store,
+                    LFRFID_TEXT_STORE_SIZE,
+                    "[%s]\n%s\n(%s)",
+                    protocol_name,
+                    furi_string_get_cstr(app->file_name),
+                    target);
+            } else {
+                snprintf(
+                    app->text_store, LFRFID_TEXT_STORE_SIZE, "[%s]\n(%s)", protocol_name, target);
+            }
+            popup_set_text(popup, app->text_store, 94, 29, AlignCenter, AlignTop);
+            consumed = true;
+        } else if(event.event == LfRfidEventWriteOK) {
             notification_message(app->notifications, &sequence_success);
             scene_manager_next_scene(app->scene_manager, LfRfidSceneWriteSuccess);
             consumed = true;

--- a/applications/main/lfrfid/scenes/lfrfid_scene_write_and_set_pass.c
+++ b/applications/main/lfrfid/scenes/lfrfid_scene_write_and_set_pass.c
@@ -22,14 +22,16 @@ void lfrfid_scene_write_and_set_pass_on_enter(void* context) {
     LfRfid* app = context;
     Popup* popup = app->popup;
 
-    popup_set_header(popup, "Writing\nwith\npassword", 94, 8, AlignCenter, AlignTop);
+    popup_set_header(popup, "Writing\nwith\npassword", 94, 4, AlignCenter, AlignTop);
     popup_set_icon(popup, 0, 8, &I_NFC_manual_60x50);
+    // Mirror the Write scene: show the protocol and the target chip. This path always writes a
+    // T5577 (the only chip that supports a password), so the target is fixed.
     snprintf(
         app->text_store,
         LFRFID_TEXT_STORE_SIZE,
-        "[%s]",
+        "[%s]\n(T5577)",
         protocol_dict_get_name(app->dict, app->protocol_id));
-    popup_set_text(popup, app->text_store, 94, 45, AlignCenter, AlignTop);
+    popup_set_text(popup, app->text_store, 94, 41, AlignCenter, AlignTop);
 
     view_dispatcher_switch_to_view(app->view_dispatcher, LfRfidViewPopup);
 

--- a/applications/main/lfrfid/scenes/lfrfid_scene_write_success.c
+++ b/applications/main/lfrfid/scenes/lfrfid_scene_write_success.c
@@ -6,6 +6,13 @@ void lfrfid_scene_write_success_on_enter(void* context) {
 
     popup_set_header(popup, "Success!", 75, 10, AlignLeft, AlignTop);
     popup_set_icon(popup, 0, 9, &I_DolphinSuccess_91x55);
+
+    // Show which chip the write actually landed on, when detected.
+    const char* write_chip_name = lfrfid_worker_get_write_chip_name(app->lfworker);
+    if(write_chip_name[0] != '\0') {
+        popup_set_text(popup, write_chip_name, 75, 26, AlignLeft, AlignTop);
+    }
+
     popup_set_context(popup, app);
     popup_set_callback(popup, lfrfid_popup_timeout_callback);
     popup_set_timeout(popup, 1500);

--- a/applications/main/lfrfid/scenes/lfrfid_scene_write_success.c
+++ b/applications/main/lfrfid/scenes/lfrfid_scene_write_success.c
@@ -7,10 +7,12 @@ void lfrfid_scene_write_success_on_enter(void* context) {
     popup_set_header(popup, "Success!", 75, 10, AlignLeft, AlignTop);
     popup_set_icon(popup, 0, 9, &I_DolphinSuccess_91x55);
 
-    // Show which chip the write actually landed on, when detected.
+    // Show which chip the write actually landed on, when detected. Placed in the strip to
+    // the right of the 91px-wide dolphin icon (right-aligned at the screen edge) so it does
+    // not overlap the artwork.
     const char* write_chip_name = lfrfid_worker_get_write_chip_name(app->lfworker);
     if(write_chip_name[0] != '\0') {
-        popup_set_text(popup, write_chip_name, 75, 26, AlignLeft, AlignTop);
+        popup_set_text(popup, write_chip_name, 128, 30, AlignRight, AlignTop);
     }
 
     popup_set_context(popup, app);

--- a/lib/lfrfid/lfrfid_worker.c
+++ b/lib/lfrfid/lfrfid_worker.c
@@ -30,6 +30,7 @@ LFRFIDWorker* lfrfid_worker_alloc(ProtocolDict* dict) {
     worker->cb_ctx = NULL;
     worker->raw_filename = NULL;
     worker->mode_storage = NULL;
+    worker->write_chip_name[0] = '\0';
 
     worker->thread = furi_thread_alloc_ex("LfrfidWorker", 2048, lfrfid_worker_thread, worker);
 
@@ -137,6 +138,11 @@ void lfrfid_worker_stop(LFRFIDWorker* worker) {
     furi_check(worker);
 
     furi_thread_flags_set(furi_thread_get_id(worker->thread), LFRFIDEventStopMode);
+}
+
+const char* lfrfid_worker_get_write_chip_name(LFRFIDWorker* worker) {
+    furi_check(worker);
+    return worker->write_chip_name;
 }
 
 void lfrfid_worker_start_thread(LFRFIDWorker* worker) {

--- a/lib/lfrfid/lfrfid_worker.h
+++ b/lib/lfrfid/lfrfid_worker.h
@@ -16,6 +16,7 @@ typedef enum {
     LFRFIDWorkerWriteProtocolCannotBeWritten,
     LFRFIDWorkerWriteFobCannotBeWritten,
     LFRFIDWorkerWriteTooLongToWrite,
+    LFRFIDWorkerWriteStartTarget, // a new write target/variant attempt started (progress UI)
 } LFRFIDWorkerWriteResult;
 
 typedef enum {
@@ -159,8 +160,8 @@ void lfrfid_worker_stop(LFRFIDWorker* worker);
 /** Name of the chip the last successful write landed on
  *
  * Set by the write modes when a write is verified (e.g. "T5577", "EM4305" or a
- * "Hitag U\n<variant>" label). Returns an empty string when nothing has been
- * written yet or the chip could not be identified.
+ * Hitag micro model code like "8210"). Returns an empty string when nothing has
+ * been written yet or the chip could not be identified.
  *
  * @param      worker  The worker
  * @return     pointer to a NUL-terminated, worker-owned string (may contain '\n')

--- a/lib/lfrfid/lfrfid_worker.h
+++ b/lib/lfrfid/lfrfid_worker.h
@@ -164,7 +164,7 @@ void lfrfid_worker_stop(LFRFIDWorker* worker);
  * been written yet or the chip could not be identified.
  *
  * @param      worker  The worker
- * @return     pointer to a NUL-terminated, worker-owned string (may contain '\n')
+ * @return     pointer to a NUL-terminated, worker-owned string (single line, no newline)
  */
 const char* lfrfid_worker_get_write_chip_name(LFRFIDWorker* worker);
 

--- a/lib/lfrfid/lfrfid_worker.h
+++ b/lib/lfrfid/lfrfid_worker.h
@@ -156,6 +156,17 @@ void lfrfid_worker_emulate_raw_start(
  */
 void lfrfid_worker_stop(LFRFIDWorker* worker);
 
+/** Name of the chip the last successful write landed on
+ *
+ * Set by the write modes when a write is verified (e.g. "T5577", "EM4305" or a
+ * "Hitag U\n<variant>" label). Returns an empty string when nothing has been
+ * written yet or the chip could not be identified.
+ *
+ * @param      worker  The worker
+ * @return     pointer to a NUL-terminated, worker-owned string (may contain '\n')
+ */
+const char* lfrfid_worker_get_write_chip_name(LFRFIDWorker* worker);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/lfrfid/lfrfid_worker_i.h
+++ b/lib/lfrfid/lfrfid_worker_i.h
@@ -10,7 +10,7 @@
 #include "lfrfid_raw_worker.h"
 #include "protocols/lfrfid_protocols.h"
 
-// Longest value is a chip name like "8265/H5" (7 chars); 24 leaves generous headroom.
+// Longest value is a chip name like "EM4305" (6 chars); 24 leaves generous headroom.
 #define LFRFID_WORKER_WRITE_CHIP_NAME_SIZE 24
 
 #ifdef __cplusplus

--- a/lib/lfrfid/lfrfid_worker_i.h
+++ b/lib/lfrfid/lfrfid_worker_i.h
@@ -49,7 +49,7 @@ struct LFRFIDWorker {
     ProtocolDict* protocols;
     LFRFIDProtocol protocol;
 
-    // Chip the last successful write landed on (e.g. "T5577", "Hitag U\n8265/H5").
+    // Chip the last successful write landed on (e.g. "T5577", "EM4305", "8210").
     // Empty string means "unknown / not detected". Read via lfrfid_worker_get_write_chip_name().
     char write_chip_name[24];
 };

--- a/lib/lfrfid/lfrfid_worker_i.h
+++ b/lib/lfrfid/lfrfid_worker_i.h
@@ -48,6 +48,10 @@ struct LFRFIDWorker {
 
     ProtocolDict* protocols;
     LFRFIDProtocol protocol;
+
+    // Chip the last successful write landed on (e.g. "T5577", "Hitag U\n8265/H5").
+    // Empty string means "unknown / not detected". Read via lfrfid_worker_get_write_chip_name().
+    char write_chip_name[24];
 };
 
 extern const LFRFIDWorkerModeType lfrfid_worker_modes[];

--- a/lib/lfrfid/lfrfid_worker_i.h
+++ b/lib/lfrfid/lfrfid_worker_i.h
@@ -10,6 +10,9 @@
 #include "lfrfid_raw_worker.h"
 #include "protocols/lfrfid_protocols.h"
 
+// Longest value is a chip name like "8265/H5" (7 chars); 24 leaves generous headroom.
+#define LFRFID_WORKER_WRITE_CHIP_NAME_SIZE 24
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -51,7 +54,7 @@ struct LFRFIDWorker {
 
     // Chip the last successful write landed on (e.g. "T5577", "EM4305", "8210").
     // Empty string means "unknown / not detected". Read via lfrfid_worker_get_write_chip_name().
-    char write_chip_name[24];
+    char write_chip_name[LFRFID_WORKER_WRITE_CHIP_NAME_SIZE];
 };
 
 extern const LFRFIDWorkerModeType lfrfid_worker_modes[];

--- a/lib/lfrfid/lfrfid_worker_modes.c
+++ b/lib/lfrfid/lfrfid_worker_modes.c
@@ -557,10 +557,12 @@ static LFRFIDWorkerWriteVerifyResult lfrfid_worker_write_verify(
     return LFRFIDWorkerWriteVerifyNoMatch;
 }
 
-// Like lfrfid_worker_write_verify, but also counts a non-matching read towards the
-// "card cannot be written" feedback. Counting per verify (rather than once per pass)
-// keeps that feedback timely now that a single pass issues several writes + verifies.
-static LFRFIDWorkerWriteVerifyResult lfrfid_worker_write_verify_attempt(
+// Read the tag back for one write attempt and decide whether the write loop should stop:
+// on a match, report success (the chip name was already recorded by
+// lfrfid_worker_write_set_target); on a user abort, just stop; on a non-match, count it
+// towards the "card cannot be written" feedback (timely now that a pass issues several
+// writes + verifies) and keep trying. Returns true when the loop should stop.
+static bool lfrfid_worker_write_verify_and_finish(
     LFRFIDWorker* worker,
     LFRFIDProtocol protocol,
     const uint8_t* verify_data,
@@ -570,14 +572,19 @@ static LFRFIDWorkerWriteVerifyResult lfrfid_worker_write_verify_attempt(
     LFRFIDWorkerWriteVerifyResult result =
         lfrfid_worker_write_verify(worker, protocol, verify_data, read_data, data_size);
 
-    if(result == LFRFIDWorkerWriteVerifyNoMatch) {
-        (*unsuccessful_reads)++;
-        if(*unsuccessful_reads == LFRFID_WORKER_WRITE_MAX_UNSUCCESSFUL_READS && worker->write_cb) {
-            worker->write_cb(LFRFIDWorkerWriteFobCannotBeWritten, worker->cb_ctx);
-        }
+    if(result == LFRFIDWorkerWriteVerifyAbort) {
+        return true;
+    }
+    if(result == LFRFIDWorkerWriteVerifyMatch) {
+        if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
+        return true;
     }
 
-    return result;
+    (*unsuccessful_reads)++;
+    if(*unsuccessful_reads == LFRFID_WORKER_WRITE_MAX_UNSUCCESSFUL_READS && worker->write_cb) {
+        worker->write_cb(LFRFIDWorkerWriteFobCannotBeWritten, worker->cb_ctx);
+    }
+    return false;
 }
 
 // Record the target now being attempted and notify the UI (so the write screen can show
@@ -586,21 +593,6 @@ static void lfrfid_worker_write_set_target(LFRFIDWorker* worker, const char* tar
     FURI_LOG_D(TAG, "write target: %s", target);
     snprintf(worker->write_chip_name, sizeof(worker->write_chip_name), "%s", target);
     if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteStartTarget, worker->cb_ctx);
-}
-
-// Apply a verify result for one write attempt: on a match, report success (the chip name was
-// already recorded by lfrfid_worker_write_set_target); on a user abort, just stop. Returns
-// true when the write loop should stop (matched or aborted), false to keep trying targets.
-static bool
-    lfrfid_worker_write_finish(LFRFIDWorker* worker, LFRFIDWorkerWriteVerifyResult verify) {
-    if(verify == LFRFIDWorkerWriteVerifyAbort) {
-        return true;
-    }
-    if(verify == LFRFIDWorkerWriteVerifyMatch) {
-        if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
-        return true;
-    }
-    return false;
 }
 
 static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
@@ -652,17 +644,13 @@ static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
             if(request->write_type == LFRFIDWriteTypeT5577) {
                 lfrfid_worker_write_set_target(worker, "T5577");
                 t5577_write(&request->t5577);
-                done = lfrfid_worker_write_finish(
-                    worker,
-                    lfrfid_worker_write_verify_attempt(
-                        worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads));
+                done = lfrfid_worker_write_verify_and_finish(
+                    worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads);
             } else if(request->write_type == LFRFIDWriteTypeEM4305) {
                 lfrfid_worker_write_set_target(worker, "EM4305");
                 em4305_write(&request->em4305);
-                done = lfrfid_worker_write_finish(
-                    worker,
-                    lfrfid_worker_write_verify_attempt(
-                        worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads));
+                done = lfrfid_worker_write_verify_and_finish(
+                    worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads);
             } else if(request->write_type == LFRFIDWriteTypeHitagMicro) {
                 // ID82xx / Hitag micro magic chips differ only by their LOGIN password. Try
                 // each known variant and verify after each: a wrong password is rejected and
@@ -672,10 +660,8 @@ static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
                 for(uint8_t variant = 0; variant < HitagMicroVariantCount && !done; variant++) {
                     lfrfid_worker_write_set_target(worker, hitagmicro_variant_name(variant));
                     hitagmicro_write(&request->hitagmicro, hitagmicro_variant_password(variant));
-                    done = lfrfid_worker_write_finish(
-                        worker,
-                        lfrfid_worker_write_verify_attempt(
-                            worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads));
+                    done = lfrfid_worker_write_verify_and_finish(
+                        worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads);
                 }
             } else {
                 furi_crash("Unknown write type");

--- a/lib/lfrfid/lfrfid_worker_modes.c
+++ b/lib/lfrfid/lfrfid_worker_modes.c
@@ -545,6 +545,47 @@ static LFRFIDWorkerWriteVerifyResult lfrfid_worker_write_verify(
     return LFRFIDWorkerWriteVerifyNoMatch;
 }
 
+// Like lfrfid_worker_write_verify, but also counts a non-matching read towards the
+// "card cannot be written" feedback. Counting per verify (rather than once per pass)
+// keeps that feedback timely now that a single pass issues several writes + verifies.
+static LFRFIDWorkerWriteVerifyResult lfrfid_worker_write_verify_attempt(
+    LFRFIDWorker* worker,
+    LFRFIDProtocol protocol,
+    const uint8_t* verify_data,
+    uint8_t* read_data,
+    size_t data_size,
+    size_t* unsuccessful_reads) {
+    LFRFIDWorkerWriteVerifyResult result =
+        lfrfid_worker_write_verify(worker, protocol, verify_data, read_data, data_size);
+
+    if(result == LFRFIDWorkerWriteVerifyNoMatch) {
+        (*unsuccessful_reads)++;
+        if(*unsuccessful_reads == LFRFID_WORKER_WRITE_MAX_UNSUCCESSFUL_READS && worker->write_cb) {
+            worker->write_cb(LFRFIDWorkerWriteFobCannotBeWritten, worker->cb_ctx);
+        }
+    }
+
+    return result;
+}
+
+// Apply a verify result for one write attempt: on a match, record which chip accepted the
+// data and report success; on a user abort, just stop. Returns true when the write loop
+// should stop (matched or aborted), false to keep trying other targets.
+static bool lfrfid_worker_write_finish(
+    LFRFIDWorker* worker,
+    LFRFIDWorkerWriteVerifyResult verify,
+    const char* chip_name) {
+    if(verify == LFRFIDWorkerWriteVerifyAbort) {
+        return true;
+    }
+    if(verify == LFRFIDWorkerWriteVerifyMatch) {
+        snprintf(worker->write_chip_name, sizeof(worker->write_chip_name), "%s", chip_name);
+        if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
+        return true;
+    }
+    return false;
+}
+
 static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
     LFRFIDProtocol protocol = worker->protocol;
     LFRFIDWriteRequest* request = malloc(sizeof(LFRFIDWriteRequest));
@@ -564,7 +605,8 @@ static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
     // Each writable target is written and then immediately read back, so a success can
     // report exactly which chip accepted the data (T5577 / EM4305 / Hitag micro variant).
     // Trade-off: when the present chip is not the first one tried, this is slower than a
-    // single verify per pass (each non-matching attempt costs a verify read) - see PR notes.
+    // single verify per pass - every non-matching target costs one verify read of up to
+    // LFRFID_WORKER_WRITE_VERIFY_TIME_MS.
     bool done = false;
     while(!done && !lfrfid_worker_check_for_stop(worker)) {
         FURI_LOG_D(TAG, "Data write");
@@ -592,40 +634,35 @@ static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
 
             if(request->write_type == LFRFIDWriteTypeT5577) {
                 t5577_write(&request->t5577);
-                LFRFIDWorkerWriteVerifyResult verify =
-                    lfrfid_worker_write_verify(worker, protocol, verify_data, read_data, data_size);
-                if(verify == LFRFIDWorkerWriteVerifyAbort) {
-                    done = true;
-                } else if(verify == LFRFIDWorkerWriteVerifyMatch) {
-                    snprintf(worker->write_chip_name, sizeof(worker->write_chip_name), "T5577");
-                    if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
-                    done = true;
-                }
+                done = lfrfid_worker_write_finish(
+                    worker,
+                    lfrfid_worker_write_verify_attempt(
+                        worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads),
+                    "T5577");
             } else if(request->write_type == LFRFIDWriteTypeEM4305) {
                 em4305_write(&request->em4305);
-                LFRFIDWorkerWriteVerifyResult verify =
-                    lfrfid_worker_write_verify(worker, protocol, verify_data, read_data, data_size);
-                if(verify == LFRFIDWorkerWriteVerifyAbort) {
-                    done = true;
-                } else if(verify == LFRFIDWorkerWriteVerifyMatch) {
-                    snprintf(worker->write_chip_name, sizeof(worker->write_chip_name), "EM4305");
-                    if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
-                    done = true;
-                }
+                done = lfrfid_worker_write_finish(
+                    worker,
+                    lfrfid_worker_write_verify_attempt(
+                        worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads),
+                    "EM4305");
             } else if(request->write_type == LFRFIDWriteTypeHitagMicro) {
                 // ID82xx / Hitag micro magic chips differ only by their LOGIN password.
                 // Try each known variant and verify after each: a wrong password is
                 // rejected and leaves the tag untouched, so the variant that reads back
                 // correctly is the one actually present.
+                // NB: unlike the other targets, write_data leaves the password unset and
+                // the worker fills it per variant here - a deliberate exception to the
+                // usual "write_data fully prepares the request" contract, needed because
+                // each variant must be written and read back individually.
                 for(uint8_t variant = 0; variant < HitagMicroVariantCount && !done; variant++) {
-                    memcpy(
-                        request->hitagmicro.password,
-                        hitagmicro_variant_password(variant),
-                        LFRFID_HITAGMICRO_BLOCK_SIZE);
+                    const uint8_t* password = hitagmicro_variant_password(variant);
+                    furi_check(password);
+                    memcpy(request->hitagmicro.password, password, LFRFID_HITAGMICRO_BLOCK_SIZE);
                     hitagmicro_write(&request->hitagmicro);
 
-                    LFRFIDWorkerWriteVerifyResult verify = lfrfid_worker_write_verify(
-                        worker, protocol, verify_data, read_data, data_size);
+                    LFRFIDWorkerWriteVerifyResult verify = lfrfid_worker_write_verify_attempt(
+                        worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads);
                     if(verify == LFRFIDWorkerWriteVerifyAbort) {
                         done = true;
                     } else if(verify == LFRFIDWorkerWriteVerifyMatch) {
@@ -644,14 +681,6 @@ static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
         }
 
         if(done) break;
-
-        // A whole pass without any target verifying counts as one failed attempt.
-        unsuccessful_reads++;
-        if(unsuccessful_reads == LFRFID_WORKER_WRITE_MAX_UNSUCCESSFUL_READS) {
-            if(worker->write_cb) {
-                worker->write_cb(LFRFIDWorkerWriteFobCannotBeWritten, worker->cb_ctx);
-            }
-        }
 
         if(!too_long &&
            (furi_get_tick() - write_start_time) > LFRFID_WORKER_WRITE_TOO_LONG_TIME_MS) {

--- a/lib/lfrfid/lfrfid_worker_modes.c
+++ b/lib/lfrfid/lfrfid_worker_modes.c
@@ -35,7 +35,9 @@
 #define LFRFID_WORKER_WRITE_DROP_TIME_MS     50
 #define LFRFID_WORKER_WRITE_TOO_LONG_TIME_MS 10000
 
-#define LFRFID_WORKER_WRITE_MAX_UNSUCCESSFUL_READS 5
+// Counted per verify attempt. A Hitag micro pass alone makes up to 5 attempts (T5577 +
+// EM4305 + 3 variants), so keep this above one sweep to avoid a premature "still trying".
+#define LFRFID_WORKER_WRITE_MAX_UNSUCCESSFUL_READS 10
 
 #define LFRFID_WORKER_READ_BUFFER_SIZE  512
 #define LFRFID_WORKER_READ_BUFFER_COUNT 16

--- a/lib/lfrfid/lfrfid_worker_modes.c
+++ b/lib/lfrfid/lfrfid_worker_modes.c
@@ -3,6 +3,8 @@
 #include <furi_hal.h>
 #include "lfrfid_worker_i.h"
 #include "tools/t5577.h"
+#include "tools/hitagmicro.h"
+#include <stdio.h>
 #include <toolbox/pulse_protocols/pulse_glue.h>
 #include <toolbox/buffer_stream.h>
 #include "tools/varint_pair.h"
@@ -507,9 +509,47 @@ static void lfrfid_worker_mode_emulate_process(LFRFIDWorker* worker) {
 /********************************************* WRITE **********************************************/
 /**************************************************************************************************/
 
+typedef enum {
+    LFRFIDWorkerWriteVerifyMatch,
+    LFRFIDWorkerWriteVerifyNoMatch,
+    LFRFIDWorkerWriteVerifyAbort,
+} LFRFIDWorkerWriteVerifyResult;
+
+// Read the tag back once and check whether it now holds the data we intended to write.
+// Used both to confirm a write and to identify which chip actually accepted it.
+static LFRFIDWorkerWriteVerifyResult lfrfid_worker_write_verify(
+    LFRFIDWorker* worker,
+    LFRFIDProtocol protocol,
+    const uint8_t* verify_data,
+    uint8_t* read_data,
+    size_t data_size) {
+    ProtocolId read_result = PROTOCOL_NO;
+    LFRFIDWorkerReadState state = lfrfid_worker_read_internal(
+        worker,
+        protocol_dict_get_features(worker->protocols, protocol),
+        LFRFID_WORKER_WRITE_VERIFY_TIME_MS,
+        &read_result);
+
+    if(state == LFRFIDWorkerReadExit) {
+        return LFRFIDWorkerWriteVerifyAbort;
+    }
+
+    if(state == LFRFIDWorkerReadOK && read_result == protocol) {
+        memset(read_data, 0, data_size);
+        protocol_dict_get_data(worker->protocols, protocol, read_data, data_size);
+        if(memcmp(read_data, verify_data, data_size) == 0) {
+            return LFRFIDWorkerWriteVerifyMatch;
+        }
+    }
+
+    return LFRFIDWorkerWriteVerifyNoMatch;
+}
+
 static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
     LFRFIDProtocol protocol = worker->protocol;
     LFRFIDWriteRequest* request = malloc(sizeof(LFRFIDWriteRequest));
+
+    worker->write_chip_name[0] = '\0';
 
     uint32_t write_start_time = furi_get_tick();
     bool too_long = false;
@@ -521,21 +561,25 @@ static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
 
     protocol_dict_get_data(worker->protocols, protocol, verify_data, data_size);
 
-    while(!lfrfid_worker_check_for_stop(worker)) {
+    // Each writable target is written and then immediately read back, so a success can
+    // report exactly which chip accepted the data (T5577 / EM4305 / Hitag micro variant).
+    // Trade-off: when the present chip is not the first one tried, this is slower than a
+    // single verify per pass (each non-matching attempt costs a verify read) - see PR notes.
+    bool done = false;
+    while(!done && !lfrfid_worker_check_for_stop(worker)) {
         FURI_LOG_D(TAG, "Data write");
         furi_delay_ms(5); // halt
         uint16_t skips = 0;
-        for(size_t i = 0; i < LFRFIDWriteTypeMax; i++) {
-            memset(request, 0, sizeof(LFRFIDWriteRequest));
-            LFRFIDWriteType write_type = i;
-            request->write_type = write_type;
 
+        for(size_t i = 0; i < LFRFIDWriteTypeMax && !done; i++) {
+            memset(request, 0, sizeof(LFRFIDWriteRequest));
+            request->write_type = (LFRFIDWriteType)i;
+
+            // A preceding verify read overwrites the protocol's data, so restore the
+            // intended ID before (re)encoding each write.
             protocol_dict_set_data(worker->protocols, protocol, verify_data, data_size);
 
-            bool can_be_written =
-                protocol_dict_get_write_data(worker->protocols, protocol, request);
-
-            if(!can_be_written) {
+            if(!protocol_dict_get_write_data(worker->protocols, protocol, request)) {
                 skips++;
                 if(skips == LFRFIDWriteTypeMax) {
                     if(worker->write_cb) {
@@ -546,50 +590,67 @@ static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
                 continue;
             }
 
-            memset(read_data, 0, data_size);
-
             if(request->write_type == LFRFIDWriteTypeT5577) {
                 t5577_write(&request->t5577);
+                LFRFIDWorkerWriteVerifyResult verify =
+                    lfrfid_worker_write_verify(worker, protocol, verify_data, read_data, data_size);
+                if(verify == LFRFIDWorkerWriteVerifyAbort) {
+                    done = true;
+                } else if(verify == LFRFIDWorkerWriteVerifyMatch) {
+                    snprintf(worker->write_chip_name, sizeof(worker->write_chip_name), "T5577");
+                    if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
+                    done = true;
+                }
             } else if(request->write_type == LFRFIDWriteTypeEM4305) {
                 em4305_write(&request->em4305);
+                LFRFIDWorkerWriteVerifyResult verify =
+                    lfrfid_worker_write_verify(worker, protocol, verify_data, read_data, data_size);
+                if(verify == LFRFIDWorkerWriteVerifyAbort) {
+                    done = true;
+                } else if(verify == LFRFIDWorkerWriteVerifyMatch) {
+                    snprintf(worker->write_chip_name, sizeof(worker->write_chip_name), "EM4305");
+                    if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
+                    done = true;
+                }
+            } else if(request->write_type == LFRFIDWriteTypeHitagMicro) {
+                // ID82xx / Hitag micro magic chips differ only by their LOGIN password.
+                // Try each known variant and verify after each: a wrong password is
+                // rejected and leaves the tag untouched, so the variant that reads back
+                // correctly is the one actually present.
+                for(uint8_t variant = 0; variant < HitagMicroVariantCount && !done; variant++) {
+                    memcpy(
+                        request->hitagmicro.password,
+                        hitagmicro_variant_password(variant),
+                        LFRFID_HITAGMICRO_BLOCK_SIZE);
+                    hitagmicro_write(&request->hitagmicro);
+
+                    LFRFIDWorkerWriteVerifyResult verify = lfrfid_worker_write_verify(
+                        worker, protocol, verify_data, read_data, data_size);
+                    if(verify == LFRFIDWorkerWriteVerifyAbort) {
+                        done = true;
+                    } else if(verify == LFRFIDWorkerWriteVerifyMatch) {
+                        snprintf(
+                            worker->write_chip_name,
+                            sizeof(worker->write_chip_name),
+                            "Hitag U\n%s",
+                            hitagmicro_variant_name(variant));
+                        if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
+                        done = true;
+                    }
+                }
             } else {
                 furi_crash("Unknown write type");
             }
         }
-        ProtocolId read_result = PROTOCOL_NO;
-        LFRFIDWorkerReadState state = lfrfid_worker_read_internal(
-            worker,
-            protocol_dict_get_features(worker->protocols, protocol),
-            LFRFID_WORKER_WRITE_VERIFY_TIME_MS,
-            &read_result);
 
-        if(state == LFRFIDWorkerReadOK) {
-            bool read_success = false;
+        if(done) break;
 
-            if(read_result == protocol) {
-                protocol_dict_get_data(worker->protocols, protocol, read_data, data_size);
-
-                if(memcmp(read_data, verify_data, data_size) == 0) {
-                    read_success = true;
-                }
+        // A whole pass without any target verifying counts as one failed attempt.
+        unsuccessful_reads++;
+        if(unsuccessful_reads == LFRFID_WORKER_WRITE_MAX_UNSUCCESSFUL_READS) {
+            if(worker->write_cb) {
+                worker->write_cb(LFRFIDWorkerWriteFobCannotBeWritten, worker->cb_ctx);
             }
-
-            if(read_success) {
-                if(worker->write_cb) {
-                    worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
-                }
-                break;
-            } else {
-                unsuccessful_reads++;
-
-                if(unsuccessful_reads == LFRFID_WORKER_WRITE_MAX_UNSUCCESSFUL_READS) {
-                    if(worker->write_cb) {
-                        worker->write_cb(LFRFIDWorkerWriteFobCannotBeWritten, worker->cb_ctx);
-                    }
-                }
-            }
-        } else if(state == LFRFIDWorkerReadExit) {
-            break;
         }
 
         if(!too_long &&
@@ -612,6 +673,8 @@ static void lfrfid_worker_mode_write_and_set_pass_process(LFRFIDWorker* worker) 
     LFRFIDProtocol protocol = worker->protocol;
     LFRFIDWriteRequest* request = malloc(sizeof(LFRFIDWriteRequest));
     request->write_type = LFRFIDWriteTypeT5577;
+
+    worker->write_chip_name[0] = '\0';
 
     bool can_be_written = protocol_dict_get_write_data(worker->protocols, protocol, request);
 
@@ -664,6 +727,7 @@ static void lfrfid_worker_mode_write_and_set_pass_process(LFRFIDWorker* worker) 
                 if(read_success) {
                     FURI_LOG_D(TAG, "Write with password %08lX success", pass);
 
+                    snprintf(worker->write_chip_name, sizeof(worker->write_chip_name), "T5577");
                     if(worker->write_cb) {
                         worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
                     }

--- a/lib/lfrfid/lfrfid_worker_modes.c
+++ b/lib/lfrfid/lfrfid_worker_modes.c
@@ -540,6 +540,14 @@ static LFRFIDWorkerWriteVerifyResult lfrfid_worker_write_verify(
         if(memcmp(read_data, verify_data, data_size) == 0) {
             return LFRFIDWorkerWriteVerifyMatch;
         }
+        // Read back the right protocol but different data: the tag emulates something, but
+        // not what we wrote (wrong block/config mapping, or a stale ID).
+        FURI_LOG_D(TAG, "verify: read protocol %d but data mismatch", (int)read_result);
+    } else {
+        // Nothing readable as the target protocol: the tag is not emulating our ID at all
+        // (write likely did not take, or it needs a different power cycle / read).
+        FURI_LOG_D(
+            TAG, "verify: no match (read state %d, protocol %d)", (int)state, (int)read_result);
     }
 
     return LFRFIDWorkerWriteVerifyNoMatch;
@@ -658,6 +666,8 @@ static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
                 for(uint8_t variant = 0; variant < HitagMicroVariantCount && !done; variant++) {
                     const uint8_t* password = hitagmicro_variant_password(variant);
                     furi_check(password);
+                    FURI_LOG_D(
+                        TAG, "Hitag micro: writing variant %s", hitagmicro_variant_name(variant));
                     memcpy(request->hitagmicro.password, password, LFRFID_HITAGMICRO_BLOCK_SIZE);
                     hitagmicro_write(&request->hitagmicro);
 

--- a/lib/lfrfid/lfrfid_worker_modes.c
+++ b/lib/lfrfid/lfrfid_worker_modes.c
@@ -576,18 +576,23 @@ static LFRFIDWorkerWriteVerifyResult lfrfid_worker_write_verify_attempt(
     return result;
 }
 
-// Apply a verify result for one write attempt: on a match, record which chip accepted the
-// data and report success; on a user abort, just stop. Returns true when the write loop
-// should stop (matched or aborted), false to keep trying other targets.
-static bool lfrfid_worker_write_finish(
-    LFRFIDWorker* worker,
-    LFRFIDWorkerWriteVerifyResult verify,
-    const char* chip_name) {
+// Record the target now being attempted and notify the UI (so the write screen can show
+// it). On success this same string is what the success screen reports as the written chip.
+static void lfrfid_worker_write_set_target(LFRFIDWorker* worker, const char* target) {
+    FURI_LOG_D(TAG, "write target: %s", target);
+    snprintf(worker->write_chip_name, sizeof(worker->write_chip_name), "%s", target);
+    if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteStartTarget, worker->cb_ctx);
+}
+
+// Apply a verify result for one write attempt: on a match, report success (the chip name was
+// already recorded by lfrfid_worker_write_set_target); on a user abort, just stop. Returns
+// true when the write loop should stop (matched or aborted), false to keep trying targets.
+static bool
+    lfrfid_worker_write_finish(LFRFIDWorker* worker, LFRFIDWorkerWriteVerifyResult verify) {
     if(verify == LFRFIDWorkerWriteVerifyAbort) {
         return true;
     }
     if(verify == LFRFIDWorkerWriteVerifyMatch) {
-        snprintf(worker->write_chip_name, sizeof(worker->write_chip_name), "%s", chip_name);
         if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
         return true;
     }
@@ -641,49 +646,35 @@ static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
             }
 
             if(request->write_type == LFRFIDWriteTypeT5577) {
+                lfrfid_worker_write_set_target(worker, "T5577");
                 t5577_write(&request->t5577);
                 done = lfrfid_worker_write_finish(
                     worker,
                     lfrfid_worker_write_verify_attempt(
-                        worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads),
-                    "T5577");
+                        worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads));
             } else if(request->write_type == LFRFIDWriteTypeEM4305) {
+                lfrfid_worker_write_set_target(worker, "EM4305");
                 em4305_write(&request->em4305);
                 done = lfrfid_worker_write_finish(
                     worker,
                     lfrfid_worker_write_verify_attempt(
-                        worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads),
-                    "EM4305");
+                        worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads));
             } else if(request->write_type == LFRFIDWriteTypeHitagMicro) {
-                // ID82xx / Hitag micro magic chips differ only by their LOGIN password.
-                // Try each known variant and verify after each: a wrong password is
-                // rejected and leaves the tag untouched, so the variant that reads back
-                // correctly is the one actually present.
-                // NB: unlike the other targets, write_data leaves the password unset and
-                // the worker fills it per variant here - a deliberate exception to the
-                // usual "write_data fully prepares the request" contract, needed because
-                // each variant must be written and read back individually.
+                // ID82xx / Hitag micro magic chips differ only by their LOGIN password. Try
+                // each known variant and verify after each: a wrong password is rejected and
+                // leaves the tag untouched, so the variant that reads back correctly is the
+                // one actually present. (write_data leaves the password unset; the worker
+                // fills it per variant here - a deliberate exception to the usual contract.)
                 for(uint8_t variant = 0; variant < HitagMicroVariantCount && !done; variant++) {
                     const uint8_t* password = hitagmicro_variant_password(variant);
                     furi_check(password);
-                    FURI_LOG_D(
-                        TAG, "Hitag micro: writing variant %s", hitagmicro_variant_name(variant));
+                    lfrfid_worker_write_set_target(worker, hitagmicro_variant_name(variant));
                     memcpy(request->hitagmicro.password, password, LFRFID_HITAGMICRO_BLOCK_SIZE);
                     hitagmicro_write(&request->hitagmicro);
-
-                    LFRFIDWorkerWriteVerifyResult verify = lfrfid_worker_write_verify_attempt(
-                        worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads);
-                    if(verify == LFRFIDWorkerWriteVerifyAbort) {
-                        done = true;
-                    } else if(verify == LFRFIDWorkerWriteVerifyMatch) {
-                        snprintf(
-                            worker->write_chip_name,
-                            sizeof(worker->write_chip_name),
-                            "Hitag U\n%s",
-                            hitagmicro_variant_name(variant));
-                        if(worker->write_cb) worker->write_cb(LFRFIDWorkerWriteOK, worker->cb_ctx);
-                        done = true;
-                    }
+                    done = lfrfid_worker_write_finish(
+                        worker,
+                        lfrfid_worker_write_verify_attempt(
+                            worker, protocol, verify_data, read_data, data_size, &unsuccessful_reads));
                 }
             } else {
                 furi_crash("Unknown write type");

--- a/lib/lfrfid/lfrfid_worker_modes.c
+++ b/lib/lfrfid/lfrfid_worker_modes.c
@@ -35,9 +35,11 @@
 #define LFRFID_WORKER_WRITE_DROP_TIME_MS     50
 #define LFRFID_WORKER_WRITE_TOO_LONG_TIME_MS 10000
 
-// Counted per verify attempt. A Hitag micro pass alone makes up to 5 attempts (T5577 +
-// EM4305 + 3 variants), so keep this above one sweep to avoid a premature "still trying".
-#define LFRFID_WORKER_WRITE_MAX_UNSUCCESSFUL_READS 10
+// Non-matching verifies before the "Still Trying to Write..." popup. The same popup is also
+// driven by the LFRFID_WORKER_WRITE_TOO_LONG_TIME_MS timer (which fires regardless of
+// protocol), so this is just a sane retry count, not a tuned value - kept at the long-standing
+// default rather than inflated for the multi-target Hitag micro pass.
+#define LFRFID_WORKER_WRITE_MAX_UNSUCCESSFUL_READS 5
 
 #define LFRFID_WORKER_READ_BUFFER_SIZE  512
 #define LFRFID_WORKER_READ_BUFFER_COUNT 16
@@ -665,14 +667,11 @@ static void lfrfid_worker_mode_write_process(LFRFIDWorker* worker) {
                 // ID82xx / Hitag micro magic chips differ only by their LOGIN password. Try
                 // each known variant and verify after each: a wrong password is rejected and
                 // leaves the tag untouched, so the variant that reads back correctly is the
-                // one actually present. (write_data leaves the password unset; the worker
-                // fills it per variant here - a deliberate exception to the usual contract.)
+                // one actually present. The password is the per-variant credential, passed
+                // alongside the shared block/config data.
                 for(uint8_t variant = 0; variant < HitagMicroVariantCount && !done; variant++) {
-                    const uint8_t* password = hitagmicro_variant_password(variant);
-                    furi_check(password);
                     lfrfid_worker_write_set_target(worker, hitagmicro_variant_name(variant));
-                    memcpy(request->hitagmicro.password, password, LFRFID_HITAGMICRO_BLOCK_SIZE);
-                    hitagmicro_write(&request->hitagmicro);
+                    hitagmicro_write(&request->hitagmicro, hitagmicro_variant_password(variant));
                     done = lfrfid_worker_write_finish(
                         worker,
                         lfrfid_worker_write_verify_attempt(

--- a/lib/lfrfid/protocols/lfrfid_protocols.h
+++ b/lib/lfrfid/protocols/lfrfid_protocols.h
@@ -2,6 +2,7 @@
 #include <toolbox/protocols/protocol.h>
 #include "../tools/t5577.h"
 #include "../tools/em4305.h"
+#include "../tools/hitagmicro.h"
 
 typedef enum {
     LFRFIDFeatureASK = 1 << 0, /** ASK Demodulation */
@@ -43,6 +44,7 @@ extern const ProtocolBase* const lfrfid_protocols[];
 typedef enum {
     LFRFIDWriteTypeT5577,
     LFRFIDWriteTypeEM4305,
+    LFRFIDWriteTypeHitagMicro, // ID82xx / Hitag micro magic chips (EM4100 emulation)
 
     LFRFIDWriteTypeMax,
 } LFRFIDWriteType;
@@ -52,5 +54,6 @@ typedef struct {
     union {
         LFRFIDT5577 t5577;
         LFRFIDEM4305 em4305;
+        LFRFIDHitagMicro hitagmicro;
     };
 } LFRFIDWriteRequest;

--- a/lib/lfrfid/protocols/protocol_em4100.c
+++ b/lib/lfrfid/protocols/protocol_em4100.c
@@ -365,6 +365,35 @@ bool protocol_em4100_write_data(ProtocolEM4100* protocol, void* data) {
         request->em4305.word[6] = encoded_data_reversed >> 32;
         request->em4305.mask = 0x70;
         result = true;
+    } else if(request->write_type == LFRFIDWriteTypeHitagMicro) {
+        // ID82xx / Hitag micro magic chip emulating EM4100 via Transponder-Talks-First.
+        // The 64-bit EM4100 frame is split MSB-first into two 32-bit pages.
+        uint64_t frame = protocol->encoded_data;
+        for(uint8_t i = 0; i < LFRFID_HITAGMICRO_BLOCK_SIZE; i++) {
+            request->hitagmicro.block0[i] = (uint8_t)(frame >> (56 - i * 8));
+            request->hitagmicro.block1[i] = (uint8_t)(frame >> (24 - i * 8));
+        }
+        // TTF config (page 0xFF). Transmitted byte0 is reflect8() of the logical
+        // config byte (ttf=1, ttf_mode=01 "Block0,Block1", Manchester, datarate from
+        // clock): clk64 -> 0xA0 -> 0x05, clk32 -> 0xA1 -> 0x85, clk16 -> 0xA2 -> 0x45.
+        uint8_t config_byte0;
+        switch(protocol->clock_per_bit) {
+        case 32:
+            config_byte0 = 0x85;
+            break;
+        case 16:
+            config_byte0 = 0x45;
+            break;
+        default: // clock 64
+            config_byte0 = 0x05;
+            break;
+        }
+        request->hitagmicro.config[0] = config_byte0;
+        request->hitagmicro.config[1] = 0x00;
+        request->hitagmicro.config[2] = 0x00;
+        request->hitagmicro.config[3] = 0x00;
+        // password is selected per chip variant by the worker
+        result = true;
     }
     return result;
 }

--- a/lib/lfrfid/protocols/protocol_em4100.c
+++ b/lib/lfrfid/protocols/protocol_em4100.c
@@ -392,7 +392,6 @@ bool protocol_em4100_write_data(ProtocolEM4100* protocol, void* data) {
         request->hitagmicro.config[1] = 0x00;
         request->hitagmicro.config[2] = 0x00;
         request->hitagmicro.config[3] = 0x00;
-        // password is selected per chip variant by the worker
         result = true;
     }
     return result;

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -275,15 +275,21 @@ void hitagmicro_write(const LFRFIDHitagMicro* data, const uint8_t* password) {
     // the select/login actually took - leaves the tag reconfigured-but-dataless, i.e. emitting
     // nothing (a "brick"). Config-last means a failed/partial run keeps the previous working
     // config, while a fresh tag still gets configured once its data is in place.
-    const uint8_t pages[3] = {
-        HITAGMICRO_PAGE_BLOCK0, HITAGMICRO_PAGE_BLOCK1, HITAGMICRO_PAGE_CONFIG};
-    const uint8_t* const blocks[3] = {data->block0, data->block1, data->config};
-    const char* const labels[3] = {"WRITE block0", "WRITE block1", "WRITE config"};
+    // One row per block (page + data + label kept together so they cannot drift apart).
+    const struct {
+        uint8_t page;
+        const uint8_t* block;
+        const char* label;
+    } steps[3] = {
+        {HITAGMICRO_PAGE_BLOCK0, data->block0, "WRITE block0"},
+        {HITAGMICRO_PAGE_BLOCK1, data->block1, "WRITE block1"},
+        {HITAGMICRO_PAGE_CONFIG, data->config, "WRITE config"},
+    };
 
     for(uint8_t i = 0; i < 3; i++) {
         uint8_t write_tx[16] = {0};
-        size_t write_bits = hitagmicro_build_write(write_tx, pages[i], blocks[i]);
-        hitagmicro_log_frame(labels[i], write_tx, write_bits);
+        size_t write_bits = hitagmicro_build_write(write_tx, steps[i].page, steps[i].block);
+        hitagmicro_log_frame(steps[i].label, write_tx, write_bits);
 
         hitagmicro_field_on();
         furi_delay_us(HITAGMICRO_CHARGE_US);

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -245,17 +245,20 @@ void hitagmicro_write(LFRFIDHitagMicro* data) {
     hitagmicro_log_frame("READ config", read_cfg_tx, read_cfg_bits);
     hitagmicro_log_frame("LOGIN", login_tx, login_bits);
 
-    // Proxmark3's clone selects the tag fresh - with a power cycle - for every block, and
-    // writes in the order config, block0, block1. Mirror that exactly: each iteration powers
-    // up, runs the full select+login open-loop (we transmit each command and wait out the
-    // tag's unread response window), writes one block, then powers down so the next block
-    // starts from a clean select. A blind LOGIN+WRITE without the select does nothing, and a
-    // single select followed by several writes only lands the first - the chip drops the
-    // session after a write, so it must be re-selected per block.
+    // Each block is written in its own power-cycled session (power up, full open-loop
+    // select+login, write, power down): the chip drops the session after a write and must be
+    // re-selected per block, and a blind LOGIN+WRITE without the select does nothing.
+    //
+    // Config is written LAST (the PM3 client writes it first). These magic chips are normally
+    // already EM4100/TTF-configured, so the data blocks alone change the emitted ID. Writing
+    // config first and then having the data writes not land - open-loop has no way to confirm
+    // the select/login actually took - leaves the tag reconfigured-but-dataless, i.e. emitting
+    // nothing (a "brick"). Config-last means a failed/partial run keeps the previous working
+    // config, while a fresh tag still gets configured once its data is in place.
     const uint8_t pages[3] = {
-        HITAGMICRO_PAGE_CONFIG, HITAGMICRO_PAGE_BLOCK0, HITAGMICRO_PAGE_BLOCK1};
-    const uint8_t* const blocks[3] = {data->config, data->block0, data->block1};
-    const char* const labels[3] = {"WRITE config", "WRITE block0", "WRITE block1"};
+        HITAGMICRO_PAGE_BLOCK0, HITAGMICRO_PAGE_BLOCK1, HITAGMICRO_PAGE_CONFIG};
+    const uint8_t* const blocks[3] = {data->block0, data->block1, data->config};
+    const char* const labels[3] = {"WRITE block0", "WRITE block1", "WRITE config"};
 
     for(uint8_t i = 0; i < 3; i++) {
         uint8_t write_tx[16] = {0};

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -8,9 +8,12 @@
 
 // --- Hitag micro / ID82xx reader->tag frame constants (from Proxmark3) ---------
 // flags/commands: include/protocols.h ; frame layout: armsrc/hitagu.c
-#define HITAGMICRO_FLAGS     0x04 // HITAGU_FLAG_CRCT (CRC requested on responses)
-#define HITAGMICRO_CMD_LOGIN 0x28 // HITAGU_CMD_LOGIN
-#define HITAGMICRO_CMD_WRITE 0x14 // HITAGU_CMD_WRITE_SINGLE_BLOCK
+#define HITAGMICRO_FLAGS       0x04 // HITAGU_FLAG_CRCT (CRC requested on responses)
+#define HITAGMICRO_CMD_READ_UID 0x02 // HITAGU_CMD_READ_UID
+#define HITAGMICRO_CMD_SYSINFO  0x17 // HITAGU_CMD_SYSINFO
+#define HITAGMICRO_CMD_READ     0x12 // HITAGU_CMD_READ_MULTIPLE_BLOCK
+#define HITAGMICRO_CMD_LOGIN    0x28 // HITAGU_CMD_LOGIN
+#define HITAGMICRO_CMD_WRITE    0x14 // HITAGU_CMD_WRITE_SINGLE_BLOCK
 
 #define HITAGMICRO_PAGE_BLOCK0 0x00 // first EM4100 data block
 #define HITAGMICRO_PAGE_BLOCK1 0x01 // second EM4100 data block
@@ -29,7 +32,15 @@
 #define HITAGMICRO_BIT1_ON_US       160 // (T_1 - T_LOW): field-on tail of a '1' (224us cell)
 #define HITAGMICRO_SOF_VIOLATION_US 288 // T_CODE_VIOLATION: field-on part of the SOF
 #define HITAGMICRO_CHARGE_US        3000 // field-on charge before the first frame
-#define HITAGMICRO_WAIT_US          1600 // field-on hold between frames (field stays energized)
+
+// Field-on hold after each command, long enough for the tag to finish its (unread)
+// response before the next command. Derived from a Proxmark3 `lf hitag htu` clone trace
+// (timings in 8us ETU): READ UID response is the longest (~18ms).
+#define HITAGMICRO_WAIT_UID_US   21000 // after READ UID (48-bit UID response)
+#define HITAGMICRO_WAIT_SYS_US   13000 // after GET SYSTEM INFO
+#define HITAGMICRO_WAIT_READ_US  17000 // after READ config block
+#define HITAGMICRO_WAIT_LOGIN_US 9000 // after LOGIN (auth ack)
+#define HITAGMICRO_WAIT_WRITE_US 9000 // after each WRITE (ack + EEPROM programming)
 
 // --- Variant tables --------------------------------------------------------------
 static const uint8_t hitagmicro_passwords[HitagMicroVariantCount][LFRFID_HITAGMICRO_BLOCK_SIZE] = {
@@ -141,6 +152,26 @@ static size_t hitagmicro_build_write(uint8_t* tx, uint8_t page, const uint8_t* d
     return bitpos;
 }
 
+// Payload-less command frame: flags(5) + cmd(6) + CRC(16). Used for READ UID and SYSINFO.
+static size_t hitagmicro_build_cmd(uint8_t* tx, uint8_t cmd) {
+    size_t bitpos = 0;
+    hitagmicro_put_lsb(tx, &bitpos, HITAGMICRO_FLAGS, 5);
+    hitagmicro_put_lsb(tx, &bitpos, cmd, 6);
+    hitagmicro_put_crc(tx, &bitpos, hitagmicro_crc16(tx, bitpos));
+    return bitpos;
+}
+
+// READ MULTIPLE BLOCK frame: flags(5) + cmd(6) + page(8) + count(8) + CRC(16).
+static size_t hitagmicro_build_read(uint8_t* tx, uint8_t page, uint8_t count) {
+    size_t bitpos = 0;
+    hitagmicro_put_lsb(tx, &bitpos, HITAGMICRO_FLAGS, 5);
+    hitagmicro_put_lsb(tx, &bitpos, HITAGMICRO_CMD_READ, 6);
+    hitagmicro_put_lsb(tx, &bitpos, page, 8);
+    hitagmicro_put_lsb(tx, &bitpos, count, 8);
+    hitagmicro_put_crc(tx, &bitpos, hitagmicro_crc16(tx, bitpos));
+    return bitpos;
+}
+
 // --- Modulation ------------------------------------------------------------------
 static void hitagmicro_gap(void) {
     furi_hal_rfid_tim_read_pause();
@@ -180,22 +211,40 @@ static void hitagmicro_log_frame(const char* label, const uint8_t* tx, size_t nb
     FURI_LOG_D(TAG, "tx %s (%u bits): %s", label, (unsigned)nbits, hex);
 }
 
+// Transmit one frame (timing-critical, interrupts off), then hold the field on for wait_us
+// with interrupts enabled so the tag can finish its (unread) response before the next
+// command. Keeping the long waits outside FURI_CRITICAL bounds the interrupts-off window to
+// a single frame (~13ms worst case).
+static void hitagmicro_send(const uint8_t* tx, size_t nbits, uint32_t wait_us) {
+    FURI_CRITICAL_ENTER();
+    hitagmicro_send_frame(tx, nbits);
+    FURI_CRITICAL_EXIT();
+    furi_delay_us(wait_us);
+}
+
 void hitagmicro_write(LFRFIDHitagMicro* data) {
     furi_check(data);
 
-    // Build every frame up front: bit packing and CRC need no timing guarantees, so they
-    // run with interrupts enabled. Only the bit-banged modulation below must be timed, so
-    // it is all the FURI_CRITICAL section has to cover. ({0} zero-fills, which the builders
-    // rely on for the unwritten tail bits of the last byte.)
+    // Build every frame up front (bit packing + CRC need no timing guarantees). {0}
+    // zero-fills, which the builders rely on for the unwritten tail bits of the last byte.
+    uint8_t read_uid_tx[16] = {0};
+    uint8_t sysinfo_tx[16] = {0};
+    uint8_t read_cfg_tx[16] = {0};
     uint8_t login_tx[16] = {0};
     uint8_t block0_tx[16] = {0};
     uint8_t block1_tx[16] = {0};
     uint8_t config_tx[16] = {0};
+    size_t read_uid_bits = hitagmicro_build_cmd(read_uid_tx, HITAGMICRO_CMD_READ_UID);
+    size_t sysinfo_bits = hitagmicro_build_cmd(sysinfo_tx, HITAGMICRO_CMD_SYSINFO);
+    size_t read_cfg_bits = hitagmicro_build_read(read_cfg_tx, HITAGMICRO_PAGE_CONFIG, 0x00);
     size_t login_bits = hitagmicro_build_login(login_tx, data->password);
     size_t block0_bits = hitagmicro_build_write(block0_tx, HITAGMICRO_PAGE_BLOCK0, data->block0);
     size_t block1_bits = hitagmicro_build_write(block1_tx, HITAGMICRO_PAGE_BLOCK1, data->block1);
     size_t config_bits = hitagmicro_build_write(config_tx, HITAGMICRO_PAGE_CONFIG, data->config);
 
+    hitagmicro_log_frame("READ UID", read_uid_tx, read_uid_bits);
+    hitagmicro_log_frame("SYSINFO", sysinfo_tx, sysinfo_bits);
+    hitagmicro_log_frame("READ config", read_cfg_tx, read_cfg_bits);
     hitagmicro_log_frame("LOGIN", login_tx, login_bits);
     hitagmicro_log_frame("WRITE block0", block0_tx, block0_bits);
     hitagmicro_log_frame("WRITE block1", block1_tx, block1_bits);
@@ -205,28 +254,23 @@ void hitagmicro_write(LFRFIDHitagMicro* data) {
     // do not ground the antenna
     furi_hal_rfid_pin_pull_release();
 
-    FURI_CRITICAL_ENTER();
-
-    // Charge the tag before talking to it.
+    // Charge the tag, then run the same exchange Proxmark3's `lf hitag htu` clone does, but
+    // open-loop: each command is transmitted and we just wait out the tag's (unread)
+    // response window. The tag still selects/authenticates on receipt - we just can't
+    // observe it (no RX). A blind LOGIN+WRITE alone does nothing; the chip must first be
+    // selected by the READ UID exchange, which is why this whole chain is sent.
     furi_delay_us(HITAGMICRO_CHARGE_US);
 
-    // 1. LOGIN with the chip password. The field is intentionally kept energized through
-    //    the writes below so the authenticated session is not dropped between frames.
-    hitagmicro_send_frame(login_tx, login_bits);
-    furi_delay_us(HITAGMICRO_WAIT_US);
+    // Select + authenticate.
+    hitagmicro_send(read_uid_tx, read_uid_bits, HITAGMICRO_WAIT_UID_US);
+    hitagmicro_send(sysinfo_tx, sysinfo_bits, HITAGMICRO_WAIT_SYS_US);
+    hitagmicro_send(read_cfg_tx, read_cfg_bits, HITAGMICRO_WAIT_READ_US);
+    hitagmicro_send(login_tx, login_bits, HITAGMICRO_WAIT_LOGIN_US);
 
-    // 2. WRITE EM4100 data block 0 (page 0x00).
-    hitagmicro_send_frame(block0_tx, block0_bits);
-    furi_delay_us(HITAGMICRO_WAIT_US);
-
-    // 3. WRITE EM4100 data block 1 (page 0x01).
-    hitagmicro_send_frame(block1_tx, block1_bits);
-    furi_delay_us(HITAGMICRO_WAIT_US);
-
-    // 4. WRITE config last, so TTF EM4100 emulation only starts once data is in place.
-    hitagmicro_send_frame(config_tx, config_bits);
-
-    FURI_CRITICAL_EXIT();
+    // Write data first, config last so TTF EM4100 emulation only starts once data is placed.
+    hitagmicro_send(block0_tx, block0_bits, HITAGMICRO_WAIT_WRITE_US);
+    hitagmicro_send(block1_tx, block1_bits, HITAGMICRO_WAIT_WRITE_US);
+    hitagmicro_send(config_tx, config_bits, HITAGMICRO_WAIT_WRITE_US);
 
     furi_hal_rfid_tim_read_stop();
     furi_hal_rfid_pins_reset();

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -41,7 +41,8 @@
 #define HITAGMICRO_WAIT_READ_US  17000 // after READ config block
 #define HITAGMICRO_WAIT_LOGIN_US 9000 // after LOGIN (auth ack)
 #define HITAGMICRO_WAIT_WRITE_US 9000 // after each WRITE (ack + EEPROM programming)
-#define HITAGMICRO_POWERDOWN_US  10000 // field off between blocks so the tag resets cleanly
+#define HITAGMICRO_POWERDOWN_US  20000 // field off between blocks so the tag resets cleanly
+#define HITAGMICRO_LATCH_CYCLES  4 // clean power cycles after writing to start TTF emission
 
 // --- Variant tables --------------------------------------------------------------
 static const uint8_t hitagmicro_passwords[HitagMicroVariantCount][LFRFID_HITAGMICRO_BLOCK_SIZE] = {
@@ -274,6 +275,20 @@ void hitagmicro_write(LFRFIDHitagMicro* data) {
         furi_hal_rfid_pins_reset();
 
         // Field off between blocks so the tag fully powers down and re-selects cleanly.
+        furi_delay_us(HITAGMICRO_POWERDOWN_US);
+    }
+
+    // The 8265 starts TTF emission only after the written config is latched by a clean
+    // power cycle clear of the write session; a single cycle right after writing can be
+    // missed by the read-back verify (the emission then shows up a variant later, causing a
+    // mislabel). Cycle the field a few more times here so the verify that follows sees the
+    // cloned ID promptly and attributes it to the variant that actually wrote it.
+    for(uint8_t i = 0; i < HITAGMICRO_LATCH_CYCLES; i++) {
+        furi_hal_rfid_tim_read_start(125000, 0.5);
+        furi_hal_rfid_pin_pull_release();
+        furi_delay_us(HITAGMICRO_CHARGE_US);
+        furi_hal_rfid_tim_read_stop();
+        furi_hal_rfid_pins_reset();
         furi_delay_us(HITAGMICRO_POWERDOWN_US);
     }
 }

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -1,0 +1,215 @@
+#include "hitagmicro.h"
+#include <furi.h>
+#include <furi_hal_rfid.h>
+#include <string.h>
+
+#define TAG "HitagMicro"
+
+// --- Hitag micro / ID82xx reader->tag frame constants (from Proxmark3) ---------
+// flags/commands: include/protocols.h ; frame layout: armsrc/hitagu.c
+#define HITAGMICRO_FLAGS     0x04 // HITAGU_FLAG_CRCT (CRC requested on responses)
+#define HITAGMICRO_CMD_LOGIN 0x28 // HITAGU_CMD_LOGIN
+#define HITAGMICRO_CMD_WRITE 0x14 // HITAGU_CMD_WRITE_SINGLE_BLOCK
+
+#define HITAGMICRO_PAGE_BLOCK0 0x00 // first EM4100 data block
+#define HITAGMICRO_PAGE_BLOCK1 0x01 // second EM4100 data block
+#define HITAGMICRO_PAGE_CONFIG 0xFF // HITAGU_CONFIG_PADR
+
+// --- Reader->tag BPLM/OOK modulation timings, microseconds -----------------------
+// The reader->tag link is plain on/off-keyed field-gap modulation (NOT Manchester;
+// Manchester is only the tag->reader direction, unused here). Each bit cell begins
+// with a fixed field gap, then the field is held on for the rest of the cell; a '1'
+// keeps the field on longer than a '0'. Values mirror Proxmark3 armsrc/hitag_common.h
+// where T0 = one 125 kHz carrier cycle = 8 us: T_LOW=8, T_0=20, T_1=28,
+// T_CODE_VIOLATION=36 cycles. Chip tolerances are wide (T_0 18..22, T_1 26..32).
+#define HITAGMICRO_GAP_US           64 // T_LOW: leading field-off gap of every cell
+#define HITAGMICRO_BIT0_ON_US       96 // (T_0 - T_LOW): field-on tail of a '0' (160us cell)
+#define HITAGMICRO_BIT1_ON_US       160 // (T_1 - T_LOW): field-on tail of a '1' (224us cell)
+#define HITAGMICRO_SOF_VIOLATION_US 288 // T_CODE_VIOLATION: field-on part of the SOF
+#define HITAGMICRO_CHARGE_US        3000 // field-on charge before the first frame
+#define HITAGMICRO_WAIT_US          1600 // field-on hold between frames (keeps LOGIN session)
+
+// --- Variant tables --------------------------------------------------------------
+static const uint8_t hitagmicro_passwords[HitagMicroVariantCount][LFRFID_HITAGMICRO_BLOCK_SIZE] = {
+    [HitagMicroVariant8265] = {0x00, 0x00, 0x00, 0x00},
+    [HitagMicroVariant8210] = {0x9A, 0xC4, 0x99, 0x9C},
+    [HitagMicroVariantH55] = {0x49, 0x6B, 0x0E, 0x59},
+};
+
+static const char* const hitagmicro_names[HitagMicroVariantCount] = {
+    [HitagMicroVariant8265] = "8265/H5",
+    [HitagMicroVariant8210] = "8210",
+    [HitagMicroVariantH55] = "H5.5",
+};
+
+const uint8_t* hitagmicro_variant_password(HitagMicroVariant variant) {
+    if(variant >= HitagMicroVariantCount) return NULL;
+    return hitagmicro_passwords[variant];
+}
+
+const char* hitagmicro_variant_name(HitagMicroVariant variant) {
+    if(variant >= HitagMicroVariantCount) return "Unknown";
+    return hitagmicro_names[variant];
+}
+
+// --- Frame building --------------------------------------------------------------
+// Bits are stored MSB-first (bit offset 0 == MSB of buf[0]), matching Proxmark3's
+// concatbits() so the produced byte stream is identical to the firmware's.
+static void hitagmicro_put_bit(uint8_t* buf, size_t* bitpos, bool bit) {
+    size_t pos = *bitpos;
+    if(bit) {
+        buf[pos / 8] |= (1 << (7 - (pos % 8)));
+    } else {
+        buf[pos / 8] &= ~(1 << (7 - (pos % 8)));
+    }
+    *bitpos = pos + 1;
+}
+
+// Append the low nbits of a byte value, LSB-first (concatbits src_lsb=true).
+static void hitagmicro_put_lsb(uint8_t* buf, size_t* bitpos, uint8_t value, uint8_t nbits) {
+    for(uint8_t i = 0; i < nbits; i++) {
+        hitagmicro_put_bit(buf, bitpos, (value >> i) & 1);
+    }
+}
+
+// Append nbits from a byte array, MSB-first (concatbits src_lsb=false).
+static void
+    hitagmicro_put_msb_bytes(uint8_t* buf, size_t* bitpos, const uint8_t* src, size_t nbits) {
+    for(size_t i = 0; i < nbits; i++) {
+        hitagmicro_put_bit(buf, bitpos, (src[i / 8] >> (7 - (i % 8))) & 1);
+    }
+}
+
+// CRC-16/CCITT, poly 0x1021, init 0x0000, refin=false, refout=true.
+// Ported from Proxmark3 common/crc16.c Crc16() for these fixed parameters; operates
+// on a bit length (our frames are not byte-aligned: 43 or 51 bits before the CRC).
+static uint16_t hitagmicro_crc16(const uint8_t* d, size_t bitlength) {
+    if(bitlength == 0) return 0;
+
+    uint16_t remainder = 0;
+    uint8_t offset = 8 - (bitlength % 8);
+    uint8_t prebits = 0;
+
+    for(size_t i = 0; i < (bitlength + 7) / 8; i++) {
+        uint8_t c = prebits | (uint8_t)(d[i] >> offset);
+        prebits = (uint8_t)(d[i] << (8 - offset));
+
+        remainder ^= (uint16_t)(c << 8);
+        for(uint8_t j = 8; j; --j) {
+            if(remainder & 0x8000) {
+                remainder = (uint16_t)((remainder << 1) ^ 0x1021);
+            } else {
+                remainder <<= 1;
+            }
+        }
+    }
+
+    // refout: reflect the 16-bit remainder
+    uint16_t reflected = 0;
+    for(uint8_t i = 0; i < 16; i++) {
+        reflected = (uint16_t)((reflected << 1) | ((remainder >> i) & 1));
+    }
+    return reflected;
+}
+
+// Append the 16-bit CRC, LSB-first (concatbits of the little-endian value, src_lsb=true).
+static void hitagmicro_put_crc(uint8_t* buf, size_t* bitpos, uint16_t crc) {
+    for(uint8_t i = 0; i < 16; i++) {
+        hitagmicro_put_bit(buf, bitpos, (crc >> i) & 1);
+    }
+}
+
+// LOGIN frame: flags(5) + cmd(6) + password(32) + CRC(16). Returns total bit count.
+static size_t hitagmicro_build_login(uint8_t* tx, const uint8_t* password) {
+    size_t bitpos = 0;
+    hitagmicro_put_lsb(tx, &bitpos, HITAGMICRO_FLAGS, 5);
+    hitagmicro_put_lsb(tx, &bitpos, HITAGMICRO_CMD_LOGIN, 6);
+    hitagmicro_put_msb_bytes(tx, &bitpos, password, 32);
+    hitagmicro_put_crc(tx, &bitpos, hitagmicro_crc16(tx, bitpos));
+    return bitpos;
+}
+
+// WRITE SINGLE BLOCK frame: flags(5) + cmd(6) + page(8) + data(32) + CRC(16).
+static size_t hitagmicro_build_write(uint8_t* tx, uint8_t page, const uint8_t* data) {
+    size_t bitpos = 0;
+    hitagmicro_put_lsb(tx, &bitpos, HITAGMICRO_FLAGS, 5);
+    hitagmicro_put_lsb(tx, &bitpos, HITAGMICRO_CMD_WRITE, 6);
+    hitagmicro_put_lsb(tx, &bitpos, page, 8);
+    hitagmicro_put_msb_bytes(tx, &bitpos, data, 32);
+    hitagmicro_put_crc(tx, &bitpos, hitagmicro_crc16(tx, bitpos));
+    return bitpos;
+}
+
+// --- Modulation ------------------------------------------------------------------
+static void hitagmicro_gap(void) {
+    furi_hal_rfid_tim_read_pause();
+    furi_delay_us(HITAGMICRO_GAP_US);
+    furi_hal_rfid_tim_read_continue();
+}
+
+static void hitagmicro_send_bit(bool bit) {
+    hitagmicro_gap();
+    furi_delay_us(bit ? HITAGMICRO_BIT1_ON_US : HITAGMICRO_BIT0_ON_US);
+}
+
+static void hitagmicro_send_sof(void) {
+    // SOF = a '0' bit followed by a code violation (gap + extended field-on).
+    hitagmicro_send_bit(false);
+    furi_hal_rfid_tim_read_pause();
+    furi_delay_us(HITAGMICRO_GAP_US);
+    furi_hal_rfid_tim_read_continue();
+    furi_delay_us(HITAGMICRO_SOF_VIOLATION_US);
+}
+
+static void hitagmicro_send_frame(const uint8_t* tx, size_t nbits) {
+    hitagmicro_send_sof();
+    for(size_t i = 0; i < nbits; i++) {
+        hitagmicro_send_bit((tx[i / 8] >> (7 - (i % 8))) & 1);
+    }
+    // EOF = a trailing gap; the field stays energized for the next frame.
+    hitagmicro_gap();
+}
+
+void hitagmicro_write(LFRFIDHitagMicro* data) {
+    furi_check(data);
+
+    uint8_t tx[16];
+    size_t nbits;
+
+    furi_hal_rfid_tim_read_start(125000, 0.5);
+    // do not ground the antenna
+    furi_hal_rfid_pin_pull_release();
+
+    FURI_CRITICAL_ENTER();
+
+    // Charge the tag before talking to it.
+    furi_delay_us(HITAGMICRO_CHARGE_US);
+
+    // 1. LOGIN with the chip password (held by the kept-on field for the writes).
+    memset(tx, 0, sizeof(tx));
+    nbits = hitagmicro_build_login(tx, data->password);
+    hitagmicro_send_frame(tx, nbits);
+    furi_delay_us(HITAGMICRO_WAIT_US);
+
+    // 2. WRITE EM4100 data block 0 (page 0x00).
+    memset(tx, 0, sizeof(tx));
+    nbits = hitagmicro_build_write(tx, HITAGMICRO_PAGE_BLOCK0, data->block0);
+    hitagmicro_send_frame(tx, nbits);
+    furi_delay_us(HITAGMICRO_WAIT_US);
+
+    // 3. WRITE EM4100 data block 1 (page 0x01).
+    memset(tx, 0, sizeof(tx));
+    nbits = hitagmicro_build_write(tx, HITAGMICRO_PAGE_BLOCK1, data->block1);
+    hitagmicro_send_frame(tx, nbits);
+    furi_delay_us(HITAGMICRO_WAIT_US);
+
+    // 4. WRITE config last, so TTF EM4100 emulation only starts once data is in place.
+    memset(tx, 0, sizeof(tx));
+    nbits = hitagmicro_build_write(tx, HITAGMICRO_PAGE_CONFIG, data->config);
+    hitagmicro_send_frame(tx, nbits);
+
+    FURI_CRITICAL_EXIT();
+
+    furi_hal_rfid_tim_read_stop();
+    furi_hal_rfid_pins_reset();
+}

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -42,7 +42,8 @@
 #define HITAGMICRO_WAIT_LOGIN_US 9000 // after LOGIN (auth ack)
 #define HITAGMICRO_WAIT_WRITE_US 9000 // after each WRITE (ack + EEPROM programming)
 #define HITAGMICRO_POWERDOWN_US  20000 // field off between blocks so the tag resets cleanly
-#define HITAGMICRO_LATCH_CYCLES  4 // clean power cycles after writing to start TTF emission
+#define HITAGMICRO_LATCH_CYCLES  6 // clean power cycles after writing to start TTF emission
+#define HITAGMICRO_LATCH_HOLD_US 50000 // field-on per latch cycle (long enough to re-read config)
 
 // --- Variant tables --------------------------------------------------------------
 static const uint8_t hitagmicro_passwords[HitagMicroVariantCount][LFRFID_HITAGMICRO_BLOCK_SIZE] = {
@@ -286,7 +287,9 @@ void hitagmicro_write(LFRFIDHitagMicro* data) {
     for(uint8_t i = 0; i < HITAGMICRO_LATCH_CYCLES; i++) {
         furi_hal_rfid_tim_read_start(125000, 0.5);
         furi_hal_rfid_pin_pull_release();
-        furi_delay_us(HITAGMICRO_CHARGE_US);
+        // Hold the field on long enough for the tag to power up and re-read the new config
+        // (a brief charge-only pulse is not counted as a real power cycle by the chip).
+        furi_delay_us(HITAGMICRO_LATCH_HOLD_US);
         furi_hal_rfid_tim_read_stop();
         furi_hal_rfid_pins_reset();
         furi_delay_us(HITAGMICRO_POWERDOWN_US);

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -2,6 +2,7 @@
 #include <furi.h>
 #include <furi_hal_rfid.h>
 #include <lib/bit_lib/bit_lib.h>
+#include <stdio.h>
 
 #define TAG "HitagMicro"
 
@@ -168,6 +169,17 @@ static void hitagmicro_send_frame(const uint8_t* tx, size_t nbits) {
     hitagmicro_gap();
 }
 
+// Log a built frame as hex (debug level). Open-loop has no RX, so the transmitted frames
+// are the main thing we can trace - compare them against a Proxmark3 `lf hitag htu` capture.
+static void hitagmicro_log_frame(const char* label, const uint8_t* tx, size_t nbits) {
+    char hex[3 * 9 + 1] = {0}; // up to 9 bytes (67-bit max frame)
+    size_t pos = 0;
+    for(size_t i = 0; i < (nbits + 7) / 8 && pos + 3 < sizeof(hex); i++) {
+        pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", tx[i]);
+    }
+    FURI_LOG_D(TAG, "tx %s (%u bits): %s", label, (unsigned)nbits, hex);
+}
+
 void hitagmicro_write(LFRFIDHitagMicro* data) {
     furi_check(data);
 
@@ -183,6 +195,11 @@ void hitagmicro_write(LFRFIDHitagMicro* data) {
     size_t block0_bits = hitagmicro_build_write(block0_tx, HITAGMICRO_PAGE_BLOCK0, data->block0);
     size_t block1_bits = hitagmicro_build_write(block1_tx, HITAGMICRO_PAGE_BLOCK1, data->block1);
     size_t config_bits = hitagmicro_build_write(config_tx, HITAGMICRO_PAGE_CONFIG, data->config);
+
+    hitagmicro_log_frame("LOGIN", login_tx, login_bits);
+    hitagmicro_log_frame("WRITE block0", block0_tx, block0_bits);
+    hitagmicro_log_frame("WRITE block1", block1_tx, block1_bits);
+    hitagmicro_log_frame("WRITE config", config_tx, config_bits);
 
     furi_hal_rfid_tim_read_start(125000, 0.5);
     // do not ground the antenna

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -40,7 +40,8 @@
 #define HITAGMICRO_WAIT_SYS_US   13000 // after GET SYSTEM INFO
 #define HITAGMICRO_WAIT_READ_US  17000 // after READ config block
 #define HITAGMICRO_WAIT_LOGIN_US 9000 // after LOGIN (auth ack)
-#define HITAGMICRO_WAIT_WRITE_US 9000 // after each WRITE (ack + EEPROM programming)
+#define HITAGMICRO_WAIT_WRITE_US 30000 // field-on after WRITE so the EEPROM finishes programming
+#define HITAGMICRO_WRITE_REPEATS 2 // re-send each WRITE per session (8265 commits intermittently)
 #define HITAGMICRO_POWERDOWN_US  20000 // field off between blocks so the tag resets cleanly
 #define HITAGMICRO_LATCH_CYCLES  6 // clean power cycles after writing to start TTF emission
 #define HITAGMICRO_LATCH_HOLD_US 50000 // field-on per latch cycle (long enough to re-read config)
@@ -270,7 +271,11 @@ void hitagmicro_write(LFRFIDHitagMicro* data) {
         hitagmicro_send(sysinfo_tx, sysinfo_bits, HITAGMICRO_WAIT_SYS_US);
         hitagmicro_send(read_cfg_tx, read_cfg_bits, HITAGMICRO_WAIT_READ_US);
         hitagmicro_send(login_tx, login_bits, HITAGMICRO_WAIT_LOGIN_US);
-        hitagmicro_send(write_tx, write_bits, HITAGMICRO_WAIT_WRITE_US);
+        // The 8265 commits a WRITE only intermittently; re-send it a few times within the
+        // session (idempotent - same data) to raise the odds it lands this pass.
+        for(uint8_t w = 0; w < HITAGMICRO_WRITE_REPEATS; w++) {
+            hitagmicro_send(write_tx, write_bits, HITAGMICRO_WAIT_WRITE_US);
+        }
 
         furi_hal_rfid_tim_read_stop();
         furi_hal_rfid_pins_reset();

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -243,9 +243,9 @@ void hitagmicro_write(const LFRFIDHitagMicro* data, const uint8_t* password) {
     // warm and actively emitting (its verify read held the field on for up to ~2s, and the latch
     // cycles below drive it into TTF emission). The open-loop chain assumes a cold chip, so
     // without a guaranteed long field-off a 2nd consecutive write to the same tag lands on a chip
-    // that never reset and is silently ignored.
-    furi_hal_rfid_tim_read_stop();
-    furi_hal_rfid_pins_reset();
+    // that never reset and is silently ignored. The read timer is already stopped on entry (the
+    // worker's verify read and any prior session leave the field off), so just hold it off - do
+    // NOT call tim_read_stop() here: it furi_check-asserts the timer bus is currently running.
     furi_delay_us(HITAGMICRO_COLD_RESET_US);
 
     // The select-chain frames are identical for every block, so build them once. The {0}

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -8,7 +8,7 @@
 
 // --- Hitag micro / ID82xx reader->tag frame constants (from Proxmark3) ---------
 // flags/commands: include/protocols.h ; frame layout: armsrc/hitagu.c
-#define HITAGMICRO_FLAGS       0x04 // HITAGU_FLAG_CRCT (CRC requested on responses)
+#define HITAGMICRO_FLAGS        0x04 // HITAGU_FLAG_CRCT (CRC requested on responses)
 #define HITAGMICRO_CMD_READ_UID 0x02 // HITAGU_CMD_READ_UID
 #define HITAGMICRO_CMD_SYSINFO  0x17 // HITAGU_CMD_SYSINFO
 #define HITAGMICRO_CMD_READ     0x12 // HITAGU_CMD_READ_MULTIPLE_BLOCK

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -53,7 +53,7 @@ static const struct {
     uint8_t password[LFRFID_HITAGMICRO_BLOCK_SIZE];
     const char* name;
 } hitagmicro_variants[HitagMicroVariantCount] = {
-    [HitagMicroVariant8265] = {{0x00, 0x00, 0x00, 0x00}, "8265/H5"},
+    [HitagMicroVariant8265] = {{0x00, 0x00, 0x00, 0x00}, "8265"},
     [HitagMicroVariant8210] = {{0x9A, 0xC4, 0x99, 0x9C}, "8210"},
     [HitagMicroVariantH55] = {{0x49, 0x6B, 0x0E, 0x59}, "H5.5"},
 };

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -41,6 +41,7 @@
 #define HITAGMICRO_WAIT_READ_US  17000 // after READ config block
 #define HITAGMICRO_WAIT_LOGIN_US 9000 // after LOGIN (auth ack)
 #define HITAGMICRO_WAIT_WRITE_US 9000 // after each WRITE (ack + EEPROM programming)
+#define HITAGMICRO_POWERDOWN_US  10000 // field off between blocks so the tag resets cleanly
 
 // --- Variant tables --------------------------------------------------------------
 static const uint8_t hitagmicro_passwords[HitagMicroVariantCount][LFRFID_HITAGMICRO_BLOCK_SIZE] = {
@@ -225,53 +226,54 @@ static void hitagmicro_send(const uint8_t* tx, size_t nbits, uint32_t wait_us) {
 void hitagmicro_write(LFRFIDHitagMicro* data) {
     furi_check(data);
 
-    // Build every frame up front (bit packing + CRC need no timing guarantees). {0}
+    // The select-chain frames are identical for every block, so build them once. {0}
     // zero-fills, which the builders rely on for the unwritten tail bits of the last byte.
     uint8_t read_uid_tx[16] = {0};
     uint8_t sysinfo_tx[16] = {0};
     uint8_t read_cfg_tx[16] = {0};
     uint8_t login_tx[16] = {0};
-    uint8_t block0_tx[16] = {0};
-    uint8_t block1_tx[16] = {0};
-    uint8_t config_tx[16] = {0};
     size_t read_uid_bits = hitagmicro_build_cmd(read_uid_tx, HITAGMICRO_CMD_READ_UID);
     size_t sysinfo_bits = hitagmicro_build_cmd(sysinfo_tx, HITAGMICRO_CMD_SYSINFO);
     size_t read_cfg_bits = hitagmicro_build_read(read_cfg_tx, HITAGMICRO_PAGE_CONFIG, 0x00);
     size_t login_bits = hitagmicro_build_login(login_tx, data->password);
-    size_t block0_bits = hitagmicro_build_write(block0_tx, HITAGMICRO_PAGE_BLOCK0, data->block0);
-    size_t block1_bits = hitagmicro_build_write(block1_tx, HITAGMICRO_PAGE_BLOCK1, data->block1);
-    size_t config_bits = hitagmicro_build_write(config_tx, HITAGMICRO_PAGE_CONFIG, data->config);
 
     hitagmicro_log_frame("READ UID", read_uid_tx, read_uid_bits);
     hitagmicro_log_frame("SYSINFO", sysinfo_tx, sysinfo_bits);
     hitagmicro_log_frame("READ config", read_cfg_tx, read_cfg_bits);
     hitagmicro_log_frame("LOGIN", login_tx, login_bits);
-    hitagmicro_log_frame("WRITE block0", block0_tx, block0_bits);
-    hitagmicro_log_frame("WRITE block1", block1_tx, block1_bits);
-    hitagmicro_log_frame("WRITE config", config_tx, config_bits);
 
-    furi_hal_rfid_tim_read_start(125000, 0.5);
-    // do not ground the antenna
-    furi_hal_rfid_pin_pull_release();
+    // Proxmark3's clone selects the tag fresh - with a power cycle - for every block, and
+    // writes in the order config, block0, block1. Mirror that exactly: each iteration powers
+    // up, runs the full select+login open-loop (we transmit each command and wait out the
+    // tag's unread response window), writes one block, then powers down so the next block
+    // starts from a clean select. A blind LOGIN+WRITE without the select does nothing, and a
+    // single select followed by several writes only lands the first - the chip drops the
+    // session after a write, so it must be re-selected per block.
+    const uint8_t pages[3] = {
+        HITAGMICRO_PAGE_CONFIG, HITAGMICRO_PAGE_BLOCK0, HITAGMICRO_PAGE_BLOCK1};
+    const uint8_t* const blocks[3] = {data->config, data->block0, data->block1};
+    const char* const labels[3] = {"WRITE config", "WRITE block0", "WRITE block1"};
 
-    // Charge the tag, then run the same exchange Proxmark3's `lf hitag htu` clone does, but
-    // open-loop: each command is transmitted and we just wait out the tag's (unread)
-    // response window. The tag still selects/authenticates on receipt - we just can't
-    // observe it (no RX). A blind LOGIN+WRITE alone does nothing; the chip must first be
-    // selected by the READ UID exchange, which is why this whole chain is sent.
-    furi_delay_us(HITAGMICRO_CHARGE_US);
+    for(uint8_t i = 0; i < 3; i++) {
+        uint8_t write_tx[16] = {0};
+        size_t write_bits = hitagmicro_build_write(write_tx, pages[i], blocks[i]);
+        hitagmicro_log_frame(labels[i], write_tx, write_bits);
 
-    // Select + authenticate.
-    hitagmicro_send(read_uid_tx, read_uid_bits, HITAGMICRO_WAIT_UID_US);
-    hitagmicro_send(sysinfo_tx, sysinfo_bits, HITAGMICRO_WAIT_SYS_US);
-    hitagmicro_send(read_cfg_tx, read_cfg_bits, HITAGMICRO_WAIT_READ_US);
-    hitagmicro_send(login_tx, login_bits, HITAGMICRO_WAIT_LOGIN_US);
+        furi_hal_rfid_tim_read_start(125000, 0.5);
+        // do not ground the antenna
+        furi_hal_rfid_pin_pull_release();
 
-    // Write data first, config last so TTF EM4100 emulation only starts once data is placed.
-    hitagmicro_send(block0_tx, block0_bits, HITAGMICRO_WAIT_WRITE_US);
-    hitagmicro_send(block1_tx, block1_bits, HITAGMICRO_WAIT_WRITE_US);
-    hitagmicro_send(config_tx, config_bits, HITAGMICRO_WAIT_WRITE_US);
+        furi_delay_us(HITAGMICRO_CHARGE_US);
+        hitagmicro_send(read_uid_tx, read_uid_bits, HITAGMICRO_WAIT_UID_US);
+        hitagmicro_send(sysinfo_tx, sysinfo_bits, HITAGMICRO_WAIT_SYS_US);
+        hitagmicro_send(read_cfg_tx, read_cfg_bits, HITAGMICRO_WAIT_READ_US);
+        hitagmicro_send(login_tx, login_bits, HITAGMICRO_WAIT_LOGIN_US);
+        hitagmicro_send(write_tx, write_bits, HITAGMICRO_WAIT_WRITE_US);
 
-    furi_hal_rfid_tim_read_stop();
-    furi_hal_rfid_pins_reset();
+        furi_hal_rfid_tim_read_stop();
+        furi_hal_rfid_pins_reset();
+
+        // Field off between blocks so the tag fully powers down and re-selects cleanly.
+        furi_delay_us(HITAGMICRO_POWERDOWN_US);
+    }
 }

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -45,41 +45,35 @@
 #define HITAGMICRO_POWERDOWN_US  20000 // field off between blocks so the tag resets cleanly
 #define HITAGMICRO_LATCH_CYCLES  6 // clean power cycles after writing to start TTF emission
 #define HITAGMICRO_LATCH_HOLD_US 50000 // field-on per latch cycle (long enough to re-read config)
+#define HITAGMICRO_COLD_RESET_US 100000 // leading field-off so a warm/emitting tag fully resets
 
-// --- Variant tables --------------------------------------------------------------
-static const uint8_t hitagmicro_passwords[HitagMicroVariantCount][LFRFID_HITAGMICRO_BLOCK_SIZE] = {
-    [HitagMicroVariant8265] = {0x00, 0x00, 0x00, 0x00},
-    [HitagMicroVariant8210] = {0x9A, 0xC4, 0x99, 0x9C},
-    [HitagMicroVariantH55] = {0x49, 0x6B, 0x0E, 0x59},
-};
-
-static const char* const hitagmicro_names[HitagMicroVariantCount] = {
-    [HitagMicroVariant8265] = "8265/H5",
-    [HitagMicroVariant8210] = "8210",
-    [HitagMicroVariantH55] = "H5.5",
+// --- Variant table ---------------------------------------------------------------
+// One row per chip: password and display name kept together so the two cannot drift apart.
+static const struct {
+    uint8_t password[LFRFID_HITAGMICRO_BLOCK_SIZE];
+    const char* name;
+} hitagmicro_variants[HitagMicroVariantCount] = {
+    [HitagMicroVariant8265] = {{0x00, 0x00, 0x00, 0x00}, "8265/H5"},
+    [HitagMicroVariant8210] = {{0x9A, 0xC4, 0x99, 0x9C}, "8210"},
+    [HitagMicroVariantH55] = {{0x49, 0x6B, 0x0E, 0x59}, "H5.5"},
 };
 
 const uint8_t* hitagmicro_variant_password(HitagMicroVariant variant) {
     if(variant >= HitagMicroVariantCount) return NULL;
-    return hitagmicro_passwords[variant];
+    return hitagmicro_variants[variant].password;
 }
 
 const char* hitagmicro_variant_name(HitagMicroVariant variant) {
     if(variant >= HitagMicroVariantCount) return "Unknown";
-    return hitagmicro_names[variant];
+    return hitagmicro_variants[variant].name;
 }
 
 // --- Frame building --------------------------------------------------------------
 // Bits are stored MSB-first (bit offset 0 == MSB of buf[0]), matching Proxmark3's
 // concatbits() so the produced byte stream is identical to the firmware's.
 static void hitagmicro_put_bit(uint8_t* buf, size_t* bitpos, bool bit) {
-    size_t pos = *bitpos;
-    if(bit) {
-        buf[pos / 8] |= (1 << (7 - (pos % 8)));
-    } else {
-        buf[pos / 8] &= ~(1 << (7 - (pos % 8)));
-    }
-    *bitpos = pos + 1;
+    bit_lib_set_bit(buf, *bitpos, bit);
+    (*bitpos)++;
 }
 
 // Append the low nbits of a byte value, LSB-first (concatbits src_lsb=true).
@@ -93,7 +87,7 @@ static void hitagmicro_put_lsb(uint8_t* buf, size_t* bitpos, uint8_t value, uint
 static void
     hitagmicro_put_msb_bytes(uint8_t* buf, size_t* bitpos, const uint8_t* src, size_t nbits) {
     for(size_t i = 0; i < nbits; i++) {
-        hitagmicro_put_bit(buf, bitpos, (src[i / 8] >> (7 - (i % 8))) & 1);
+        hitagmicro_put_bit(buf, bitpos, bit_lib_get_bit(src, i));
     }
 }
 
@@ -207,6 +201,7 @@ static void hitagmicro_send_frame(const uint8_t* tx, size_t nbits) {
 // Log a built frame as hex (debug level). Open-loop has no RX, so the transmitted frames
 // are the main thing we can trace - compare them against a Proxmark3 `lf hitag htu` capture.
 static void hitagmicro_log_frame(const char* label, const uint8_t* tx, size_t nbits) {
+    if(furi_log_get_level() < FuriLogLevelDebug) return; // skip the hex build when it is discarded
     char hex[3 * 9 + 1] = {0}; // up to 9 bytes (67-bit max frame)
     size_t pos = 0;
     for(size_t i = 0; i < (nbits + 7) / 8 && pos + 3 < sizeof(hex); i++) {
@@ -218,7 +213,7 @@ static void hitagmicro_log_frame(const char* label, const uint8_t* tx, size_t nb
 // Transmit one frame (timing-critical, interrupts off), then hold the field on for wait_us
 // with interrupts enabled so the tag can finish its (unread) response before the next
 // command. Keeping the long waits outside FURI_CRITICAL bounds the interrupts-off window to
-// a single frame (~13ms worst case).
+// a single frame (~13ms typical, up to ~16ms for an all-ones WRITE).
 static void hitagmicro_send(const uint8_t* tx, size_t nbits, uint32_t wait_us) {
     FURI_CRITICAL_ENTER();
     hitagmicro_send_frame(tx, nbits);
@@ -226,11 +221,36 @@ static void hitagmicro_send(const uint8_t* tx, size_t nbits, uint32_t wait_us) {
     furi_delay_us(wait_us);
 }
 
-void hitagmicro_write(LFRFIDHitagMicro* data) {
-    furi_check(data);
+// Energize / de-energize the 125 kHz field. pin_pull_release keeps the antenna from being
+// grounded; field_off waits POWERDOWN so the tag powers down and re-selects cleanly between
+// blocks. Mirrors t5577_start / t5577_stop in the sibling writers.
+static void hitagmicro_field_on(void) {
+    furi_hal_rfid_tim_read_start(125000, 0.5);
+    furi_hal_rfid_pin_pull_release();
+}
 
-    // The select-chain frames are identical for every block, so build them once. {0}
-    // zero-fills, which the builders rely on for the unwritten tail bits of the last byte.
+static void hitagmicro_field_off(void) {
+    furi_hal_rfid_tim_read_stop();
+    furi_hal_rfid_pins_reset();
+    furi_delay_us(HITAGMICRO_POWERDOWN_US);
+}
+
+void hitagmicro_write(const LFRFIDHitagMicro* data, const uint8_t* password) {
+    furi_check(data);
+    furi_check(password);
+
+    // Cold power-on-reset before the select chain. A preceding successful write leaves this tag
+    // warm and actively emitting (its verify read held the field on for up to ~2s, and the latch
+    // cycles below drive it into TTF emission). The open-loop chain assumes a cold chip, so
+    // without a guaranteed long field-off a 2nd consecutive write to the same tag lands on a chip
+    // that never reset and is silently ignored.
+    furi_hal_rfid_tim_read_stop();
+    furi_hal_rfid_pins_reset();
+    furi_delay_us(HITAGMICRO_COLD_RESET_US);
+
+    // The select-chain frames are identical for every block, so build them once. The {0}
+    // zero-fills the buffers as a safety measure; only the first N bits are ever transmitted
+    // or fed to the CRC, so the unwritten tail bits never affect the wire output.
     uint8_t read_uid_tx[16] = {0};
     uint8_t sysinfo_tx[16] = {0};
     uint8_t read_cfg_tx[16] = {0};
@@ -238,7 +258,7 @@ void hitagmicro_write(LFRFIDHitagMicro* data) {
     size_t read_uid_bits = hitagmicro_build_cmd(read_uid_tx, HITAGMICRO_CMD_READ_UID);
     size_t sysinfo_bits = hitagmicro_build_cmd(sysinfo_tx, HITAGMICRO_CMD_SYSINFO);
     size_t read_cfg_bits = hitagmicro_build_read(read_cfg_tx, HITAGMICRO_PAGE_CONFIG, 0x00);
-    size_t login_bits = hitagmicro_build_login(login_tx, data->password);
+    size_t login_bits = hitagmicro_build_login(login_tx, password);
 
     hitagmicro_log_frame("READ UID", read_uid_tx, read_uid_bits);
     hitagmicro_log_frame("SYSINFO", sysinfo_tx, sysinfo_bits);
@@ -265,10 +285,7 @@ void hitagmicro_write(LFRFIDHitagMicro* data) {
         size_t write_bits = hitagmicro_build_write(write_tx, pages[i], blocks[i]);
         hitagmicro_log_frame(labels[i], write_tx, write_bits);
 
-        furi_hal_rfid_tim_read_start(125000, 0.5);
-        // do not ground the antenna
-        furi_hal_rfid_pin_pull_release();
-
+        hitagmicro_field_on();
         furi_delay_us(HITAGMICRO_CHARGE_US);
         hitagmicro_send(read_uid_tx, read_uid_bits, HITAGMICRO_WAIT_UID_US);
         hitagmicro_send(sysinfo_tx, sysinfo_bits, HITAGMICRO_WAIT_SYS_US);
@@ -280,11 +297,7 @@ void hitagmicro_write(LFRFIDHitagMicro* data) {
             hitagmicro_send(write_tx, write_bits, HITAGMICRO_WAIT_WRITE_US);
         }
 
-        furi_hal_rfid_tim_read_stop();
-        furi_hal_rfid_pins_reset();
-
-        // Field off between blocks so the tag fully powers down and re-selects cleanly.
-        furi_delay_us(HITAGMICRO_POWERDOWN_US);
+        hitagmicro_field_off();
     }
 
     // The 8265 starts TTF emission only after the written config is latched by a clean
@@ -293,13 +306,10 @@ void hitagmicro_write(LFRFIDHitagMicro* data) {
     // mislabel). Cycle the field a few more times here so the verify that follows sees the
     // cloned ID promptly and attributes it to the variant that actually wrote it.
     for(uint8_t i = 0; i < HITAGMICRO_LATCH_CYCLES; i++) {
-        furi_hal_rfid_tim_read_start(125000, 0.5);
-        furi_hal_rfid_pin_pull_release();
+        hitagmicro_field_on();
         // Hold the field on long enough for the tag to power up and re-read the new config
         // (a brief charge-only pulse is not counted as a real power cycle by the chip).
         furi_delay_us(HITAGMICRO_LATCH_HOLD_US);
-        furi_hal_rfid_tim_read_stop();
-        furi_hal_rfid_pins_reset();
-        furi_delay_us(HITAGMICRO_POWERDOWN_US);
+        hitagmicro_field_off();
     }
 }

--- a/lib/lfrfid/tools/hitagmicro.c
+++ b/lib/lfrfid/tools/hitagmicro.c
@@ -1,7 +1,7 @@
 #include "hitagmicro.h"
 #include <furi.h>
 #include <furi_hal_rfid.h>
-#include <string.h>
+#include <lib/bit_lib/bit_lib.h>
 
 #define TAG "HitagMicro"
 
@@ -19,15 +19,16 @@
 // The reader->tag link is plain on/off-keyed field-gap modulation (NOT Manchester;
 // Manchester is only the tag->reader direction, unused here). Each bit cell begins
 // with a fixed field gap, then the field is held on for the rest of the cell; a '1'
-// keeps the field on longer than a '0'. Values mirror Proxmark3 armsrc/hitag_common.h
-// where T0 = one 125 kHz carrier cycle = 8 us: T_LOW=8, T_0=20, T_1=28,
-// T_CODE_VIOLATION=36 cycles. Chip tolerances are wide (T_0 18..22, T_1 26..32).
+// keeps the field on longer than a '0'. Constants mirror Proxmark3 armsrc/hitag_common.h,
+// which are in T0 units (T0 = one 125 kHz carrier cycle = 8 us): T_LOW=8 T0 (64us),
+// T_0=20 T0 (160us), T_1=28 T0 (224us), T_CODE_VIOLATION=36 T0 (288us). Chip tolerances
+// are wide (T_0 18..22, T_1 26..32 T0).
 #define HITAGMICRO_GAP_US           64 // T_LOW: leading field-off gap of every cell
 #define HITAGMICRO_BIT0_ON_US       96 // (T_0 - T_LOW): field-on tail of a '0' (160us cell)
 #define HITAGMICRO_BIT1_ON_US       160 // (T_1 - T_LOW): field-on tail of a '1' (224us cell)
 #define HITAGMICRO_SOF_VIOLATION_US 288 // T_CODE_VIOLATION: field-on part of the SOF
 #define HITAGMICRO_CHARGE_US        3000 // field-on charge before the first frame
-#define HITAGMICRO_WAIT_US          1600 // field-on hold between frames (keeps LOGIN session)
+#define HITAGMICRO_WAIT_US          1600 // field-on hold between frames (field stays energized)
 
 // --- Variant tables --------------------------------------------------------------
 static const uint8_t hitagmicro_passwords[HitagMicroVariantCount][LFRFID_HITAGMICRO_BLOCK_SIZE] = {
@@ -80,14 +81,17 @@ static void
     }
 }
 
-// CRC-16/CCITT, poly 0x1021, init 0x0000, refin=false, refout=true.
-// Ported from Proxmark3 common/crc16.c Crc16() for these fixed parameters; operates
-// on a bit length (our frames are not byte-aligned: 43 or 51 bits before the CRC).
+// CRC-16 with poly 0x1021, init 0x0000, refin=false, refout=true. (This refin/refout
+// mix is not a standard named CCITT variant; it is what the Hitag U frames use.)
+// Ported from Proxmark3 common/crc16.c Crc16(); takes a bit length because our frames
+// are not byte-aligned (43-bit LOGIN, 51-bit WRITE before the CRC).
 static uint16_t hitagmicro_crc16(const uint8_t* d, size_t bitlength) {
     if(bitlength == 0) return 0;
 
     uint16_t remainder = 0;
-    uint8_t offset = 8 - (bitlength % 8);
+    // Front-pad the stream with zeros to byte-align it for the loop; the pad is 0 for an
+    // already byte-aligned length. Leading zero bits do not change the CRC (init is 0).
+    uint8_t offset = (8 - (bitlength % 8)) % 8;
     uint8_t prebits = 0;
 
     for(size_t i = 0; i < (bitlength + 7) / 8; i++) {
@@ -105,11 +109,7 @@ static uint16_t hitagmicro_crc16(const uint8_t* d, size_t bitlength) {
     }
 
     // refout: reflect the 16-bit remainder
-    uint16_t reflected = 0;
-    for(uint8_t i = 0; i < 16; i++) {
-        reflected = (uint16_t)((reflected << 1) | ((remainder >> i) & 1));
-    }
-    return reflected;
+    return bit_lib_reverse_16_fast(remainder);
 }
 
 // Append the 16-bit CRC, LSB-first (concatbits of the little-endian value, src_lsb=true).
@@ -155,9 +155,7 @@ static void hitagmicro_send_bit(bool bit) {
 static void hitagmicro_send_sof(void) {
     // SOF = a '0' bit followed by a code violation (gap + extended field-on).
     hitagmicro_send_bit(false);
-    furi_hal_rfid_tim_read_pause();
-    furi_delay_us(HITAGMICRO_GAP_US);
-    furi_hal_rfid_tim_read_continue();
+    hitagmicro_gap();
     furi_delay_us(HITAGMICRO_SOF_VIOLATION_US);
 }
 
@@ -173,8 +171,18 @@ static void hitagmicro_send_frame(const uint8_t* tx, size_t nbits) {
 void hitagmicro_write(LFRFIDHitagMicro* data) {
     furi_check(data);
 
-    uint8_t tx[16];
-    size_t nbits;
+    // Build every frame up front: bit packing and CRC need no timing guarantees, so they
+    // run with interrupts enabled. Only the bit-banged modulation below must be timed, so
+    // it is all the FURI_CRITICAL section has to cover. ({0} zero-fills, which the builders
+    // rely on for the unwritten tail bits of the last byte.)
+    uint8_t login_tx[16] = {0};
+    uint8_t block0_tx[16] = {0};
+    uint8_t block1_tx[16] = {0};
+    uint8_t config_tx[16] = {0};
+    size_t login_bits = hitagmicro_build_login(login_tx, data->password);
+    size_t block0_bits = hitagmicro_build_write(block0_tx, HITAGMICRO_PAGE_BLOCK0, data->block0);
+    size_t block1_bits = hitagmicro_build_write(block1_tx, HITAGMICRO_PAGE_BLOCK1, data->block1);
+    size_t config_bits = hitagmicro_build_write(config_tx, HITAGMICRO_PAGE_CONFIG, data->config);
 
     furi_hal_rfid_tim_read_start(125000, 0.5);
     // do not ground the antenna
@@ -185,28 +193,21 @@ void hitagmicro_write(LFRFIDHitagMicro* data) {
     // Charge the tag before talking to it.
     furi_delay_us(HITAGMICRO_CHARGE_US);
 
-    // 1. LOGIN with the chip password (held by the kept-on field for the writes).
-    memset(tx, 0, sizeof(tx));
-    nbits = hitagmicro_build_login(tx, data->password);
-    hitagmicro_send_frame(tx, nbits);
+    // 1. LOGIN with the chip password. The field is intentionally kept energized through
+    //    the writes below so the authenticated session is not dropped between frames.
+    hitagmicro_send_frame(login_tx, login_bits);
     furi_delay_us(HITAGMICRO_WAIT_US);
 
     // 2. WRITE EM4100 data block 0 (page 0x00).
-    memset(tx, 0, sizeof(tx));
-    nbits = hitagmicro_build_write(tx, HITAGMICRO_PAGE_BLOCK0, data->block0);
-    hitagmicro_send_frame(tx, nbits);
+    hitagmicro_send_frame(block0_tx, block0_bits);
     furi_delay_us(HITAGMICRO_WAIT_US);
 
     // 3. WRITE EM4100 data block 1 (page 0x01).
-    memset(tx, 0, sizeof(tx));
-    nbits = hitagmicro_build_write(tx, HITAGMICRO_PAGE_BLOCK1, data->block1);
-    hitagmicro_send_frame(tx, nbits);
+    hitagmicro_send_frame(block1_tx, block1_bits);
     furi_delay_us(HITAGMICRO_WAIT_US);
 
     // 4. WRITE config last, so TTF EM4100 emulation only starts once data is in place.
-    memset(tx, 0, sizeof(tx));
-    nbits = hitagmicro_build_write(tx, HITAGMICRO_PAGE_CONFIG, data->config);
-    hitagmicro_send_frame(tx, nbits);
+    hitagmicro_send_frame(config_tx, config_bits);
 
     FURI_CRITICAL_EXIT();
 

--- a/lib/lfrfid/tools/hitagmicro.h
+++ b/lib/lfrfid/tools/hitagmicro.h
@@ -34,7 +34,7 @@ typedef struct {
  */
 const uint8_t* hitagmicro_variant_password(HitagMicroVariant variant);
 
-/** Human readable name of a chip variant, e.g. "8265 / H5". */
+/** Human readable name of a chip variant, e.g. "8265/H5". */
 const char* hitagmicro_variant_name(HitagMicroVariant variant);
 
 /** Write an EM4100 clone to an ID82xx / Hitag micro magic chip.

--- a/lib/lfrfid/tools/hitagmicro.h
+++ b/lib/lfrfid/tools/hitagmicro.h
@@ -33,7 +33,7 @@ typedef struct {
  */
 const uint8_t* hitagmicro_variant_password(HitagMicroVariant variant);
 
-/** Human readable name of a chip variant, e.g. "8265/H5". */
+/** Human readable name of a chip variant, e.g. "8265". */
 const char* hitagmicro_variant_name(HitagMicroVariant variant);
 
 /** Write an EM4100 clone to an ID82xx / Hitag micro magic chip.
@@ -47,7 +47,7 @@ const char* hitagmicro_variant_name(HitagMicroVariant variant);
  * is written last so a failed run cannot leave the tag reconfigured-but-dataless.
  * Success is confirmed afterwards by the worker re-reading the EM4100 emulation.
  *
- * @param      data      The data to write (EM4100 blocks and TTF config)
+ * @param      data      The payload to clone; the caller fully populates block0/block1/config
  * @param      password  The 4-byte LOGIN password (MSB-first) for the target chip variant
  */
 void hitagmicro_write(const LFRFIDHitagMicro* data, const uint8_t* password);

--- a/lib/lfrfid/tools/hitagmicro.h
+++ b/lib/lfrfid/tools/hitagmicro.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LFRFID_HITAGMICRO_BLOCK_SIZE 4
+
+// Known ID82xx / Hitag micro "magic" cloning chips. They are identical apart
+// from the LOGIN password, so a single writer handles all of them.
+typedef enum {
+    HitagMicroVariant8265, // 8265 (CN) / H5 (RU) - factory default, password 00000000
+    HitagMicroVariant8210, // 8210 (CN) - password 9AC4999C
+    HitagMicroVariantH55, // H5.5 (RU) - password 496B0E59
+
+    HitagMicroVariantCount,
+} HitagMicroVariant;
+
+// Data to clone an EM4100 ID onto an ID82xx / Hitag micro magic chip.
+// All fields are stored MSB-first, exactly as they are transmitted on the wire.
+typedef struct {
+    uint8_t block0[LFRFID_HITAGMICRO_BLOCK_SIZE]; // EM4100 frame bits 63..32 -> page 0x00
+    uint8_t block1[LFRFID_HITAGMICRO_BLOCK_SIZE]; // EM4100 frame bits 31..0  -> page 0x01
+    uint8_t config[LFRFID_HITAGMICRO_BLOCK_SIZE]; // TTF config word          -> page 0xFF
+    uint8_t password[LFRFID_HITAGMICRO_BLOCK_SIZE]; // LOGIN credential
+} LFRFIDHitagMicro;
+
+/** Return the 4-byte LOGIN password for a given chip variant (MSB-first).
+ *
+ * @param      variant  The chip variant
+ * @return     pointer to a static 4-byte password, or NULL if variant is invalid
+ */
+const uint8_t* hitagmicro_variant_password(HitagMicroVariant variant);
+
+/** Human readable name of a chip variant, e.g. "8265 / H5". */
+const char* hitagmicro_variant_name(HitagMicroVariant variant);
+
+/** Write an EM4100 clone to an ID82xx / Hitag micro magic chip.
+ *
+ * This is an open-loop (transmit-only) write that mirrors how em4305_write() and
+ * t5577_write() work: it modulates the field and never reads the tag back. It
+ * reproduces the reader->tag frames that Proxmark3's `lf em 410x clone --htu`
+ * sends (LOGIN + WRITE block0 + WRITE block1 + WRITE config), but skips the
+ * closed-loop SELECT/anticollision exchange. This is sufficient for a single
+ * known-password chip in the field; success is confirmed afterwards by the
+ * worker re-reading the resulting EM4100 emulation.
+ *
+ * @param      data  The data to write (blocks, config and password)
+ */
+void hitagmicro_write(LFRFIDHitagMicro* data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/lfrfid/tools/hitagmicro.h
+++ b/lib/lfrfid/tools/hitagmicro.h
@@ -24,7 +24,6 @@ typedef struct {
     uint8_t block0[LFRFID_HITAGMICRO_BLOCK_SIZE]; // EM4100 frame bits 63..32 -> page 0x00
     uint8_t block1[LFRFID_HITAGMICRO_BLOCK_SIZE]; // EM4100 frame bits 31..0  -> page 0x01
     uint8_t config[LFRFID_HITAGMICRO_BLOCK_SIZE]; // TTF config word          -> page 0xFF
-    uint8_t password[LFRFID_HITAGMICRO_BLOCK_SIZE]; // LOGIN credential
 } LFRFIDHitagMicro;
 
 /** Return the 4-byte LOGIN password for a given chip variant (MSB-first).
@@ -40,16 +39,18 @@ const char* hitagmicro_variant_name(HitagMicroVariant variant);
 /** Write an EM4100 clone to an ID82xx / Hitag micro magic chip.
  *
  * This is an open-loop (transmit-only) write that mirrors how em4305_write() and
- * t5577_write() work: it modulates the field and never reads the tag back. It
- * reproduces the reader->tag frames that Proxmark3's `lf em 410x clone --htu`
- * sends (LOGIN + WRITE block0 + WRITE block1 + WRITE config), but skips the
- * closed-loop SELECT/anticollision exchange. This is sufficient for a single
- * known-password chip in the field; success is confirmed afterwards by the
- * worker re-reading the resulting EM4100 emulation.
+ * t5577_write() work: it modulates the field and never reads the tag back. Each
+ * block is written in its own power-cycled session that replays the reader->tag
+ * frames Proxmark3's `lf em 410x clone --htu` sends - an open-loop select chain
+ * (READ UID -> GET SYSTEM INFO -> READ config) followed by LOGIN and the WRITE -
+ * but without the closed-loop RX/anticollision (no tag responses are read). Config
+ * is written last so a failed run cannot leave the tag reconfigured-but-dataless.
+ * Success is confirmed afterwards by the worker re-reading the EM4100 emulation.
  *
- * @param      data  The data to write (blocks, config and password)
+ * @param      data      The data to write (EM4100 blocks and TTF config)
+ * @param      password  The 4-byte LOGIN password (MSB-first) for the target chip variant
  */
-void hitagmicro_write(LFRFIDHitagMicro* data);
+void hitagmicro_write(const LFRFIDHitagMicro* data, const uint8_t* password);
 
 #ifdef __cplusplus
 }

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,87.8,,
+Version,+,87.10,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/applications.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
@@ -2102,6 +2102,9 @@ Function,+,hex_char_to_hex_nibble,_Bool,"char, uint8_t*"
 Function,+,hex_char_to_uint8,_Bool,"char, char, uint8_t*"
 Function,+,hex_chars_to_uint64,_Bool,"const char*, uint64_t*"
 Function,+,hex_chars_to_uint8,_Bool,"const char*, uint8_t*"
+Function,+,hitagmicro_variant_name,const char*,HitagMicroVariant
+Function,+,hitagmicro_variant_password,const uint8_t*,HitagMicroVariant
+Function,+,hitagmicro_write,void,LFRFIDHitagMicro*
 Function,-,hypot,double,"double, double"
 Function,-,hypotf,float,"float, float"
 Function,-,hypotl,long double,"long double, long double"
@@ -2427,6 +2430,7 @@ Function,+,lfrfid_worker_alloc,LFRFIDWorker*,ProtocolDict*
 Function,+,lfrfid_worker_emulate_raw_start,void,"LFRFIDWorker*, const char*, LFRFIDWorkerEmulateRawCallback, void*"
 Function,+,lfrfid_worker_emulate_start,void,"LFRFIDWorker*, LFRFIDProtocol"
 Function,+,lfrfid_worker_free,void,LFRFIDWorker*
+Function,+,lfrfid_worker_get_write_chip_name,const char*,LFRFIDWorker*
 Function,+,lfrfid_worker_read_raw_start,void,"LFRFIDWorker*, const char*, LFRFIDWorkerReadType, LFRFIDWorkerReadRawCallback, void*"
 Function,+,lfrfid_worker_read_start,void,"LFRFIDWorker*, LFRFIDWorkerReadType, LFRFIDWorkerReadCallback, void*"
 Function,+,lfrfid_worker_start_thread,void,LFRFIDWorker*

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,87.10,,
+Version,+,87.9,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/applications.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
@@ -2104,7 +2104,7 @@ Function,+,hex_chars_to_uint64,_Bool,"const char*, uint64_t*"
 Function,+,hex_chars_to_uint8,_Bool,"const char*, uint8_t*"
 Function,+,hitagmicro_variant_name,const char*,HitagMicroVariant
 Function,+,hitagmicro_variant_password,const uint8_t*,HitagMicroVariant
-Function,+,hitagmicro_write,void,LFRFIDHitagMicro*
+Function,+,hitagmicro_write,void,"const LFRFIDHitagMicro*, const uint8_t*"
 Function,-,hypot,double,"double, double"
 Function,-,hypotf,float,"float, float"
 Function,-,hypotl,long double,"long double, long double"


### PR DESCRIPTION
# What's new

Adds writing an EM4100 ID onto ID82xx / Hitag micro "8265" magic chips (the
Proxmark3 `lf em 410x clone --htu` target) directly from the LF RFID app.

- No new UI / no chip picker: writing an EM4100 now also targets these chips.
  The writer tries the three known password variants (8265, 8210, H5.5),
  verifies by read-back, and shows the detected chip on the success screen
  and the current target while writing.
- New open-loop (TX-only) 125 kHz writer `lib/lfrfid/tools/hitagmicro.c`,
  modeled on `t5577_write`/`em4305_write`. It replays the reader->tag frames
  PM3 sends — open-loop select chain (READ UID -> GET SYSTEM INFO -> READ
  config) -> LOGIN -> WRITE — per power-cycled block, with **config written
  last** so a failed run can't leave the tag reconfigured-but-dataless
  (brick), and a **leading cold field-off** so two consecutive writes to the
  same tag both take.
- Hand-rolled `hitagmicro_crc16` (bit-length CRC; `bit_lib_crc16` is
  byte-aligned only and the frames are 43/51 bits); reuses
  `bit_lib_reverse_16_fast`.
- EM4100->page mapping in `protocol_em4100.c`; integrated into `lfrfid_worker`.
- "Write and set password" screen now also shows its target `(T5577)` for
  consistency with the Write screen.
- Firmware API: 87.8 -> 87.9 (new `hitagmicro_*` and
  `lfrfid_worker_get_write_chip_name` symbols).

# Verification

Build & flash firmware + resources: `./fbt COMPACT=1 DEBUG=0 flash_usb_full`

1. **T5577 regression** — save an EM4100, write it to a T5577 -> "Success!"
   shows `T5577`; LF read confirms the ID.
2. **Hitag micro** — place an 8265 / 8210 / H5.5 magic chip, open a saved
   EM4100, Write -> "Success!" shows `8265` / `8210` / `H5.5`; LF read of the
   tag returns the cloned EM4100 ID.
3. **Back-to-back write** — write card A (success), then *without moving the
   tag* open card B and Write -> the second write also succeeds (cold-reset).
4. **Write and set password** (T5577) — still works; screen shows `(T5577)`.
5. No crash/brick across repeated writes; a non-writable card still shows the
   "Still Trying to Write..." hint.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

- [x] Fully AI generated (explain what all the generated code does in moderate detail).

The new code was written by Claude (Claude Code) under my direction. It adds
an open-loop Hitag micro / ID82xx writer (`lib/lfrfid/tools/hitagmicro.c`):
it builds the BPLM reader->tag frames (READ UID, GET SYSTEM INFO, READ config,
LOGIN, WRITE) with a CRC-16 matching the chip and transmits them per
power-cycled block (config last; leading cold-reset between sessions). This is
wired into the LFRFID worker as a new write target that sweeps the three
password variants and confirms the result by reading the tag back, plus the
EM4100->block/config mapping and small UI changes (detected chip name on the
write/success screens). Wire format and timings were derived from the
Proxmark3 `lf hitag htu` implementation; every variant was validated on real
8265/8210/H5.5 hardware, all design/UX decisions were mine, and the changes
were reviewed multi-pass before submitting.

# Checklist (For Reviewer) (Don't fill this out!):

- [x] PR has proper description of new feature/bugfix
- [x] Description contains actions to verify feature/bugfix on the hardware
- [x] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
