### PR TITLE
CI: fix free-flash report to subtract BLE coprocessor stack region

### DIFF
--- a/.github/scripts/fw_size_report.py
+++ b/.github/scripts/fw_size_report.py
@@ -1,47 +1,75 @@
 #!/usr/bin/env python3
-"""Report f7 firmware flash/RAM usage and DFU size from a built firmware.elf.
+"""Report f7 firmware flash/RAM usage, DFU size, and *usable* free flash.
 
-Parses `arm-none-eabi-size -A <firmware.elf>`. On the STM32WB55 the firmware
-grows up from the start of flash and the linker fills the gap up to the radio
-stack / internal-storage boundary with a `.free_flash` section
-(targets/f7/stm32wb55xx_flash.ld) — so its size *is* "how much flash is left".
+Parses ``arm-none-eabi-size -A <firmware.elf>``. On the STM32WB55 the firmware
+grows up from the start of flash and the linker fills the gap up to the top of
+the 1 MB flash with a ``.free_flash`` section (targets/f7/stm32wb55xx_flash.ld).
 
-  flash used = .text + .rodata + .data   (flash-resident)
-  flash free = .free_flash
+IMPORTANT: ``.free_flash`` overcounts usable space. The linker script models
+flash as the full ``0x08000000..0x08100000`` 1 MB, but the BLE coprocessor
+("core2") radio stack + FUS physically occupy the TOP of flash and are NOT
+usable by our firmware/storage. So the real free flash is::
+
+    radio_addr = FUS_BASE - ceil(copro_bin_size / 4096) * 4096   # stack load addr
+    reserved   = flash_top - radio_addr                          # radio stack + FUS/secure
+    usable_free = .free_flash - reserved                         # == radio_addr - free_flash_start
+
+This mirrors Momentum's report (flash_free = radio_addr - flash_base - fw_size)
+and the repo's own scripts/flipper/assets/coprobin.py (CoproFusFooter.get_flash_base),
+where the radio stack load address depends only on the .bin size. For the default
+``ble_light`` stack the reserved region is 164.00 KiB, leaving ~21.79 KiB usable.
+
+  flash used = flash_top - .free_flash size - radio reserved ... reported as
+               firmware footprint = free_flash_start - FLASH_BASE  (all sections)
   RAM used   = .data + .bss
 
-Emits Markdown (--out) and prints JSON to stdout:
-  {"free_bytes":int|null,"used_bytes":int|null,"total_bytes":int|null,"dfu_bytes":int|null}
+Emits Markdown (--out) and prints JSON to stdout.
 
 Sources (any one):
   * CI:   --size-bin <arm-none-eabi-size> --elf <firmware.elf>
   * Test: --size-output <captured `size -A` text file>
-DFU size (optional): --dfu <firmware.dfu>
+Optional: --dfu <firmware.dfu>   --copro-bin <radio stack .bin>  --copro-label ble_light
 """
 
 import argparse
 import json
+import math
 import os
 import subprocess
 from pathlib import Path
 
-FLASH_SECTIONS = (".text", ".rodata", ".data")  # flash-resident
 RAM_SECTIONS = (".data", ".bss")
+
+# STM32WB55 flash geometry (see targets/f7/stm32wb55xx_flash.ld + coprobin.py).
+FLASH_BASE = 0x08000000
+FLASH_TOP = 0x08100000  # ORIGIN(FLASH) + LENGTH(FLASH) = 1 MiB
+FUS_BASE = 0x080F4000   # CoproFusFooter.FUS_BASE
+FLASH_PAGE = 4096
 
 
 def parse_size(text):
-    """Return {section: bytes} from `arm-none-eabi-size -A` (sysv) output."""
+    """Return {section: (bytes, addr)} from `arm-none-eabi-size -A` (sysv) output."""
     sizes = {}
     for line in text.splitlines():
         parts = line.split()
         if len(parts) != 3:  # "section size addr"; header/total rows differ
             continue
-        section, size, _addr = parts
+        section, size, addr = parts
         try:
-            sizes[section] = int(size)
+            sizes[section] = (int(size), int(addr))
         except ValueError:
             continue  # e.g. the "section size addr" header row
     return sizes
+
+
+def radio_load_addr(copro_size):
+    """Flash load address of the radio stack, from its .bin size alone.
+
+    Same math as scripts/flipper/assets/coprobin.py CoproFusFooter.get_flash_base:
+    the stack is page-aligned and butts up against FUS_BASE.
+    """
+    pages = math.ceil(copro_size / FLASH_PAGE)
+    return FUS_BASE - pages * FLASH_PAGE
 
 
 def human(n):
@@ -60,6 +88,8 @@ def main():
     ap.add_argument("--elf", help="firmware.elf")
     ap.add_argument("--size-output", help="test mode: captured `size -A` output")
     ap.add_argument("--dfu", help="firmware.dfu (optional, for file size)")
+    ap.add_argument("--copro-bin", help="radio stack .bin (to reserve its flash region)")
+    ap.add_argument("--copro-label", default="", help="radio stack label, e.g. ble_light")
     ap.add_argument("--out", default="size_report.md")
     args = ap.parse_args()
 
@@ -76,33 +106,72 @@ def main():
         size_text = ""
 
     sizes = parse_size(size_text)
-    free = sizes.get(".free_flash")
-    used = sum(sizes[s] for s in FLASH_SECTIONS if s in sizes) or None
-    ram = sum(sizes[s] for s in RAM_SECTIONS if s in sizes) or None
-    total = used + free if (used is not None and free is not None) else None
+
+    free_flash, free_flash_start = sizes.get(".free_flash", (None, None))
+    # Exact firmware flash footprint = everything below .free_flash (all sections,
+    # alignment, init arrays, the .data LMA copy). Falls back to None if no ELF.
+    firmware = (free_flash_start - FLASH_BASE) if free_flash_start is not None else None
+    ram = sum(sizes[s][0] for s in RAM_SECTIONS if s in sizes) or None
     dfu = os.path.getsize(args.dfu) if (args.dfu and Path(args.dfu).exists()) else None
 
-    lines = ["### 💾 Flash & RAM (f7)", ""]
-    if free is None and used is None:
+    # Reserve the radio stack + FUS region that the linker counts as ".free_flash".
+    radio_addr = reserved = usable_free = None
+    copro_size = None
+    if args.copro_bin and Path(args.copro_bin).exists():
+        copro_size = os.path.getsize(args.copro_bin)
+        radio_addr = radio_load_addr(copro_size)
+        reserved = FLASH_TOP - radio_addr
+        if free_flash is not None:
+            usable_free = free_flash - reserved
+
+    label = f" ({args.copro_label})" if args.copro_label else ""
+    lines = [f"### 💾 Flash & RAM — f7{label}", ""]
+    if free_flash is None and firmware is None:
         lines.append("_Size data unavailable (firmware ELF not found)._")
     else:
         lines += ["| Metric | Size |", "|---|---|"]
-        if used is not None:
-            lines.append(f"| Firmware (flash-resident) | {human(used)} |")
-        if free is not None:
-            pct = f" — {free / total * 100:.1f}% of region free" if total else ""
-            lines.append(f"| **Free flash** | **{human(free)}**{pct} |")
-        if total is not None:
-            lines.append(f"| Flash region (used + free) | {human(total)} |")
+        if firmware is not None:
+            lines.append(f"| Firmware (flash) | {human(firmware)} |")
         if dfu is not None:
             lines.append(f"| DFU image | {human(dfu)} |")
+        if reserved is not None:
+            lines.append(f"| Reserved — radio stack + FUS | {human(reserved)} |")
+        if usable_free is not None:
+            warn = " ⚠️" if usable_free < 16 * 1024 else ""
+            lines.append(f"| **Free flash (usable)** | **{human(usable_free)}{warn}** |")
+        elif free_flash is not None:
+            # No copro bin -> can only show the raw linker section (overcounts).
+            lines.append(f"| Free flash (gross, excl. radio stack) | {human(free_flash)} |")
         if ram is not None:
             lines.append(f"| RAM (.data + .bss) | {human(ram)} |")
+        lines.append("")
+        if usable_free is not None:
+            lines.append(
+                f"<sub>1 MiB flash = firmware + usable free + radio/FUS. The BLE "
+                f"coprocessor stack sits at the top of flash (load addr "
+                f"`0x{radio_addr:08X}`); the linker's `.free_flash` "
+                f"({human(free_flash)}) counts that region as free, so usable free = "
+                f"`.free_flash` − reserved ({human(reserved)}).</sub>"
+            )
+        elif free_flash is not None:
+            lines.append(
+                "<sub>⚠️ Radio stack size unknown (copro .bin not found), so this is the "
+                "raw linker `.free_flash` and **overcounts** — the BLE coprocessor stack "
+                "(~164 KiB for ble_light) at the top of flash is not subtracted.</sub>"
+            )
+
     Path(args.out).write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     print(json.dumps({
-        "free_bytes": free, "used_bytes": used,
-        "total_bytes": total, "dfu_bytes": dfu,
+        "usable_free_bytes": usable_free,
+        "free_flash_section_bytes": free_flash,
+        "radio_reserved_bytes": reserved,
+        "radio_addr": (f"0x{radio_addr:08X}" if radio_addr is not None else None),
+        "copro_bin_bytes": copro_size,
+        "copro_label": args.copro_label or None,
+        "firmware_flash_bytes": firmware,
+        "dfu_bytes": dfu,
+        "ram_bytes": ram,
     }))
 
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -7,9 +7,9 @@
 #   * Builds the f7 "clean" flavor only (firmware + in-tree apps). The default/extra
 #     app packs are PREBUILT binaries from xMasterX/all-the-plugins, NOT compiled
 #     from the PR, so bundling them validates nothing here.
-#   * Flash budget comes from the firmware ELF's `.free_flash` section — the linker
-#     fills the gap up to the radio stack with it (targets/f7/stm32wb55xx_flash.ld),
-#     so its size is exactly "how much flash is left". See fw_size_report.py.
+#   * Flash budget comes from the firmware ELF's `.free_flash` section MINUS the
+#     BLE coprocessor radio stack + FUS region that sits at the top of flash (the
+#     linker counts it as free, but it isn't usable). See fw_size_report.py.
 #   * The clean build also gates API drift: fbt fails if the exported API surface
 #     changes without targets/*/api_symbols.csv being updated + version-bumped.
 #
@@ -89,7 +89,10 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
-      # ---------- Flash budget: DFU size + free flash ----------
+      # ---------- Flash budget: DFU size + usable free flash ----------
+      # "Usable free" subtracts the BLE coprocessor (core2) radio stack + FUS region
+      # that sits at the top of flash — the linker's .free_flash counts it as free but
+      # it is not usable by our firmware. Resolve the configured stack from fbt_options.
       - name: Measure firmware size
         if: always()
         shell: bash
@@ -98,9 +101,14 @@ jobs:
           [ -z "$SIZE_BIN" ] && SIZE_BIN="$(command -v arm-none-eabi-size || true)"
           ELF="$(find build -name firmware.elf -type f 2>/dev/null | head -1)"
           DFU="$(find build -name firmware.dfu -type f 2>/dev/null | head -1)"
-          echo "size-bin=$SIZE_BIN | elf=$ELF | dfu=$DFU"
+          COPRO_BIN="$(python -c 'import fbt_options as o; print(f"{o.COPRO_STACK_BIN_DIR}/{o.COPRO_STACK_BIN}")' 2>/dev/null || true)"
+          COPRO_LABEL="$(python -c 'import fbt_options as o; print(o.COPRO_STACK_TYPE)' 2>/dev/null || true)"
+          [ -f "$COPRO_BIN" ] || COPRO_BIN=""
+          echo "size-bin=$SIZE_BIN | elf=$ELF | dfu=$DFU | copro=$COPRO_BIN ($COPRO_LABEL)"
           python .github/scripts/fw_size_report.py \
-            --size-bin "$SIZE_BIN" --elf "$ELF" --dfu "$DFU" --out size_report.md || true
+            --size-bin "$SIZE_BIN" --elf "$ELF" --dfu "$DFU" \
+            --copro-bin "$COPRO_BIN" --copro-label "$COPRO_LABEL" \
+            --out size_report.md || true
           [ -f size_report.md ] || echo "_Size report unavailable._" > size_report.md
 
       # ---------- Public API change report (PRs only) ----------


### PR DESCRIPTION
## What

The **Build & analyze** flash report was showing the linker's `.free_flash` section verbatim (~**185 KiB**), which **overcounts** usable space.

The linker script (`targets/f7/stm32wb55xx_flash.ld`) models flash as the full 1 MB `0x08000000..0x08100000` and fills the gap above the firmware with `.free_flash`. But the **BLE coprocessor (core2) radio stack + FUS** physically occupy the **top** of flash and are **not** usable by our firmware/storage — so the real usable free flash is much smaller.

> Reported by @ the repo owner: real free is ~21.77 KiB, not 185 — the report wasn't accounting for the second core's BLE stack.

## Fix

Subtract the radio-stack + FUS region, the same way Momentum's CI and this repo's own `scripts/flipper/assets/coprobin.py` compute it (the stack load address depends only on the `.bin` size):

```
radio_addr  = FUS_BASE(0x080F4000) - ceil(copro_size / 4096) * 4096
reserved    = flash_top(0x08100000) - radio_addr      # radio stack + FUS/secure
usable_free = .free_flash - reserved                  # == radio_addr - free_flash_start
```

For the default **`ble_light`** stack (116 956 B) the reserved region is **164.00 KiB**, so:

| Metric | Size |
|---|---|
| Firmware (flash) | 838.21 KiB |
| Reserved — radio stack + FUS | 164.00 KiB |
| **Free flash (usable)** | **21.79 KiB** |

The workflow resolves the configured stack from `fbt_options.py` (`COPRO_STACK_BIN`/`COPRO_STACK_TYPE`) and passes it to `fw_size_report.py`. If the copro `.bin` can't be located, it falls back to the raw `.free_flash` with an explicit **overcount** warning instead of silently misreporting.

The corrected number will appear in this PR's own auto-comment below. 👇

🤖 Generated with [Claude Code](https://claude.com/claude-code)