### PR TITLE
[NFC]: show MIFARE Ultralight/NTAG PWD & PACK on read screen too

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
@@ -273,6 +273,9 @@ static void nfc_scene_read_success_on_enter_mf_ultralight(NfcApp* instance) {
         furi_string_replace(temp_str, "Mifare", "MIFARE");
 
         nfc_render_mf_ultralight_info(data, NfcProtocolFormatTypeShort, temp_str);
+
+        // Show captured PWD/PACK on a plain read too, matching the Unlock screen.
+        nfc_render_mf_ultralight_pwd_pack_if_read(data, temp_str);
     }
 
     mf_ultralight_auth_reset(instance->mf_ul_auth);

--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.c
@@ -48,6 +48,14 @@ void nfc_render_mf_ultralight_pwd_pack(const MfUltralightData* data, FuriString*
     nfc_render_mf_ultralight_pages_count(data, str);
 }
 
+void nfc_render_mf_ultralight_pwd_pack_if_read(const MfUltralightData* data, FuriString* str) {
+    // Only when the dump actually captured them (see mf_ultralight_is_pwd_pack_read).
+    MfUltralightConfigPages* config = NULL;
+    if(mf_ultralight_is_pwd_pack_read(data) && mf_ultralight_get_config_page(data, &config)) {
+        nfc_render_mf_ultralight_pwd_pack_lines(config, str);
+    }
+}
+
 void nfc_render_mf_ultralight_info(
     const MfUltralightData* data,
     NfcProtocolFormatType format_type,
@@ -58,12 +66,9 @@ void nfc_render_mf_ultralight_info(
 
     nfc_render_mf_ultralight_counters(data, str);
 
-    // Surface PWD/PACK in the full info view (open dump / CLI) when the dump actually
-    // captured them. Short format (read-success summary) is intentionally left untouched.
-    MfUltralightConfigPages* config = NULL;
-    if(format_type == NfcProtocolFormatTypeFull && mf_ultralight_is_pwd_pack_read(data) &&
-       mf_ultralight_get_config_page(data, &config)) {
-        nfc_render_mf_ultralight_pwd_pack_lines(config, str);
+    // PWD/PACK is a verbose extra, like the other Full-only fields.
+    if(format_type == NfcProtocolFormatTypeFull) {
+        nfc_render_mf_ultralight_pwd_pack_if_read(data, str);
     }
 }
 

--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.h
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.h
@@ -12,3 +12,5 @@ void nfc_render_mf_ultralight_info(
 void nfc_render_mf_ultralight_dump(const MfUltralightData* data, FuriString* str);
 
 void nfc_render_mf_ultralight_pwd_pack(const MfUltralightData* data, FuriString* str);
+
+void nfc_render_mf_ultralight_pwd_pack_if_read(const MfUltralightData* data, FuriString* str);


### PR DESCRIPTION
## What

Follow-up to #1010. MIFARE Ultralight / NTAG **Password (PWD) & PACK** now also appear on the standard **read-success screen** — not only in **More → Info** — whenever the read actually captured them (e.g. a card still on the default password, which the poller auto-authenticates).

Before this, a plain read that captured PWD/PACK surfaced them only in the full Info view, while the explicit **Unlock** flow already printed them on the read screen. This closes that inconsistency.

## How

- `NfcProtocolFormatType` is a verbosity axis (`Short ⊂ Full`), so PWD/PACK stays a `Full`-only extra inside the shared `nfc_render_mf_ultralight_info` — consistent with every sibling `nfc_render_*_info`.
- Factored the "render PWD/PACK if captured" logic into `nfc_render_mf_ultralight_pwd_pack_if_read()`.
- The read-success **scene** explicitly appends it on the plain-read branch, mirroring the existing Unlock branch — keeping the scene-specific policy in the scene rather than bolting it onto the shared renderer.

Gating reuses `mf_ultralight_is_pwd_pack_read()` (added in #1010), so masked / un-captured values are never shown.

## Notes

- No API changes — these render symbols are app-internal.
- clang-format / lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)