### PR TITLE
NFC: add Bambu Lab filament spool parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * LFRFID: **Support of Hitag Micro chips** (8265/8210/H5.5) (by @mishamyte | PR #1002)
 * LFRFID: **Wipe T5577** (reset to blank, with read-back verification) (by @mishamyte | PR #1003)
 * NFC: Show MIFARE Ultralight/NTAG PWD & PACK in full info view / on read screen too (by @mishamyte | PR #1010 #1011)
+* NFC: **Add Bambu Lab filament spool parser** (type, color, code, temps, spool specs) (ported from [uzyn/flipper-bambu](https://github.com/uzyn/flipper-bambu), GPL-3.0)
 * Apps: **NFC Magic** - Gen2 CUID/static-nonce detection, Gen1 4b/7b UID, length-aware wipe & write guard (by @mishamyte)
 * Apps: Build tag (**14jun2026**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes

--- a/applications/main/nfc/application.fam
+++ b/applications/main/nfc/application.fam
@@ -216,6 +216,15 @@ App(
 # Parser plugins
 
 App(
+    appid="bambu_parser",
+    apptype=FlipperAppType.PLUGIN,
+    entry_point="bambu_plugin_ep",
+    targets=["f7"],
+    requires=["nfc"],
+    sources=["plugins/supported_cards/bambu.c"],
+)
+
+App(
     appid="all_in_one_parser",
     apptype=FlipperAppType.PLUGIN,
     entry_point="all_in_one_plugin_ep",

--- a/applications/main/nfc/plugins/supported_cards/bambu.c
+++ b/applications/main/nfc/plugins/supported_cards/bambu.c
@@ -1,0 +1,505 @@
+/*
+ * bambu.c - Parser for Bambu Lab filament spool RFID tags (MIFARE Classic 1K).
+ *
+ * Ported into the firmware from the standalone flipper-bambu plugin:
+ *   https://github.com/uzyn/flipper-bambu
+ *
+ * Copyright U-Zyn Chua <https://uzyn.com>
+ *
+ * Filament database sourced from https://github.com/queengooborg/Bambu-Lab-RFID-Library
+ * Tag format research from https://github.com/Bambu-Research-Group/RFID-Tag-Guide
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "nfc_supported_card_plugin.h"
+#include <flipper_application/flipper_application.h>
+#include <nfc/nfc_device.h>
+#include <nfc/protocols/mf_classic/mf_classic.h>
+#include <nfc/protocols/mf_classic/mf_classic_poller_sync.h>
+#include <furi.h>
+#include <string.h>
+
+#include "bambu_filaments.h"
+#include "bambu_parser.h"
+
+static const uint8_t bambu_required_blocks[] = {
+    BLOCK_MATERIAL_IDS,
+    BLOCK_FILAMENT_TYPE,
+    BLOCK_DETAILED_TYPE,
+    BLOCK_COLOR_WEIGHT,
+    BLOCK_TEMPERATURES,
+    BLOCK_NOZZLE,
+    BLOCK_SPOOL_WIDTH,
+    BLOCK_PRODUCTION_DATE,
+    BLOCK_FILAMENT_LENGTH,
+};
+
+typedef struct {
+    uint8_t data[64];
+    uint32_t data_len;
+    uint64_t bit_len;
+    uint32_t state[8];
+} BambuSha256Context;
+
+static inline uint32_t bambu_sha256_rotr(uint32_t value, uint32_t bits) {
+    return (value >> bits) | (value << (32 - bits));
+}
+
+static inline uint32_t bambu_sha256_ch(uint32_t x, uint32_t y, uint32_t z) {
+    return (x & y) ^ (~x & z);
+}
+
+static inline uint32_t bambu_sha256_maj(uint32_t x, uint32_t y, uint32_t z) {
+    return (x & y) ^ (x & z) ^ (y & z);
+}
+
+static inline uint32_t bambu_sha256_ep0(uint32_t x) {
+    return bambu_sha256_rotr(x, 2) ^ bambu_sha256_rotr(x, 13) ^ bambu_sha256_rotr(x, 22);
+}
+
+static inline uint32_t bambu_sha256_ep1(uint32_t x) {
+    return bambu_sha256_rotr(x, 6) ^ bambu_sha256_rotr(x, 11) ^ bambu_sha256_rotr(x, 25);
+}
+
+static inline uint32_t bambu_sha256_sig0(uint32_t x) {
+    return bambu_sha256_rotr(x, 7) ^ bambu_sha256_rotr(x, 18) ^ (x >> 3);
+}
+
+static inline uint32_t bambu_sha256_sig1(uint32_t x) {
+    return bambu_sha256_rotr(x, 17) ^ bambu_sha256_rotr(x, 19) ^ (x >> 10);
+}
+
+static void bambu_sha256_transform(BambuSha256Context* context, const uint8_t data[64]) {
+    static const uint32_t k[64] = {
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    };
+
+    uint32_t message[64];
+    for(size_t i = 0, j = 0; i < 16; i++, j += 4) {
+        message[i] = ((uint32_t)data[j] << 24) | ((uint32_t)data[j + 1] << 16) |
+                     ((uint32_t)data[j + 2] << 8) | ((uint32_t)data[j + 3]);
+    }
+
+    for(size_t i = 16; i < 64; i++) {
+        message[i] = bambu_sha256_sig1(message[i - 2]) + message[i - 7] +
+                     bambu_sha256_sig0(message[i - 15]) + message[i - 16];
+    }
+
+    uint32_t a = context->state[0];
+    uint32_t b = context->state[1];
+    uint32_t c = context->state[2];
+    uint32_t d = context->state[3];
+    uint32_t e = context->state[4];
+    uint32_t f = context->state[5];
+    uint32_t g = context->state[6];
+    uint32_t h = context->state[7];
+
+    for(size_t i = 0; i < 64; i++) {
+        uint32_t t1 = h + bambu_sha256_ep1(e) + bambu_sha256_ch(e, f, g) + k[i] + message[i];
+        uint32_t t2 = bambu_sha256_ep0(a) + bambu_sha256_maj(a, b, c);
+
+        h = g;
+        g = f;
+        f = e;
+        e = d + t1;
+        d = c;
+        c = b;
+        b = a;
+        a = t1 + t2;
+    }
+
+    context->state[0] += a;
+    context->state[1] += b;
+    context->state[2] += c;
+    context->state[3] += d;
+    context->state[4] += e;
+    context->state[5] += f;
+    context->state[6] += g;
+    context->state[7] += h;
+}
+
+static void bambu_sha256_init(BambuSha256Context* context) {
+    context->data_len = 0;
+    context->bit_len = 0;
+    context->state[0] = 0x6a09e667;
+    context->state[1] = 0xbb67ae85;
+    context->state[2] = 0x3c6ef372;
+    context->state[3] = 0xa54ff53a;
+    context->state[4] = 0x510e527f;
+    context->state[5] = 0x9b05688c;
+    context->state[6] = 0x1f83d9ab;
+    context->state[7] = 0x5be0cd19;
+}
+
+static void bambu_sha256_update(BambuSha256Context* context, const uint8_t* data, size_t len) {
+    for(size_t i = 0; i < len; i++) {
+        context->data[context->data_len++] = data[i];
+        if(context->data_len == 64) {
+            bambu_sha256_transform(context, context->data);
+            context->bit_len += 512;
+            context->data_len = 0;
+        }
+    }
+}
+
+static void bambu_sha256_final(BambuSha256Context* context, uint8_t hash[32]) {
+    uint32_t i = context->data_len;
+
+    context->data[i++] = 0x80;
+    if(i > 56) {
+        while(i < 64) {
+            context->data[i++] = 0x00;
+        }
+        bambu_sha256_transform(context, context->data);
+        i = 0;
+    }
+
+    while(i < 56) {
+        context->data[i++] = 0x00;
+    }
+
+    context->bit_len += (uint64_t)context->data_len * 8;
+    context->data[56] = (uint8_t)(context->bit_len >> 56);
+    context->data[57] = (uint8_t)(context->bit_len >> 48);
+    context->data[58] = (uint8_t)(context->bit_len >> 40);
+    context->data[59] = (uint8_t)(context->bit_len >> 32);
+    context->data[60] = (uint8_t)(context->bit_len >> 24);
+    context->data[61] = (uint8_t)(context->bit_len >> 16);
+    context->data[62] = (uint8_t)(context->bit_len >> 8);
+    context->data[63] = (uint8_t)(context->bit_len);
+    bambu_sha256_transform(context, context->data);
+
+    for(i = 0; i < 4; i++) {
+        hash[i] = (uint8_t)((context->state[0] >> (24 - i * 8)) & 0x000000ff);
+        hash[i + 4] = (uint8_t)((context->state[1] >> (24 - i * 8)) & 0x000000ff);
+        hash[i + 8] = (uint8_t)((context->state[2] >> (24 - i * 8)) & 0x000000ff);
+        hash[i + 12] = (uint8_t)((context->state[3] >> (24 - i * 8)) & 0x000000ff);
+        hash[i + 16] = (uint8_t)((context->state[4] >> (24 - i * 8)) & 0x000000ff);
+        hash[i + 20] = (uint8_t)((context->state[5] >> (24 - i * 8)) & 0x000000ff);
+        hash[i + 24] = (uint8_t)((context->state[6] >> (24 - i * 8)) & 0x000000ff);
+        hash[i + 28] = (uint8_t)((context->state[7] >> (24 - i * 8)) & 0x000000ff);
+    }
+}
+
+static void bambu_hmac_sha256(
+    const uint8_t* key,
+    size_t key_len,
+    const uint8_t* data,
+    size_t data_len,
+    uint8_t out[32]) {
+    uint8_t key_block[64] = {0};
+    if(key_len > sizeof(key_block)) {
+        BambuSha256Context key_hash_ctx;
+        bambu_sha256_init(&key_hash_ctx);
+        bambu_sha256_update(&key_hash_ctx, key, key_len);
+        bambu_sha256_final(&key_hash_ctx, key_block);
+    } else {
+        memcpy(key_block, key, key_len);
+    }
+
+    uint8_t ipad[64];
+    uint8_t opad[64];
+    for(size_t i = 0; i < 64; i++) {
+        ipad[i] = key_block[i] ^ 0x36;
+        opad[i] = key_block[i] ^ 0x5C;
+    }
+
+    uint8_t inner_hash[32];
+    BambuSha256Context inner_ctx;
+    bambu_sha256_init(&inner_ctx);
+    bambu_sha256_update(&inner_ctx, ipad, sizeof(ipad));
+    bambu_sha256_update(&inner_ctx, data, data_len);
+    bambu_sha256_final(&inner_ctx, inner_hash);
+
+    BambuSha256Context outer_ctx;
+    bambu_sha256_init(&outer_ctx);
+    bambu_sha256_update(&outer_ctx, opad, sizeof(opad));
+    bambu_sha256_update(&outer_ctx, inner_hash, sizeof(inner_hash));
+    bambu_sha256_final(&outer_ctx, out);
+}
+
+static void bambu_derive_keys_from_uid(const uint8_t* uid, size_t uid_len, MfClassicDeviceKeys* keys) {
+    static const uint8_t master_key[16] = {
+        0x9A,
+        0x75,
+        0x9C,
+        0xF2,
+        0xC4,
+        0xF7,
+        0xCA,
+        0xFF,
+        0x22,
+        0x2C,
+        0xB9,
+        0x76,
+        0x9B,
+        0x41,
+        0xBC,
+        0x96,
+    };
+    static const uint8_t hkdf_context[] = {'R', 'F', 'I', 'D', '-', 'A', '\0'};
+    static const size_t sector_count = 16;
+    static const size_t key_size = sizeof(MfClassicKey);
+    uint8_t prk[32];
+    bambu_hmac_sha256(master_key, sizeof(master_key), uid, uid_len, prk);
+
+    uint8_t key_material[16 * sizeof(MfClassicKey)] = {0};
+    uint8_t t[32] = {0};
+    size_t t_len = 0;
+    uint8_t hmac_input[32 + sizeof(hkdf_context) + 1];
+    size_t generated = 0;
+    uint8_t counter = 1;
+
+    while(generated < sizeof(key_material)) {
+        size_t input_len = 0;
+        if(t_len > 0) {
+            memcpy(hmac_input, t, t_len);
+            input_len = t_len;
+        }
+        memcpy(&hmac_input[input_len], hkdf_context, sizeof(hkdf_context));
+        input_len += sizeof(hkdf_context);
+        hmac_input[input_len++] = counter++;
+
+        bambu_hmac_sha256(prk, sizeof(prk), hmac_input, input_len, t);
+        t_len = sizeof(t);
+
+        size_t chunk_len = sizeof(t);
+        if(chunk_len > sizeof(key_material) - generated) {
+            chunk_len = sizeof(key_material) - generated;
+        }
+        memcpy(&key_material[generated], t, chunk_len);
+        generated += chunk_len;
+    }
+
+    for(size_t sector = 0; sector < sector_count; sector++) {
+        const uint8_t* sector_key = &key_material[sector * key_size];
+        memcpy(keys->key_a[sector].data, sector_key, key_size);
+        FURI_BIT_SET(keys->key_a_mask, sector);
+        memcpy(keys->key_b[sector].data, sector_key, key_size);
+        FURI_BIT_SET(keys->key_b_mask, sector);
+    }
+}
+
+static bool bambu_has_required_blocks(const MfClassicData* data) {
+    for(size_t i = 0; i < COUNT_OF(bambu_required_blocks); i++) {
+        if(!mf_classic_is_block_read(data, bambu_required_blocks[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool bambu_read(Nfc* nfc, NfcDevice* device) {
+    furi_assert(nfc);
+    furi_assert(device);
+
+    bool is_read = false;
+    MfClassicData* data = mf_classic_alloc();
+    nfc_device_copy_data(device, NfcProtocolMfClassic, data);
+
+    do {
+        MfClassicType type = MfClassicType1k;
+        MfClassicError error = mf_classic_poller_sync_detect_type(nfc, &type);
+        if(error != MfClassicErrorNone || type != MfClassicType1k) {
+            break;
+        }
+
+        size_t uid_len = 0;
+        const uint8_t* uid = nfc_device_get_uid(device, &uid_len);
+        if(uid == NULL || uid_len == 0) {
+            break;
+        }
+
+        data->type = type;
+
+        MfClassicDeviceKeys keys = {};
+        bambu_derive_keys_from_uid(uid, uid_len, &keys);
+
+        error = mf_classic_poller_sync_read(nfc, &keys, data);
+        if(error != MfClassicErrorNone && error != MfClassicErrorPartialRead) {
+            break;
+        }
+
+        if(!bambu_has_required_blocks(data)) {
+            break;
+        }
+
+        if(!bambu_tag_is_valid(data)) {
+            break;
+        }
+
+        nfc_device_set_data(device, NfcProtocolMfClassic, data);
+        is_read = true;
+    } while(false);
+
+    mf_classic_free(data);
+    return is_read;
+}
+
+// Main parse function: Extract and format all Bambu spool data
+static bool bambu_parse(const NfcDevice* device, FuriString* parsed_data) {
+    furi_assert(device);
+    furi_assert(parsed_data);
+
+    const MfClassicData* data = nfc_device_get_data(device, NfcProtocolMfClassic);
+
+    // Quick type check
+    if(data->type != MfClassicType1k) {
+        return false;
+    }
+
+    // Verify this is a Bambu tag using our detection logic
+    if(!bambu_tag_is_valid(data)) {
+        return false;
+    }
+
+    // Parse Material ID and Variant ID from Block 1
+    const uint8_t* block1 = data->block[BLOCK_MATERIAL_IDS].data;
+    char material_id[7] = {0};  // "GFxxx" + null
+    char variant_id[8] = {0};   // "xxx-Rx" + null
+    bambu_copy_ascii_string(material_id, &block1[8], 6);
+    bambu_copy_ascii_string(variant_id, &block1[0], 7);
+
+    // Parse Detailed Type from Block 4
+    const uint8_t* block4 = data->block[BLOCK_DETAILED_TYPE].data;
+    char detailed_type[17] = {0};
+    bambu_copy_ascii_string(detailed_type, block4, 16);
+
+    // Parse Color, Weight, Diameter from Block 5
+    const uint8_t* block5 = data->block[BLOCK_COLOR_WEIGHT].data;
+    uint8_t color_r = block5[0];
+    uint8_t color_g = block5[1];
+    uint8_t color_b = block5[2];
+    uint8_t color_a = block5[3];
+    uint16_t weight_grams = bambu_read_le16(&block5[4]);
+    float diameter_mm = bambu_read_le_float(&block5[8]);
+
+    // Parse Temperatures from Block 6
+    const uint8_t* block6 = data->block[BLOCK_TEMPERATURES].data;
+    uint16_t drying_temp = bambu_read_le16(&block6[0]);
+    uint16_t drying_hours = bambu_read_le16(&block6[2]);
+    uint16_t hotend_max = bambu_read_le16(&block6[8]);
+    uint16_t hotend_min = bambu_read_le16(&block6[10]);
+
+    // Parse Nozzle Diameter from Block 8 (float at bytes 12-15)
+    const uint8_t* block8 = data->block[BLOCK_NOZZLE].data;
+    float nozzle_diameter = bambu_read_le_float(&block8[12]);
+
+    // Parse Spool Width from Block 10 (uint16 at bytes 4-5, value in mm*100)
+    const uint8_t* block10 = data->block[BLOCK_SPOOL_WIDTH].data;
+    uint16_t spool_width_raw = bambu_read_le16(&block10[4]);
+    float spool_width_mm = (float)spool_width_raw / 100.0f;
+
+    // Parse Production Date from Block 12 (ASCII YYYY_MM_DD_HH_MM)
+    const uint8_t* block12 = data->block[BLOCK_PRODUCTION_DATE].data;
+    char production_date[17] = {0};
+    bambu_copy_ascii_string(production_date, block12, 16);
+
+    // Format production date from "YYYY_MM_DD_HH_MM" to "YYYY-MM-DD HH:MM"
+    // Only format if underscores are present at expected positions
+    if(production_date[4] == '_' &&
+       production_date[7] == '_' &&
+       production_date[10] == '_' &&
+       production_date[13] == '_') {
+        production_date[4] = '-';
+        production_date[7] = '-';
+        production_date[10] = ' ';
+        production_date[13] = ':';
+    }
+
+    // Parse Filament Length from Block 14 (uint16 at bytes 4-5, meters)
+    const uint8_t* block14 = data->block[BLOCK_FILAMENT_LENGTH].data;
+    uint16_t filament_length = bambu_read_le16(&block14[4]);
+
+    // Look up filament info from variant_id
+    const BambuFilamentInfo* filament_info = bambu_lookup_filament(variant_id);
+
+    // Build formatted output
+    furi_string_cat_printf(parsed_data, "\e#Bambu Lab Filament\n");
+    furi_string_cat_printf(parsed_data, "Type: %s\n", detailed_type);
+
+    // Display color: show name with hex if available, otherwise just hex
+    // For hex code: show 6-digit if fully opaque, otherwise show "#RRGGBB @ XX%"
+    if(filament_info != NULL) {
+        if(color_a == 0xFF) {
+            furi_string_cat_printf(parsed_data, "Color: %s (#%02X%02X%02X)\n",
+                                  filament_info->color_name, color_r, color_g, color_b);
+        } else {
+            uint8_t alpha_percent = (color_a * 100) / 255;
+            furi_string_cat_printf(parsed_data, "Color: %s (#%02X%02X%02X @ %u%%)\n",
+                                  filament_info->color_name, color_r, color_g, color_b, alpha_percent);
+        }
+    } else {
+        if(color_a == 0xFF) {
+            furi_string_cat_printf(parsed_data, "Color: #%02X%02X%02X\n",
+                                  color_r, color_g, color_b);
+        } else {
+            uint8_t alpha_percent = (color_a * 100) / 255;
+            furi_string_cat_printf(parsed_data, "Color: #%02X%02X%02X @ %u%%\n",
+                                  color_r, color_g, color_b, alpha_percent);
+        }
+    }
+
+    if(filament_info != NULL) {
+        furi_string_cat_printf(parsed_data, "Filament Code: %s\n", filament_info->filament_code);
+    } else {
+        furi_string_cat_printf(parsed_data, "Filament Code: Unknown (update lookup table)\n");
+        furi_string_cat_printf(parsed_data, "Material ID: %s\n", material_id);
+        furi_string_cat_printf(parsed_data, "Variant: %s\n", variant_id);
+    }
+
+    furi_string_cat_printf(parsed_data, "Prod: %s\n", production_date);
+
+
+    furi_string_cat_printf(parsed_data, "\n\e#Configurations\n");
+    furi_string_cat_printf(parsed_data, "Hotend: %u-%u C\n", hotend_min, hotend_max);
+    furi_string_cat_printf(parsed_data, "Drying: %u C for %uh\n", drying_temp, drying_hours);
+    furi_string_cat_printf(parsed_data, "Nozzle: >= %.2fmm\n", (double)nozzle_diameter);
+
+    furi_string_cat_printf(parsed_data, "\n\e#Specifications\n");
+    furi_string_cat_printf(parsed_data, "Weight: %ug\n", weight_grams);
+    furi_string_cat_printf(parsed_data, "Diameter: %.2fmm\n", (double)diameter_mm);
+    furi_string_cat_printf(parsed_data, "Spool Width: %.2fmm\n", (double)spool_width_mm);
+    if(filament_length > 0) {
+        furi_string_cat_printf(parsed_data, "Length: %um\n", filament_length);
+    }
+
+    return true;
+}
+
+static const NfcSupportedCardsPlugin bambu_plugin = {
+    .protocol = NfcProtocolMfClassic,
+    .verify = NULL,  // No early verify - validation done in parse()
+    .read = bambu_read,
+    .parse = bambu_parse,
+};
+
+static const FlipperAppPluginDescriptor bambu_plugin_descriptor = {
+    .appid = NFC_SUPPORTED_CARD_PLUGIN_APP_ID,
+    .ep_api_version = NFC_SUPPORTED_CARD_PLUGIN_API_VERSION,
+    .entry_point = &bambu_plugin,
+};
+
+const FlipperAppPluginDescriptor* bambu_plugin_ep(void) {
+    return &bambu_plugin_descriptor;
+}

--- a/applications/main/nfc/plugins/supported_cards/bambu_filaments.h
+++ b/applications/main/nfc/plugins/supported_cards/bambu_filaments.h
@@ -1,0 +1,385 @@
+// Ported from https://github.com/uzyn/flipper-bambu (GPL-3.0, (c) U-Zyn Chua)
+//
+// Bambu Lab Filament Lookup Table
+// Maps variant IDs to filament codes and color names
+// Source: https://github.com/queengooborg/Bambu-Lab-RFID-Library
+//
+// This file can be updated independently as new filaments are released.
+// To add a new filament: add an entry to bambu_filament_table[] with:
+//   { "VARIANT_ID", "5-DIGIT-CODE", "Color Name" }
+
+#ifndef BAMBU_FILAMENTS_H
+#define BAMBU_FILAMENTS_H
+
+typedef struct {
+    const char* variant_id;     // e.g., "A00-R3"
+    const char* filament_code;  // e.g., "10204"
+    const char* color_name;     // e.g., "Hot Pink"
+} BambuFilamentInfo;
+
+// Lookup table - sorted by variant_id for easier maintenance
+static const BambuFilamentInfo bambu_filament_table[] = {
+    // PLA Basic (A00-xxx) - Material ID: GFA00
+    {"A00-A0", "10300", "Orange"},
+    {"A00-A1", "10301", "Pumpkin Orange"},
+    {"A00-B1", "10602", "Blue Grey"},
+    {"A00-B3", "10604", "Cobalt Blue"},
+    {"A00-B4", "10601", "Blue"},
+    {"A00-B5", "10605", "Turquoise"},
+    {"A00-B8", "10603", "Cyan"},
+    {"A00-D0", "10103", "Gray"},
+    {"A00-D1", "10102", "Silver"},
+    {"A00-D2", "10104", "Light Gray"},
+    {"A00-D3", "10105", "Dark Gray"},
+    {"A00-G1", "10501", "Bambu Green"},
+    {"A00-G2", "10502", "Mistletoe Green"},
+    {"A00-G3", "10503", "Bright Green"},
+    {"A00-G6", "10501", "Bambu Green"},
+    {"A00-K0", "10101", "Black"},
+    {"A00-M0", "10900", "Arctic Whisper"},
+    {"A00-M1", "10901", "Solar Breeze"},
+    {"A00-M2", "10902", "Ocean to Meadow"},
+    {"A00-M3", "10903", "Pink Citrus"},
+    {"A00-M4", "10904", "Mint Lime"},
+    {"A00-M5", "10905", "Blueberry Bubblegum"},
+    {"A00-M6", "10906", "Dusk Glare"},
+    {"A00-M7", "10907", "Cotton Candy Cloud"},
+    {"A00-N0", "10800", "Brown"},
+    {"A00-N1", "10802", "Cocoa Brown"},
+    {"A00-P0", "10201", "Beige"},
+    {"A00-P2", "10701", "Indigo Purple"},
+    {"A00-P5", "10700", "Purple"},
+    {"A00-P6", "10202", "Magenta"},
+    {"A00-P7", "10203", "Pink"},
+    {"A00-R0", "10200", "Red"},
+    {"A00-R2", "10205", "Maroon Red"},
+    {"A00-R3", "10204", "Hot Pink"},
+    {"A00-W1", "10100", "Jade White"},
+    {"A00-Y0", "10400", "Yellow"},
+    {"A00-Y2", "10402", "Sunflower Yellow"},
+    {"A00-Y3", "10801", "Bronze"},
+    {"A00-Y4", "10401", "Gold"},
+
+    // PLA Matte (A01-xxx) - Material ID: GFA01
+    {"A01-A2", "11300", "Mandarin Orange"},
+    {"A01-B0", "11603", "Sky Blue"},
+    {"A01-B3", "11600", "Marine Blue"},
+    {"A01-B4", "11601", "Ice Blue"},
+    {"A01-B6", "11602", "Dark Blue"},
+    {"A01-D0", "11104", "Nardo Gray"},
+    {"A01-D3", "11102", "Ash Gray"},
+    {"A01-G0", "11502", "Apple Green"},
+    {"A01-G1", "11500", "Grass Green"},
+    {"A01-G7", "11501", "Dark Green"},
+    {"A01-K1", "11101", "Charcoal"},
+    {"A01-N0", "11802", "Dark Chocolate"},
+    {"A01-N1", "11800", "Latte Brown"},
+    {"A01-N2", "11801", "Dark Brown"},
+    {"A01-N3", "11803", "Caramel"},
+    {"A01-P3", "11201", "Sakura Pink"},
+    {"A01-P4", "11700", "Lilac Purple"},
+    {"A01-R1", "11200", "Scarlet Red"},
+    {"A01-R2", "11203", "Terracotta"},
+    {"A01-R3", "11204", "Plum"},
+    {"A01-R4", "11202", "Dark Red"},
+    {"A01-W2", "11100", "Ivory White"},
+    {"A01-W3", "11103", "Bone White"},
+    {"A01-Y2", "11400", "Lemon Yellow"},
+    {"A01-Y3", "11401", "Desert Tan"},
+
+    // PLA Metal (A02-xxx) - Material ID: GFA02
+    {"A02-B2", "13600", "Cobalt Blue Metallic"},
+    {"A02-D2", "13100", "Iron Gray Metallic"},
+    {"A02-G2", "13500", "Oxide Green Metallic"},
+    {"A02-N3", "13800", "Copper Brown Metallic"},
+    {"A02-Y1", "13400", "Iridium Gold Metallic"},
+
+    // PLA Silk+ (A06-xxx) - Material ID: GFA06
+    {"A06-B0", "13603", "Baby Blue"},
+    {"A06-B1", "13604", "Blue"},
+    {"A06-D0", "13108", "Titan Gray"},
+    {"A06-D1", "13109", "Silver"},
+    {"A06-G0", "13506", "Candy Green"},
+    {"A06-G1", "13507", "Mint"},
+    {"A06-P0", "13702", "Purple"},
+    {"A06-R0", "13205", "Candy Red"},
+    {"A06-R1", "13206", "Rose Gold"},
+    {"A06-R2", "13207", "Pink"},
+    {"A06-W0", "13110", "White"},
+    {"A06-Y0", "13404", "Champagne"},
+    {"A06-Y1", "13405", "Gold"},
+
+    // PLA Silk Multi-Color (A05-xxx) - Material ID: GFA05
+    {"A05-M1", "13906", "South Beach"},
+    {"A05-M4", "13909", "Aurora Purple"},
+    {"A05-M8", "13912", "Dawn Radiance"},
+    {"A05-T1", "13901", "Gilded Rose"},
+    {"A05-T2", "13902", "Midnight Blaze"},
+    {"A05-T3", "13903", "Neon City"},
+    {"A05-T4", "13904", "Blue Hawaii"},
+    {"A05-T5", "13905", "Velvet Eclipse"},
+
+    // PLA Marble (A07-xxx) - Material ID: GFA07
+    {"A07-D4", "13103", "White Marble"},
+    {"A07-R5", "13201", "Red Granite"},
+
+    // PLA Sparkle (A08-xxx) - Material ID: GFA08
+    {"A08-B7", "13700", "Royal Purple Sparkle"},
+    {"A08-D5", "13102", "Slate Gray Sparkle"},
+    {"A08-G3", "13501", "Alpine Green Sparkle"},
+    {"A08-K2", "13101", "Onyx Black Sparkle"},
+    {"A08-R2", "13200", "Crimson Red Sparkle"},
+    {"A08-Y1", "13402", "Classic Gold Sparkle"},
+
+    // PLA Tough (A09-xxx) - Material ID: GFA09
+    {"A09-A0", "12002", "Orange"},
+    {"A09-B4", "12004", "Light Blue"},
+    {"A09-B5", "12005", "Lavender Blue"},
+    {"A09-D1", "12001", "Silver"},
+    {"A09-R3", "12003", "Vermilion Red"},
+    {"A09-Y0", "12000", "Yellow"},
+
+    // PLA Tough+ (A10-xxx) - Material ID: GFA10
+    {"A10-D0", "12105", "Gray"},
+    {"A10-K0", "12104", "Black"},
+    {"A10-W0", "12107", "White"},
+
+    // PLA Aero (A11-xxx) - Material ID: GFA11
+    {"A11-K0", "14103", "Black"},
+    {"A11-W0", "14102", "White"},
+
+    // PLA Glow (A12-xxx) - Material ID: GFA12
+    {"A12-A0", "15300", "Orange"},
+    {"A12-B0", "15600", "Blue"},
+    {"A12-G0", "15500", "Green"},
+    {"A12-R0", "15200", "Pink"},
+    {"A12-Y0", "15400", "Yellow"},
+
+    // PLA Galaxy (A15-xxx) - Material ID: GFA15
+    {"A15-B0", "13602", "Purple"},
+    {"A15-G0", "13503", "Green"},
+    {"A15-G1", "13504", "Nebulae"},
+    {"A15-R0", "13203", "Brown"},
+
+    // PLA Wood (A16-xxx) - Material ID: GFA16
+    {"A16-G0", "13505", "Classic Birch"},
+    {"A16-K0", "13107", "Black Walnut"},
+    {"A16-N0", "13801", "Clay Brown"},
+    {"A16-R0", "13204", "Rosewood"},
+    {"A16-W0", "13106", "White Oak"},
+    {"A16-Y0", "13403", "Ochre Yellow"},
+
+    // PLA Translucent (A17-xxx) - Material ID: GFA17
+    {"A17-A0", "13301", "Orange"},
+    {"A17-B1", "13611", "Blue"},
+    {"A17-G0", "13510", "Light Jade"},
+    {"A17-P0", "13710", "Purple"},
+    {"A17-P1", "13711", "Lavender"},
+    {"A17-R0", "13210", "Red"},
+    {"A17-R1", "13211", "Cherry Pink"},
+    {"A17-Y0", "13410", "Mellow Yellow"},
+
+    // PLA Lite (A18-xxx) - Material ID: GFA18
+    {"A18-B0", "16600", "Cyan"},
+    {"A18-B1", "16601", "Blue"},
+    {"A18-D0", "16101", "Gray"},
+    {"A18-K0", "16100", "Black"},
+    {"A18-P0", "16602", "Matte Beige"},
+    {"A18-R0", "16200", "Red"},
+    {"A18-W0", "16103", "White"},
+    {"A18-Y0", "16400", "Yellow"},
+
+    // PLA-CF (A50-xxx) - Material ID: GFA50
+    {"A50-D6", "14101", "Lava Gray"},
+    {"A50-K0", "14100", "Black"},
+
+    // ABS (B00-xxx) - Material ID: GFB00
+    {"B00-A0", "40300", "Orange"},
+    {"B00-B0", "40600", "Blue"},
+    {"B00-B4", "40601", "Azure"},
+    {"B00-B6", "40602", "Navy Blue"},
+    {"B00-D0", "20101", "Gray"},
+    {"B00-D1", "40102", "Silver"},
+    {"B00-G6", "40500", "Bambu Green"},
+    {"B00-G7", "40502", "Olive"},
+    {"B00-K0", "40101", "Black"},
+    {"B00-R0", "40200", "Red"},
+    {"B00-W0", "40100", "White"},
+    {"B00-Y1", "40402", "Tangerine Yellow"},
+
+    // ASA (B01-xxx) - Material ID: GFB01
+    {"B01-D0", "45102", "Gray"},
+    {"B01-K0", "45101", "Black"},
+    {"B01-R0", "45200", "Red"},
+    {"B01-W0", "45100", "White"},
+
+    // ASA Aero (B02-xxx) - Material ID: GFB02
+    {"B02-W0", "46100", "White"},
+
+    // ASA-CF (B51-xxx) - Material ID: GFB51
+    {"B51-K0", "46101", "Black"},
+
+    // ABS-GF (B50-xxx) - Material ID: GFB50
+    {"B50-A0", "41300", "Orange"},
+    {"B50-K0", "41101", "Black"},
+
+    // PC (C00-xxx) - Material ID: GFC00
+    {"C00-C0", "60102", "Clear Black"},
+    {"C00-C1", "60103", "Transparent"},
+    {"C00-K0", "60101", "Black"},
+    {"C00-W0", "60100", "White"},
+
+    // PC FR (C01-xxx) - Material ID: GFC01
+    {"C01-D0", "63102", "Gray"},
+    {"C01-K0", "63100", "Black"},
+    {"C01-W0", "63101", "White"},
+
+    // PETG Translucent (G01-xxx) - Material ID: GFG01
+    {"G01-A0", "32300", "Translucent Orange"},
+    {"G01-B0", "32600", "Translucent Light Blue"},
+    {"G01-C0", "32101", "Clear"},
+    {"G01-D0", "32100", "Translucent Gray"},
+    {"G01-G0", "32500", "Translucent Olive"},
+    {"G01-G1", "32501", "Translucent Teal"},
+    {"G01-N0", "32800", "Translucent Brown"},
+    {"G01-P0", "32700", "Translucent Purple"},
+    {"G01-P1", "32200", "Translucent Pink"},
+
+    // PETG HF (G02-xxx) - Material ID: GFG02
+    {"G02-A0", "33300", "Orange"},
+    {"G02-B0", "33600", "Blue"},
+    {"G02-B1", "33601", "Lake Blue"},
+    {"G02-D0", "33101", "Gray"},
+    {"G02-D1", "33103", "Dark Gray"},
+    {"G02-G0", "33500", "Green"},
+    {"G02-G1", "33501", "Lime Green"},
+    {"G02-G2", "33502", "Forest Green"},
+    {"G02-K0", "33102", "Black"},
+    {"G02-N1", "33801", "Peanut Brown"},
+    {"G02-R0", "33200", "Red"},
+    {"G02-W0", "33100", "White"},
+    {"G02-Y0", "33400", "Yellow"},
+    {"G02-Y1", "33401", "Cream"},
+
+    // PETG-CF (G50-xxx) - Material ID: GFG50
+    {"G50-D6", "31101", "Titan Gray"},
+    {"G50-G7", "31500", "Malachite Green"},
+    {"G50-K0", "31100", "Black"},
+    {"G50-P7", "31700", "Violet Purple"},
+
+    // PAHT-CF (N04-xxx) - Material ID: GFN04
+    {"N04-K0", "70100", "Black"},
+
+    // PA6-GF (N08-xxx) - Material ID: GFN08
+    {"N08-K0", "72104", "Black"},
+
+    // Support for PLA/PETG (S02-xxx) - Material ID: GFS02
+    {"S02-W0", "65102", "Nature"},
+    {"S02-W1", "65104", "White"},
+
+    // Support for PA/PET (S03-xxx) - Material ID: GFS03
+    {"S03-G1", "65500", "Green"},
+
+    // PVA (S04-xxx) - Material ID: GFS04
+    {"S04-Y0", "66400", "Clear"},
+
+    // Support (S05-xxx) - Material ID: GFS05
+    {"S05-C0", "65103", "Black"},
+
+    // Support for ABS (S06-xxx) - Material ID: GFS06
+    {"S06-W0", "66100", "White"},
+
+    // TPU for AMS (U02-xxx) - Material ID: GFU02
+    {"U02-B0", "53600", "Blue"},
+    {"U02-D0", "53102", "Gray"},
+    {"U02-K0", "53101", "Black"},
+};
+
+#define BAMBU_FILAMENT_TABLE_SIZE (sizeof(bambu_filament_table) / sizeof(bambu_filament_table[0]))
+
+// Normalize variant IDs that contain padded zeros, e.g.:
+// - "A00-K00" -> "A00-K0"
+// - "A00-G06" -> "A00-G6"
+static inline void
+bambu_normalize_variant_id(const char* variant_id, char* normalized, size_t normalized_size) {
+    if(normalized_size == 0) {
+        return;
+    }
+
+    if(variant_id == NULL) {
+        normalized[0] = '\0';
+        return;
+    }
+
+    size_t src_len = strlen(variant_id);
+    if(src_len >= normalized_size) {
+        src_len = normalized_size - 1;
+    }
+    memcpy(normalized, variant_id, src_len);
+    normalized[src_len] = '\0';
+
+    const char* dash = strchr(normalized, '-');
+    if(dash == NULL) {
+        return;
+    }
+
+    size_t dash_pos = (size_t)(dash - normalized);
+    if(dash_pos + 2 >= normalized_size || normalized[dash_pos + 1] == '\0') {
+        return;
+    }
+
+    char* suffix = &normalized[dash_pos + 2];
+    if(*suffix == '\0') {
+        return;
+    }
+
+    int digits_only = 1;
+    for(size_t i = 0; suffix[i] != '\0'; i++) {
+        if(suffix[i] < '0' || suffix[i] > '9') {
+            digits_only = 0;
+            break;
+        }
+    }
+    if(!digits_only) {
+        return;
+    }
+
+    size_t leading_zeros = 0;
+    while(suffix[leading_zeros] == '0' && suffix[leading_zeros + 1] != '\0') {
+        leading_zeros++;
+    }
+
+    if(leading_zeros > 0) {
+        size_t suffix_len = strlen(suffix);
+        memmove(suffix, suffix + leading_zeros, suffix_len - leading_zeros + 1);
+    }
+}
+
+// Lookup function: Find filament info by variant_id
+// Returns NULL if not found
+static inline const BambuFilamentInfo* bambu_lookup_filament(const char* variant_id) {
+    if(variant_id == NULL || variant_id[0] == '\0') {
+        return NULL;
+    }
+
+    for(size_t i = 0; i < BAMBU_FILAMENT_TABLE_SIZE; i++) {
+        if(strcmp(bambu_filament_table[i].variant_id, variant_id) == 0) {
+            return &bambu_filament_table[i];
+        }
+    }
+
+    char normalized_variant_id[16];
+    bambu_normalize_variant_id(variant_id, normalized_variant_id, sizeof(normalized_variant_id));
+
+    if(strcmp(normalized_variant_id, variant_id) != 0) {
+        for(size_t i = 0; i < BAMBU_FILAMENT_TABLE_SIZE; i++) {
+            if(strcmp(bambu_filament_table[i].variant_id, normalized_variant_id) == 0) {
+                return &bambu_filament_table[i];
+            }
+        }
+    }
+
+    return NULL;
+}
+
+#endif // BAMBU_FILAMENTS_H

--- a/applications/main/nfc/plugins/supported_cards/bambu_parser.h
+++ b/applications/main/nfc/plugins/supported_cards/bambu_parser.h
@@ -1,0 +1,119 @@
+// Ported from https://github.com/uzyn/flipper-bambu (GPL-3.0, (c) U-Zyn Chua)
+//
+// Bambu Lab NFC Parser - Core Parsing Logic
+// This header contains the portable parsing functions shared between
+// the Flipper Zero plugin and the test suite.
+//
+// Usage:
+// - For Flipper: Include after mf_classic.h (types already defined)
+// - For tests: Define BAMBU_PARSER_TEST_MODE and mock types before including
+
+#ifndef BAMBU_PARSER_H
+#define BAMBU_PARSER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+// Block layout for Bambu Lab spool RFID tags (Mifare Classic 1K)
+// Skip blocks 3,7,11,15,... (sector trailers with MIFARE keys)
+#define BLOCK_MATERIAL_IDS      1   // Material ID (GFxxx) + Variant ID (xxx-Rx)
+#define BLOCK_FILAMENT_TYPE     2   // Filament type (PLA, PETG, ABS, etc.)
+#define BLOCK_DETAILED_TYPE     4   // Detailed type (PLA Basic, PLA Matte, etc.)
+#define BLOCK_COLOR_WEIGHT      5   // RGBA color, weight (g), diameter (mm)
+#define BLOCK_TEMPERATURES      6   // Drying temp/hours, hotend max/min temps
+#define BLOCK_NOZZLE            8   // Nozzle diameter (float at bytes 12-15)
+#define BLOCK_SPOOL_WIDTH      10   // Spool width (uint16 at bytes 4-5, mm*100)
+#define BLOCK_PRODUCTION_DATE  12   // Production date (ASCII YYYY_MM_DD_HH_MM)
+#define BLOCK_FILAMENT_LENGTH  14   // Filament length (uint16 at bytes 4-5, meters)
+
+// Helper: Read little-endian uint16
+static inline uint16_t bambu_read_le16(const uint8_t* data) {
+    return (uint16_t)(data[0] | (data[1] << 8));
+}
+
+// Helper: Read little-endian uint32 as float (IEEE 754)
+static inline float bambu_read_le_float(const uint8_t* data) {
+    union {
+        uint32_t u;
+        float f;
+    } val;
+    val.u = (uint32_t)(data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24));
+    return val.f;
+}
+
+// Helper: Check if block contains printable ASCII (with null padding allowed)
+static inline bool bambu_is_printable_ascii(const uint8_t* data, size_t len) {
+    bool found_printable = false;
+    for(size_t i = 0; i < len; i++) {
+        if(data[i] == 0) continue;  // Null padding is OK
+        if(data[i] < 0x20 || data[i] > 0x7E) return false;  // Non-printable
+        found_printable = true;
+    }
+    return found_printable;
+}
+
+// Helper: Copy null-terminated ASCII string from block data
+static inline void bambu_copy_ascii_string(char* dest, const uint8_t* src, size_t max_len) {
+    size_t i;
+    for(i = 0; i < max_len && src[i] != 0 && src[i] >= 0x20 && src[i] <= 0x7E; i++) {
+        dest[i] = (char)src[i];
+    }
+    dest[i] = '\0';
+}
+
+// Known filament types for validation
+static const char* const BAMBU_KNOWN_FILAMENT_TYPES[] = {
+    "PLA", "PETG", "ABS", "TPU", "PA", "PC", "ASA", "PVA", "HIPS", "PET"
+};
+#define BAMBU_NUM_FILAMENT_TYPES (sizeof(BAMBU_KNOWN_FILAMENT_TYPES) / sizeof(BAMBU_KNOWN_FILAMENT_TYPES[0]))
+
+// Validation: Conservative Bambu-specific validation
+// Returns true only if this looks like a Bambu Lab spool tag
+// Requires MfClassicData and MfClassicType1k to be defined
+static inline bool bambu_tag_is_valid(const MfClassicData* data) {
+    // Must be Mifare Classic 1K
+    if(data->type != MfClassicType1k) {
+        return false;
+    }
+
+    // Block 1: Check Material ID starts with "GF" at bytes 8-9
+    const uint8_t* block1 = data->block[BLOCK_MATERIAL_IDS].data;
+    if(block1[8] != 'G' || block1[9] != 'F') {
+        return false;
+    }
+
+    // Block 2: Check for known filament types
+    const uint8_t* block2 = data->block[BLOCK_FILAMENT_TYPE].data;
+    bool valid_type = false;
+    for(size_t i = 0; i < BAMBU_NUM_FILAMENT_TYPES; i++) {
+        size_t len = strlen(BAMBU_KNOWN_FILAMENT_TYPES[i]);
+        if(memcmp(block2, BAMBU_KNOWN_FILAMENT_TYPES[i], len) == 0) {
+            valid_type = true;
+            break;
+        }
+    }
+    if(!valid_type) {
+        return false;
+    }
+
+    // Block 4: Check detailed type is printable ASCII
+    const uint8_t* block4 = data->block[BLOCK_DETAILED_TYPE].data;
+    if(!bambu_is_printable_ascii(block4, 16)) {
+        return false;
+    }
+
+    // Block 5: Check diameter is plausible (1.6-2.0mm or 2.7-3.0mm range)
+    const uint8_t* block5 = data->block[BLOCK_COLOR_WEIGHT].data;
+    float diameter = bambu_read_le_float(&block5[8]);
+    bool valid_diameter = (diameter >= 1.6f && diameter <= 2.0f) ||
+                          (diameter >= 2.7f && diameter <= 3.0f);
+    if(!valid_diameter) {
+        return false;
+    }
+
+    return true;
+}
+
+#endif // BAMBU_PARSER_H


### PR DESCRIPTION
## What

Adds a built-in **supported-cards parser for Bambu Lab filament spool RFID tags** (MIFARE Classic 1K).

It derives the per-sector keys from the tag UID (HKDF / HMAC-SHA256, self-contained — no new firmware deps), validates the tag is a genuine Bambu spool, and renders:

- Material type & detailed variant (e.g. PLA Basic, PLA Matte)
- Color name + RGBA hex, filament code
- Production date
- Temperatures (hotend min/max, drying temp/hours)
- Physical specs (weight, diameter, spool width, length)

Loads like every other parser — built as `bambu_parser.fal` and deployed to `/ext/apps_data/nfc/plugins/`.

## Attribution / license

This is a **port of the standalone [uzyn/flipper-bambu](https://github.com/uzyn/flipper-bambu) plugin** (GPL-3.0, © U-Zyn Chua), copied with the original license header preserved and a link back to the source — same approach used for other externally-authored GPL parsers in the tree (`clipper.c`, `charliecard.c`). Filament DB credit: [queengooborg/Bambu-Lab-RFID-Library](https://github.com/queengooborg/Bambu-Lab-RFID-Library); tag-format research: [Bambu-Research-Group/RFID-Tag-Guide](https://github.com/Bambu-Research-Group/RFID-Tag-Guide).

## Verification

- ✅ Builds clean: `fbt fap_bambu_parser` → `bambu_parser.fal`, `APPCHK` passes (all firmware API symbols resolve, API 87.10 unchanged).
- ⏳ On-device read not yet validated against a physical spool — parse/validation logic is unchanged from upstream, which is in active use.

## Notes

Whole-file copy of GPL-3.0 code (not a reimplementation), which is consistent with existing GPL parsers here.
