### PR TITLE
[NFC]: show MIFARE Ultralight/NTAG PWD & PACK in full info view

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.c
@@ -14,6 +14,17 @@ static void nfc_render_mf_ultralight_counters(const MfUltralightData* data, Furi
         furi_string_cat_printf(str, "\nCounter %u: %lu", i, data->counter[i].counter);
 }
 
+static void nfc_render_mf_ultralight_pwd_pack_lines(
+    const MfUltralightConfigPages* config,
+    FuriString* str) {
+    furi_string_cat_printf(str, "\nPassword: ");
+    nfc_render_iso14443_3a_format_bytes(
+        str, config->password.data, MF_ULTRALIGHT_AUTH_PASSWORD_SIZE);
+
+    furi_string_cat_printf(str, "\nPACK: ");
+    nfc_render_iso14443_3a_format_bytes(str, config->pack.data, MF_ULTRALIGHT_AUTH_PACK_SIZE);
+}
+
 void nfc_render_mf_ultralight_pwd_pack(const MfUltralightData* data, FuriString* str) {
     MfUltralightConfigPages* config;
 
@@ -29,12 +40,7 @@ void nfc_render_mf_ultralight_pwd_pack(const MfUltralightData* data, FuriString*
     }
 
     if(has_config) {
-        furi_string_cat_printf(str, "\nPassword: ");
-        nfc_render_iso14443_3a_format_bytes(
-            str, config->password.data, MF_ULTRALIGHT_AUTH_PASSWORD_SIZE);
-
-        furi_string_cat_printf(str, "\nPACK: ");
-        nfc_render_iso14443_3a_format_bytes(str, config->pack.data, MF_ULTRALIGHT_AUTH_PACK_SIZE);
+        nfc_render_mf_ultralight_pwd_pack_lines(config, str);
     } else {
         furi_string_cat_printf(str, "\nThis card does not support\npassword protection!");
     }
@@ -51,6 +57,14 @@ void nfc_render_mf_ultralight_info(
     nfc_render_mf_ultralight_pages_count(data, str);
 
     nfc_render_mf_ultralight_counters(data, str);
+
+    // Surface PWD/PACK in the full info view (open dump / CLI) when the dump actually
+    // captured them. Short format (read-success summary) is intentionally left untouched.
+    MfUltralightConfigPages* config = NULL;
+    if(format_type == NfcProtocolFormatTypeFull && mf_ultralight_is_pwd_pack_read(data) &&
+       mf_ultralight_get_config_page(data, &config)) {
+        nfc_render_mf_ultralight_pwd_pack_lines(config, str);
+    }
 }
 
 void nfc_render_mf_ultralight_dump(const MfUltralightData* data, FuriString* str) {

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
@@ -653,6 +653,17 @@ bool mf_ultralight_is_all_data_read(const MfUltralightData* data) {
     return all_read;
 }
 
+bool mf_ultralight_is_pwd_pack_read(const MfUltralightData* data) {
+    furi_check(data);
+
+    // PWD lives at pwd_page, PACK at pwd_page+1. On a read where auth didn't succeed the
+    // poller rolls pages_read back by 2 (see try_default_pass) because these pages come back
+    // masked as zero, so a contiguous read that still covers both pages means the real values
+    // were actually captured. pages_read is persisted, so this holds for loaded dumps too.
+    uint8_t pwd_page = mf_ultralight_get_pwd_page_num(data->type);
+    return (pwd_page != 0) && (data->pages_read >= pwd_page + 2);
+}
+
 bool mf_ultralight_is_counter_configured(const MfUltralightData* data) {
     furi_check(data);
 

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.h
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.h
@@ -235,6 +235,8 @@ bool mf_ultralight_get_config_page(const MfUltralightData* data, MfUltralightCon
 
 bool mf_ultralight_is_all_data_read(const MfUltralightData* data);
 
+bool mf_ultralight_is_pwd_pack_read(const MfUltralightData* data);
+
 bool mf_ultralight_detect_protocol(const Iso14443_3aData* iso14443_3a_data);
 
 bool mf_ultralight_is_counter_configured(const MfUltralightData* data);

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,87.9,,
+Version,+,87.10,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/applications.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
@@ -2860,6 +2860,7 @@ Function,+,mf_ultralight_is_all_data_read,_Bool,const MfUltralightData*
 Function,+,mf_ultralight_is_counter_configured,_Bool,const MfUltralightData*
 Function,+,mf_ultralight_is_equal,_Bool,"const MfUltralightData*, const MfUltralightData*"
 Function,+,mf_ultralight_is_page_pwd_or_pack,_Bool,"MfUltralightType, uint16_t"
+Function,+,mf_ultralight_is_pwd_pack_read,_Bool,const MfUltralightData*
 Function,+,mf_ultralight_load,_Bool,"MfUltralightData*, FlipperFormat*, uint32_t"
 Function,+,mf_ultralight_poller_auth_pwd,MfUltralightError,"MfUltralightPoller*, MfUltralightPollerAuthContext*"
 Function,+,mf_ultralight_poller_authenticate_end,MfUltralightError,"MfUltralightPoller*, const uint8_t*, const uint8_t*, uint8_t*"


### PR DESCRIPTION
## What

Surfaces the **Password (PWD)** and **PACK** of MIFARE Ultralight / NTAG dumps in the **full info view** — the open-saved-dump *Info* scene and the `mfu info` CLI — when the dump actually captured them. Previously these were only visible on the post-unlock read-success screen.

## Why

The PWD/PACK are already stored in the dump's config page; there was just no way to see them when reopening a saved full dump. They're masked to zero on every plain READ (real silicon behavior, mirrored by the listener), so they only land in a dump via a successful auth.

## How

- New library predicate `mf_ultralight_is_pwd_pack_read()` (next to `mf_ultralight_is_all_data_read`) answers "did this dump genuinely capture PWD/PACK?". It gates on whether the PWD/PACK pages are within `pages_read`.
  - This leans on the existing poller convention: `try_default_pass` rolls `pages_read` back by 2 when those pages come back masked (no successful auth), so a contiguous read that still covers them means the real values were captured. `pages_read` is persisted, so the check works identically on loaded dumps.
  - Types without a config page (ULC/Origin, plain UL, NTAG203, I2C non-Plus) return `false` via `pwd_page == 0`.
- `nfc_render_mf_ultralight_info` renders the PWD/PACK lines only for `NfcProtocolFormatTypeFull` (matches the established per-protocol full-vs-short convention). The **short** read-success summary is intentionally untouched.
- Factored the shared `Password:` / `PACK:` printing into `nfc_render_mf_ultralight_pwd_pack_lines`, reused by both the unlock screen and the new info path.
- Exported the predicate in `api_symbols.csv` (version bump 87.9 → 87.10).

## Testing

- `./fbt` builds clean (f7), `api_symbols` 87.10 validated.
- `./fbt format` + `./fbt lint` clean.
- Reviewed via pr-review-toolkit (code/comments/silent-failure) and simplify passes — no correctness issues; boundary math, type coverage, and integer promotion verified.

> Note: a card that protects pages with the *default* password and isn't fully read is intentionally not surfaced (the contiguous `pages_read` counter can't represent "have PWD/PACK but a gap in data pages"). The captured values are still saved in the page buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)