### PR TITLE
[NFC]: Align MIFARE type detection with AN10833 (Classic SAK sizing, UL/NTAG GetVersion typing, Plus SL0/SL3/EV1/EV2, Ultralight AES)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * LFRFID: **Wipe T5577** (reset to blank, with read-back verification) (by @mishamyte | PR #1003)
 * NFC: Show MIFARE Ultralight/NTAG PWD & PACK in full info view / on read screen too (by @mishamyte | PR #1010 #1011)
 * NFC: **Add Bambu Lab filament spool parser** (type, color, code, temps, spool specs) (ported from [uzyn/flipper-bambu](https://github.com/uzyn/flipper-bambu), GPL-3.0)
+* NFC: **Align MIFARE type detection with NXP AN10833** - Classic/Ultralight/NTAG/Plus sizing & security level; fixes Mifare Mini clone mis-detection and Ultralight AES read hang (by @mishamyte | PR #1014)
 * RPC: **Add Network and GPS RPC services** (by @apfxtech (Network based on @noproto code and idea) | PR #1013)
 * Apps: **NFC Magic** - Gen2 CUID/static-nonce detection, Gen1 4b/7b UID, length-aware wipe & write guard (by @mishamyte)
 * Apps: Build tag (**28jun2026**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
@@ -15,8 +16,6 @@
 * Disabled debug and trace logs in the FW binary (apps .fap's are not affected) to free up some flash space for new features
 * NFC: Fix typo in SLIX poller (by @WillyJL)
 <br><br>
-#### Known NFC post-refactor regressions list: 
-- Mifare Mini clones reading is broken (original mini working fine) (OFW)
 
 ----
 

--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
@@ -238,7 +238,9 @@ static void nfc_scene_read_and_saved_menu_on_enter_mf_ultralight(NfcApp* instanc
             instance);
     }
 
-    if(is_locked) {
+    // UL-AES is "locked" but only AES auth (unimplemented) can unlock it; the password-based
+    // Unlock flow can't help, so don't offer it.
+    if(is_locked && data->type != MfUltralightTypeUltralightAES) {
         submenu_add_item(
             submenu,
             "Unlock",
@@ -289,7 +291,14 @@ static void nfc_scene_read_success_on_enter_mf_ultralight(NfcApp* instance) {
 static void nfc_scene_emulate_on_enter_mf_ultralight(NfcApp* instance) {
     const MfUltralightData* data =
         nfc_device_get_data(instance->nfc_device, NfcProtocolMfUltralight);
-    instance->listener = nfc_listener_alloc(instance->nfc, NfcProtocolMfUltralight, data);
+    if(data->type == MfUltralightTypeUltralightAES) {
+        // UL-AES has no readable memory and no AES-auth emulation, so a full emulation would just be
+        // an empty card. Present the UID only (like MIFARE Plus) instead.
+        instance->listener =
+            nfc_listener_alloc(instance->nfc, NfcProtocolIso14443_3a, data->iso14443_3a_data);
+    } else {
+        instance->listener = nfc_listener_alloc(instance->nfc, NfcProtocolMfUltralight, data);
+    }
     nfc_listener_start(instance->listener, NULL, NULL);
 }
 
@@ -507,9 +516,22 @@ static void nfc_scene_write_on_enter_mf_ultralight(NfcApp* instance) {
     nfc_poller_start(instance->poller, nfc_scene_write_poller_callback_mf_ultralight, instance);
 }
 
+#define MF_ULTRALIGHT_DEFAULT_FEATURES \
+    (NfcProtocolFeatureEmulateFull | NfcProtocolFeatureMoreInfo | NfcProtocolFeatureWrite)
+
+// UL-AES is identity-only (no memory readable without the AES auth we don't implement), so present
+// it like MIFARE Plus: UID-only emulation and no page-dump "More" view. Other UL/NTAG keep the full
+// feature set. (Write is additionally dropped for UL-AES by the read/saved menu handler.)
+static uint32_t nfc_mf_ultralight_get_features(NfcApp* instance) {
+    const MfUltralightData* data =
+        nfc_device_get_data(instance->nfc_device, NfcProtocolMfUltralight);
+    return (data->type == MfUltralightTypeUltralightAES) ? NfcProtocolFeatureEmulateUid :
+                                                           MF_ULTRALIGHT_DEFAULT_FEATURES;
+}
+
 const NfcProtocolSupportBase nfc_protocol_support_mf_ultralight = {
-    .features = NfcProtocolFeatureEmulateFull | NfcProtocolFeatureMoreInfo |
-                NfcProtocolFeatureWrite,
+    .features = MF_ULTRALIGHT_DEFAULT_FEATURES,
+    .get_features = nfc_mf_ultralight_get_features,
 
     .scene_info =
         {

--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.c
@@ -60,6 +60,17 @@ void nfc_render_mf_ultralight_info(
     const MfUltralightData* data,
     NfcProtocolFormatType format_type,
     FuriString* str) {
+    // UL-AES exposes no memory / counters without AES auth (unimplemented), so keep it identity-only
+    // like MIFARE Plus: Tech + UID (+ ATQA/SAK in Full), no pages/counters/version noise. The Short
+    // (read-result) form of iso14443_3a_info omits the Tech line, so add it explicitly to match MFP.
+    if(data->type == MfUltralightTypeUltralightAES) {
+        if(format_type != NfcProtocolFormatTypeFull) {
+            nfc_render_iso14443_tech_type(data->iso14443_3a_data, str);
+        }
+        nfc_render_iso14443_3a_info(data->iso14443_3a_data, format_type, str);
+        return;
+    }
+
     nfc_render_iso14443_3a_info(data->iso14443_3a_data, format_type, str);
 
     nfc_render_mf_ultralight_pages_count(data, str);

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support.c
@@ -226,7 +226,9 @@ bool nfc_protocol_support_has_feature(
     furi_assert(context);
 
     NfcApp* instance = context;
-    return nfc_protocol_support_get(protocol, instance)->features & feature;
+    const NfcProtocolSupportBase* base = nfc_protocol_support_get(protocol, instance);
+    const uint32_t features = base->get_features ? base->get_features(instance) : base->features;
+    return features & feature;
 }
 
 // Common scene handlers

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support_base.h
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support_base.h
@@ -44,6 +44,15 @@ typedef struct {
     const uint32_t features; /**< Feature bitmask supported by the protocol. */
 
     /**
+     * @brief Optional per-card feature bitmask.
+     *
+     * When non-NULL, this overrides @c features and is evaluated against the currently loaded card,
+     * letting a protocol vary its feature set by card type (e.g. an identity-only variant that
+     * emulates UID only and has no memory dump). Receives the app instance for card-data access.
+     */
+    uint32_t (*get_features)(NfcApp* instance);
+
+    /**
      * @brief Handlers for protocol-specific info scene.
      *
      * This scene displays general information about a saved or recently read card.

--- a/applications/main/nfc/plugins/supported_cards/ndef.c
+++ b/applications/main/nfc/plugins/supported_cards/ndef.c
@@ -826,7 +826,8 @@ static bool ndef_ul_parse(const NfcDevice* device, FuriString* parsed_data) {
     const MfUltralightData* data = nfc_device_get_data(device, NfcProtocolMfUltralight);
 
     // Check card type can contain NDEF
-    if(data->type != MfUltralightTypeNTAG203 && data->type != MfUltralightTypeNTAG213 &&
+    if(data->type != MfUltralightTypeNTAG203 && data->type != MfUltralightTypeNTAG210 &&
+       data->type != MfUltralightTypeNTAG212 && data->type != MfUltralightTypeNTAG213 &&
        data->type != MfUltralightTypeNTAG215 && data->type != MfUltralightTypeNTAG216 &&
        data->type != MfUltralightTypeNTAGI2C1K && data->type != MfUltralightTypeNTAGI2C2K &&
        data->type != MfUltralightTypeNTAGI2CPlus1K &&

--- a/lib/nfc/protocols/mf_classic/mf_classic.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic.c
@@ -21,7 +21,7 @@ static const MfClassicFeatures mf_classic_features[MfClassicTypeNum] = {
         {
             .sectors_total = 5,
             .blocks_total = 20,
-            .full_name = "Mifare Classic Mini 0.3K",
+            .full_name = "Mifare Mini 0.3K",
             .type_name = "MINI",
         },
     [MfClassicType1k] =

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller.c
@@ -127,10 +127,30 @@ static void mf_classic_poller_check_key_b_is_readable(
 NfcCommand mf_classic_poller_handler_detect_type(MfClassicPoller* instance) {
     NfcCommand command = NfcCommandReset;
 
-    if(instance->current_type_check == MfClassicType4k) {
-        iso14443_3a_copy(
-            instance->data->iso14443_3a_data,
-            iso14443_3a_poller_get_data(instance->iso14443_3a_poller));
+    // AN10833: size from the SAK bit map (test the bit, not the whole value); only fall back to
+    // the legacy block-presence probe when the SAK is not a recognized Classic value. This stops a
+    // magic CUID that answers every block from being mis-sized as 4K against its own 1K SAK.
+    iso14443_3a_copy(
+        instance->data->iso14443_3a_data,
+        iso14443_3a_poller_get_data(instance->iso14443_3a_poller));
+    const uint8_t sak = instance->data->iso14443_3a_data->sak;
+
+    if(sak == 0x09) { // Mini shares the 1K bit (0x08), so it must be matched first
+        instance->data->type = MfClassicTypeMini;
+        instance->current_type_check = MfClassicType4k;
+        instance->state = MfClassicPollerStateStart;
+        FURI_LOG_D(TAG, "Mini detected (SAK)");
+    } else if(sak & 0x10) { // bit4 -> 4K (0x18, SmartMX+Classic 0x38)
+        instance->data->type = MfClassicType4k;
+        instance->current_type_check = MfClassicType4k;
+        instance->state = MfClassicPollerStateStart;
+        FURI_LOG_D(TAG, "4K detected (SAK)");
+    } else if(sak & 0x08) { // bit3 -> 1K (0x08, SmartMX+Classic 0x28)
+        instance->data->type = MfClassicType1k;
+        instance->current_type_check = MfClassicType4k;
+        instance->state = MfClassicPollerStateStart;
+        FURI_LOG_D(TAG, "1K detected (SAK)");
+    } else if(instance->current_type_check == MfClassicType4k) {
         MfClassicError error =
             mf_classic_poller_get_nt(instance, 254, MfClassicKeyTypeA, NULL, false);
         if(error == MfClassicErrorNone) {

--- a/lib/nfc/protocols/mf_plus/mf_plus_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_i.c
@@ -19,6 +19,18 @@ const uint8_t mf_plus_ats_t1_tk_values[][MF_PLUS_T1_TK_VALUE_LEN] = {
     {0xC1, 0x05, 0x21, 0x30, 0x10, 0xF6, 0xD1}, // Mifare Plus SE
 };
 
+// Map the ATS historical bytes to a MIFARE Plus product, or MfPlusTypeUnknown if they match no
+// known S/X/SE entry. A non-table-length count never matches (and is NULL-safe).
+static MfPlusType mf_plus_type_from_ats(const uint8_t* historical_bytes, size_t len) {
+    if(len != MF_PLUS_T1_TK_VALUE_LEN) return MfPlusTypeUnknown;
+    if(memcmp(historical_bytes, mf_plus_ats_t1_tk_values[0], len) == 0) return MfPlusTypeS;
+    if(memcmp(historical_bytes, mf_plus_ats_t1_tk_values[1], len) == 0) return MfPlusTypeX;
+    if(memcmp(historical_bytes, mf_plus_ats_t1_tk_values[2], len) == 0 ||
+       memcmp(historical_bytes, mf_plus_ats_t1_tk_values[3], len) == 0)
+        return MfPlusTypeSE;
+    return MfPlusTypeUnknown;
+}
+
 MfPlusError mf_plus_get_type_from_version(
     const Iso14443_4aData* iso14443_4a_data,
     MfPlusSecurityLevel probed_security_level,
@@ -125,24 +137,10 @@ MfPlusError mf_plus_get_type_from_iso4(
     // so an untabled or short ATS still yields a generic Plus instead of Unknown. 2K vs 4K needs the
     // AN10833-forbidden ATQA nibble, so non-SE size stays Unknown.
     if(sak == 0x20 && probed_security_level != MfPlusSecurityLevelUnknown) {
+        const MfPlusType ats_type = mf_plus_type_from_ats(historical_bytes, historical_bytes_len);
+        mf_plus_data->type = (ats_type == MfPlusTypeUnknown) ? MfPlusTypePlus : ats_type;
+        mf_plus_data->size = (ats_type == MfPlusTypeSE) ? MfPlusSize1K : MfPlusSizeUnknown;
         mf_plus_data->security_level = probed_security_level;
-        mf_plus_data->size = MfPlusSizeUnknown;
-        if(ats_matchable &&
-           memcmp(historical_bytes, mf_plus_ats_t1_tk_values[0], historical_bytes_len) == 0) {
-            mf_plus_data->type = MfPlusTypeS;
-        } else if(
-            ats_matchable &&
-            memcmp(historical_bytes, mf_plus_ats_t1_tk_values[1], historical_bytes_len) == 0) {
-            mf_plus_data->type = MfPlusTypeX;
-        } else if(
-            ats_matchable &&
-            (memcmp(historical_bytes, mf_plus_ats_t1_tk_values[2], historical_bytes_len) == 0 ||
-             memcmp(historical_bytes, mf_plus_ats_t1_tk_values[3], historical_bytes_len) == 0)) {
-            mf_plus_data->type = MfPlusTypeSE; // SE is 1K regardless of security level
-            mf_plus_data->size = MfPlusSize1K;
-        } else {
-            mf_plus_data->type = MfPlusTypePlus;
-        }
         FURI_LOG_D(
             TAG,
             "Mifare Plus SL%d (SAK 20, probe-confirmed)",
@@ -228,33 +226,22 @@ MfPlusError mf_plus_get_type_from_iso4(
         }
 
         break;
-    case 0x20:
+    case 0x20: {
         // Reached only when the probe gave no usable result: keep the strict ATS-table gate so a
-        // DESFire (also SAK 0x20) is not hijacked.
-        if(memcmp(historical_bytes, mf_plus_ats_t1_tk_values[0], historical_bytes_len) == 0) {
-            mf_plus_data->type = MfPlusTypeS;
-            mf_plus_data->size = MfPlusSizeUnknown;
+        // DESFire (also SAK 0x20) is not hijacked. SL3 size needs the AN10833-forbidden ATQA, so SE
+        // stays 1K and any other matched product stays Unknown.
+        const MfPlusType ats_type = mf_plus_type_from_ats(historical_bytes, historical_bytes_len);
+        if(ats_type != MfPlusTypeUnknown) {
+            mf_plus_data->type = ats_type;
+            mf_plus_data->size = (ats_type == MfPlusTypeSE) ? MfPlusSize1K : MfPlusSizeUnknown;
             mf_plus_data->security_level = MfPlusSecurityLevel3;
-            FURI_LOG_D(TAG, "Mifare Plus S SL3");
-            error = MfPlusErrorNone;
-        } else if(memcmp(historical_bytes, mf_plus_ats_t1_tk_values[1], historical_bytes_len) == 0) {
-            mf_plus_data->type = MfPlusTypeX;
-            mf_plus_data->size = MfPlusSizeUnknown;
-            mf_plus_data->security_level = MfPlusSecurityLevel3;
-            FURI_LOG_D(TAG, "Mifare Plus X SL3");
-            error = MfPlusErrorNone;
-        } else if(
-            memcmp(historical_bytes, mf_plus_ats_t1_tk_values[2], historical_bytes_len) == 0 ||
-            memcmp(historical_bytes, mf_plus_ats_t1_tk_values[3], historical_bytes_len) == 0) {
-            // SE is 1K regardless of security level.
-            mf_plus_data->type = MfPlusTypeSE;
-            mf_plus_data->size = MfPlusSize1K;
-            mf_plus_data->security_level = MfPlusSecurityLevel3;
-            FURI_LOG_D(TAG, "Mifare Plus SE 1K SL3");
+            FURI_LOG_D(TAG, "Mifare Plus SL3 (SAK 20, ATS-matched)");
             error = MfPlusErrorNone;
         } else {
             FURI_LOG_D(TAG, "Sak 20 but no known Mifare Plus type");
         }
+        break;
+    }
     }
 
     return error;

--- a/lib/nfc/protocols/mf_plus/mf_plus_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_i.c
@@ -67,7 +67,8 @@ MfPlusError mf_plus_get_type_from_version(
         // 0x08/0x18 -> SL1. GetVersion already gave the authoritative type/size, so the SAK here
         // only refines SL; an unrecognized SAK leaves it Unknown rather than guessing SL1 (which
         // previously collapsed every non-0x20 card, mislabelling genuine SL2 as SL1).
-        switch(iso14443_4a_data->iso14443_3a_data->sak) {
+        const uint8_t sak = iso14443_4a_data->iso14443_3a_data->sak;
+        switch(sak) {
         case 0x20:
             mf_plus_data->security_level = MfPlusSecurityLevel3;
             FURI_LOG_D(TAG, "Mifare Plus EV1/2 SL3");
@@ -84,10 +85,7 @@ MfPlusError mf_plus_get_type_from_version(
             break;
         default:
             mf_plus_data->security_level = MfPlusSecurityLevelUnknown;
-            FURI_LOG_D(
-                TAG,
-                "Mifare Plus EV1/2 unknown SL (SAK 0x%02X)",
-                iso14443_4a_data->iso14443_3a_data->sak);
+            FURI_LOG_D(TAG, "Mifare Plus EV1/2 unknown SL (SAK 0x%02X)", sak);
             break;
         }
     }
@@ -183,10 +181,9 @@ MfPlusError
 
         break;
     case 0x20:
-        // SL3 / ISO14443-4. SAK 0x20 is shared with DESFire, so an ATS-historical-byte match must
-        // stay the detection gate: without it we must NOT report Plus, or DESFire would be hijacked
-        // (MfPlus is probed before MfDesfire). 2K vs 4K is only separable via the AN10833-forbidden
-        // ATQA nibble, so the size is left Unknown instead of guessed.
+        // SAK 0x20 is shared with DESFire (probed after MfPlus), so the ATS match must stay the
+        // gate or DESFire is hijacked. 2K vs 4K needs the AN10833-forbidden ATQA nibble, so size
+        // stays Unknown.
         if(memcmp(historical_bytes, mf_plus_ats_t1_tk_values[0], historical_bytes_len) == 0) {
             mf_plus_data->type = MfPlusTypeS;
             mf_plus_data->size = MfPlusSizeUnknown;

--- a/lib/nfc/protocols/mf_plus/mf_plus_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_i.c
@@ -71,12 +71,18 @@ MfPlusError mf_plus_get_type_from_version(
         const uint8_t sak = iso14443_4a_data->iso14443_3a_data->sak;
         switch(sak) {
         case 0x20:
-            // SL0 and SL3 are indistinguishable from SAK/ATS; the poller's active probe resolves
-            // them and passes the result in. Fall back to SL3 (the prior behaviour) if it could not.
-            mf_plus_data->security_level = (probed_security_level != MfPlusSecurityLevelUnknown) ?
-                                               probed_security_level :
-                                               MfPlusSecurityLevel3;
-            FURI_LOG_D(TAG, "Mifare Plus EV1/2 SL0/SL3 (probe-resolved)");
+            // GetVersion already confirmed Plus here; the probe only refines SL0 vs SL3. Keep the
+            // prior SL3 default when the probe was inconclusive.
+            if(probed_security_level != MfPlusSecurityLevelUnknown) {
+                mf_plus_data->security_level = probed_security_level;
+                FURI_LOG_D(
+                    TAG,
+                    "Mifare Plus EV1/2 SL%d (probe)",
+                    probed_security_level == MfPlusSecurityLevel0 ? 0 : 3);
+            } else {
+                mf_plus_data->security_level = MfPlusSecurityLevel3;
+                FURI_LOG_D(TAG, "Mifare Plus EV1/2 SL3 (default)");
+            }
             break;
         case 0x10:
         case 0x11:
@@ -223,9 +229,8 @@ MfPlusError mf_plus_get_type_from_iso4(
 
         break;
     case 0x20:
-        // Reached only when the probe gave no usable result (Unknown): keep the strict ATS-table
-        // gate so DESFire (also SAK 0x20) is not hijacked. 2K vs 4K needs the AN10833-forbidden
-        // ATQA nibble, so size stays Unknown.
+        // Reached only when the probe gave no usable result: keep the strict ATS-table gate so a
+        // DESFire (also SAK 0x20) is not hijacked.
         if(memcmp(historical_bytes, mf_plus_ats_t1_tk_values[0], historical_bytes_len) == 0) {
             mf_plus_data->type = MfPlusTypeS;
             mf_plus_data->size = MfPlusSizeUnknown;

--- a/lib/nfc/protocols/mf_plus/mf_plus_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_i.c
@@ -142,20 +142,21 @@ MfPlusError
 
         break;
     case 0x10:
-        // Mifare Plus X 2K SL2
-        mf_plus_data->type = MfPlusTypeX;
+        // SAK 0x10 is Plus 2K SL2 (AN10833). The bare SAK does not justify the S/X/SE product, so
+        // report a generic Plus rather than over-claiming X.
+        mf_plus_data->type = MfPlusTypePlus;
         mf_plus_data->size = MfPlusSize2K;
         mf_plus_data->security_level = MfPlusSecurityLevel2;
-        FURI_LOG_D(TAG, "Mifare Plus X 2K SL2");
+        FURI_LOG_D(TAG, "Mifare Plus 2K SL2");
         error = MfPlusErrorNone;
 
         break;
     case 0x11:
-        // Mifare Plus X 4K SL2
-        mf_plus_data->type = MfPlusTypeX;
+        // SAK 0x11 is Plus 4K SL2 (AN10833); generic Plus for the same reason as 0x10.
+        mf_plus_data->type = MfPlusTypePlus;
         mf_plus_data->size = MfPlusSize4K;
         mf_plus_data->security_level = MfPlusSecurityLevel2;
-        FURI_LOG_D(TAG, "Mifare Plus X 4K SL2");
+        FURI_LOG_D(TAG, "Mifare Plus 4K SL2");
         error = MfPlusErrorNone;
 
         break;
@@ -182,56 +183,29 @@ MfPlusError
 
         break;
     case 0x20:
+        // SL3 / ISO14443-4. SAK 0x20 is shared with DESFire, so an ATS-historical-byte match must
+        // stay the detection gate: without it we must NOT report Plus, or DESFire would be hijacked
+        // (MfPlus is probed before MfDesfire). 2K vs 4K is only separable via the AN10833-forbidden
+        // ATQA nibble, so the size is left Unknown instead of guessed.
         if(memcmp(historical_bytes, mf_plus_ats_t1_tk_values[0], historical_bytes_len) == 0) {
-            // Mifare Plus S 2/4K SL3
-            FURI_LOG_D(TAG, "Mifare Plus S SL3");
             mf_plus_data->type = MfPlusTypeS;
+            mf_plus_data->size = MfPlusSizeUnknown;
             mf_plus_data->security_level = MfPlusSecurityLevel3;
-
-            if((iso4_data->iso14443_3a_data->atqa[0] & 0x0F) == 0x04) {
-                // Mifare Plus S 2K SL3
-                mf_plus_data->size = MfPlusSize2K;
-
-                FURI_LOG_D(TAG, "Mifare Plus S 2K SL3");
-                error = MfPlusErrorNone;
-            } else if((iso4_data->iso14443_3a_data->atqa[0] & 0x0F) == 0x02) {
-                // Mifare Plus S 4K SL3
-                mf_plus_data->size = MfPlusSize4K;
-
-                FURI_LOG_D(TAG, "Mifare Plus S 4K SL3");
-                error = MfPlusErrorNone;
-            } else {
-                FURI_LOG_D(TAG, "Sak 20 but no known Mifare Plus type (S)");
-            }
+            FURI_LOG_D(TAG, "Mifare Plus S SL3");
+            error = MfPlusErrorNone;
         } else if(memcmp(historical_bytes, mf_plus_ats_t1_tk_values[1], historical_bytes_len) == 0) {
-            // Mifare Plus X 2/4K SL3
             mf_plus_data->type = MfPlusTypeX;
+            mf_plus_data->size = MfPlusSizeUnknown;
             mf_plus_data->security_level = MfPlusSecurityLevel3;
             FURI_LOG_D(TAG, "Mifare Plus X SL3");
-
-            if((iso4_data->iso14443_3a_data->atqa[0] & 0x0F) == 0x04) {
-                // Mifare Plus X 2K SL3
-                mf_plus_data->size = MfPlusSize2K;
-
-                FURI_LOG_D(TAG, "Mifare Plus X 2K SL3");
-                error = MfPlusErrorNone;
-            } else if((iso4_data->iso14443_3a_data->atqa[0] & 0x0F) == 0x02) {
-                // Mifare Plus X 4K SL3
-                mf_plus_data->size = MfPlusSize4K;
-
-                FURI_LOG_D(TAG, "Mifare Plus X 4K SL3");
-                error = MfPlusErrorNone;
-            } else {
-                FURI_LOG_D(TAG, "Sak 20 but no known Mifare Plus type (X)");
-            }
+            error = MfPlusErrorNone;
         } else if(
             memcmp(historical_bytes, mf_plus_ats_t1_tk_values[2], historical_bytes_len) == 0 ||
             memcmp(historical_bytes, mf_plus_ats_t1_tk_values[3], historical_bytes_len) == 0) {
-            // Mifare Plus SE 1K SL3
+            // SE is 1K regardless of security level.
             mf_plus_data->type = MfPlusTypeSE;
             mf_plus_data->size = MfPlusSize1K;
             mf_plus_data->security_level = MfPlusSecurityLevel3;
-
             FURI_LOG_D(TAG, "Mifare Plus SE 1K SL3");
             error = MfPlusErrorNone;
         } else {

--- a/lib/nfc/protocols/mf_plus/mf_plus_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_i.c
@@ -21,6 +21,7 @@ const uint8_t mf_plus_ats_t1_tk_values[][MF_PLUS_T1_TK_VALUE_LEN] = {
 
 MfPlusError mf_plus_get_type_from_version(
     const Iso14443_4aData* iso14443_4a_data,
+    MfPlusSecurityLevel probed_security_level,
     MfPlusData* mf_plus_data) {
     furi_assert(iso14443_4a_data);
     furi_assert(mf_plus_data);
@@ -70,8 +71,12 @@ MfPlusError mf_plus_get_type_from_version(
         const uint8_t sak = iso14443_4a_data->iso14443_3a_data->sak;
         switch(sak) {
         case 0x20:
-            mf_plus_data->security_level = MfPlusSecurityLevel3;
-            FURI_LOG_D(TAG, "Mifare Plus EV1/2 SL3");
+            // SL0 and SL3 are indistinguishable from SAK/ATS; the poller's active probe resolves
+            // them and passes the result in. Fall back to SL3 (the prior behaviour) if it could not.
+            mf_plus_data->security_level = (probed_security_level != MfPlusSecurityLevelUnknown) ?
+                                               probed_security_level :
+                                               MfPlusSecurityLevel3;
+            FURI_LOG_D(TAG, "Mifare Plus EV1/2 SL0/SL3 (probe-resolved)");
             break;
         case 0x10:
         case 0x11:
@@ -93,20 +98,57 @@ MfPlusError mf_plus_get_type_from_version(
     return error;
 }
 
-MfPlusError
-    mf_plus_get_type_from_iso4(const Iso14443_4aData* iso4_data, MfPlusData* mf_plus_data) {
+MfPlusError mf_plus_get_type_from_iso4(
+    const Iso14443_4aData* iso4_data,
+    MfPlusSecurityLevel probed_security_level,
+    MfPlusData* mf_plus_data) {
     furi_assert(iso4_data);
     furi_assert(mf_plus_data);
 
     MfPlusError error = MfPlusErrorProtocol;
 
+    const uint8_t sak = iso4_data->iso14443_3a_data->sak;
     const size_t historical_bytes_len = simple_array_get_count(iso4_data->ats_data.t1_tk);
-    if(historical_bytes_len != MF_PLUS_T1_TK_VALUE_LEN) {
+    const bool ats_matchable = (historical_bytes_len == MF_PLUS_T1_TK_VALUE_LEN);
+    const uint8_t* historical_bytes =
+        ats_matchable ? simple_array_cget_data(iso4_data->ats_data.t1_tk) : NULL;
+
+    // SAK 0x20 is shared with DESFire and cannot separate SL0 from SL3. When the poller's active
+    // probe resolved the level (non-Unknown), it has already confirmed "Plus, not DESFire", so we
+    // may report a Plus regardless of the ATS. Handle that here, before the ATS-table gate below,
+    // so an untabled or short ATS still yields a generic Plus instead of Unknown. 2K vs 4K needs the
+    // AN10833-forbidden ATQA nibble, so non-SE size stays Unknown.
+    if(sak == 0x20 && probed_security_level != MfPlusSecurityLevelUnknown) {
+        mf_plus_data->security_level = probed_security_level;
+        mf_plus_data->size = MfPlusSizeUnknown;
+        if(ats_matchable &&
+           memcmp(historical_bytes, mf_plus_ats_t1_tk_values[0], historical_bytes_len) == 0) {
+            mf_plus_data->type = MfPlusTypeS;
+        } else if(
+            ats_matchable &&
+            memcmp(historical_bytes, mf_plus_ats_t1_tk_values[1], historical_bytes_len) == 0) {
+            mf_plus_data->type = MfPlusTypeX;
+        } else if(
+            ats_matchable &&
+            (memcmp(historical_bytes, mf_plus_ats_t1_tk_values[2], historical_bytes_len) == 0 ||
+             memcmp(historical_bytes, mf_plus_ats_t1_tk_values[3], historical_bytes_len) == 0)) {
+            mf_plus_data->type = MfPlusTypeSE; // SE is 1K regardless of security level
+            mf_plus_data->size = MfPlusSize1K;
+        } else {
+            mf_plus_data->type = MfPlusTypePlus;
+        }
+        FURI_LOG_D(
+            TAG,
+            "Mifare Plus SL%d (SAK 20, probe-confirmed)",
+            probed_security_level == MfPlusSecurityLevel0 ? 0 : 3);
+        return MfPlusErrorNone;
+    }
+
+    if(!ats_matchable) {
         return MfPlusErrorProtocol;
     }
-    const uint8_t* historical_bytes = simple_array_cget_data(iso4_data->ats_data.t1_tk);
 
-    switch(iso4_data->iso14443_3a_data->sak) {
+    switch(sak) {
     case 0x08:
         if(memcmp(historical_bytes, mf_plus_ats_t1_tk_values[0], historical_bytes_len) == 0) {
             // Mifare Plus S 2K SL1
@@ -181,9 +223,9 @@ MfPlusError
 
         break;
     case 0x20:
-        // SAK 0x20 is shared with DESFire (probed after MfPlus), so the ATS match must stay the
-        // gate or DESFire is hijacked. 2K vs 4K needs the AN10833-forbidden ATQA nibble, so size
-        // stays Unknown.
+        // Reached only when the probe gave no usable result (Unknown): keep the strict ATS-table
+        // gate so DESFire (also SAK 0x20) is not hijacked. 2K vs 4K needs the AN10833-forbidden
+        // ATQA nibble, so size stays Unknown.
         if(memcmp(historical_bytes, mf_plus_ats_t1_tk_values[0], historical_bytes_len) == 0) {
             mf_plus_data->type = MfPlusTypeS;
             mf_plus_data->size = MfPlusSizeUnknown;

--- a/lib/nfc/protocols/mf_plus/mf_plus_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_i.c
@@ -63,15 +63,32 @@ MfPlusError mf_plus_get_type_from_version(
             break;
         }
 
-        // Security level
-        if(iso14443_4a_data->iso14443_3a_data->sak == 0x20) {
-            // Mifare Plus EV1/2 SL3
+        // Security level from the SAK bit map (AN10833): 0x20 -> SL3, 0x10/0x11 -> SL2,
+        // 0x08/0x18 -> SL1. GetVersion already gave the authoritative type/size, so the SAK here
+        // only refines SL; an unrecognized SAK leaves it Unknown rather than guessing SL1 (which
+        // previously collapsed every non-0x20 card, mislabelling genuine SL2 as SL1).
+        switch(iso14443_4a_data->iso14443_3a_data->sak) {
+        case 0x20:
             mf_plus_data->security_level = MfPlusSecurityLevel3;
             FURI_LOG_D(TAG, "Mifare Plus EV1/2 SL3");
-        } else {
-            // Mifare Plus EV1/2 SL1
+            break;
+        case 0x10:
+        case 0x11:
+            mf_plus_data->security_level = MfPlusSecurityLevel2;
+            FURI_LOG_D(TAG, "Mifare Plus EV1/2 SL2");
+            break;
+        case 0x08:
+        case 0x18:
             mf_plus_data->security_level = MfPlusSecurityLevel1;
             FURI_LOG_D(TAG, "Mifare Plus EV1/2 SL1");
+            break;
+        default:
+            mf_plus_data->security_level = MfPlusSecurityLevelUnknown;
+            FURI_LOG_D(
+                TAG,
+                "Mifare Plus EV1/2 unknown SL (SAK 0x%02X)",
+                iso14443_4a_data->iso14443_3a_data->sak);
+            break;
         }
     }
 

--- a/lib/nfc/protocols/mf_plus/mf_plus_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_i.c
@@ -31,6 +31,16 @@ static MfPlusType mf_plus_type_from_ats(const uint8_t* historical_bytes, size_t 
     return MfPlusTypeUnknown;
 }
 
+// SL0/SL3 expose no product-independent size byte, so once the card is confirmed Plus fall back to
+// the ATQA size coding: bit 2 (0x0004) = 2K, bit 1 (0x0002) = 4K. Size refinement only, never type
+// identification (same as PM3 hf mfp info).
+static MfPlusSize mf_plus_size_from_atqa(const uint8_t atqa[2]) {
+    const uint16_t atqa_value = atqa[0] | ((uint16_t)atqa[1] << 8);
+    if(atqa_value & 0x0004) return MfPlusSize2K;
+    if(atqa_value & 0x0002) return MfPlusSize4K;
+    return MfPlusSizeUnknown;
+}
+
 MfPlusError mf_plus_get_type_from_version(
     const Iso14443_4aData* iso14443_4a_data,
     MfPlusSecurityLevel probed_security_level,
@@ -71,8 +81,9 @@ MfPlusError mf_plus_get_type_from_version(
             FURI_LOG_D(TAG, "4K");
             break;
         default:
-            mf_plus_data->size = MfPlusSizeUnknown;
-            FURI_LOG_D(TAG, "Unknown storage size");
+            // No recognized storage byte (e.g. probe-only/older silicon) -> fall back to ATQA.
+            mf_plus_data->size = mf_plus_size_from_atqa(iso14443_4a_data->iso14443_3a_data->atqa);
+            FURI_LOG_D(TAG, "Unknown storage size; size from ATQA");
             break;
         }
 
@@ -139,7 +150,9 @@ MfPlusError mf_plus_get_type_from_iso4(
     if(sak == 0x20 && probed_security_level != MfPlusSecurityLevelUnknown) {
         const MfPlusType ats_type = mf_plus_type_from_ats(historical_bytes, historical_bytes_len);
         mf_plus_data->type = (ats_type == MfPlusTypeUnknown) ? MfPlusTypePlus : ats_type;
-        mf_plus_data->size = (ats_type == MfPlusTypeSE) ? MfPlusSize1K : MfPlusSizeUnknown;
+        mf_plus_data->size = (ats_type == MfPlusTypeSE) ?
+                                 MfPlusSize1K :
+                                 mf_plus_size_from_atqa(iso4_data->iso14443_3a_data->atqa);
         mf_plus_data->security_level = probed_security_level;
         FURI_LOG_D(
             TAG,
@@ -228,12 +241,14 @@ MfPlusError mf_plus_get_type_from_iso4(
         break;
     case 0x20: {
         // Reached only when the probe gave no usable result: keep the strict ATS-table gate so a
-        // DESFire (also SAK 0x20) is not hijacked. SL3 size needs the AN10833-forbidden ATQA, so SE
-        // stays 1K and any other matched product stays Unknown.
+        // DESFire (also SAK 0x20) is not hijacked. SE is always 1K; other products take their size
+        // from ATQA (the only SL3 size signal).
         const MfPlusType ats_type = mf_plus_type_from_ats(historical_bytes, historical_bytes_len);
         if(ats_type != MfPlusTypeUnknown) {
             mf_plus_data->type = ats_type;
-            mf_plus_data->size = (ats_type == MfPlusTypeSE) ? MfPlusSize1K : MfPlusSizeUnknown;
+            mf_plus_data->size = (ats_type == MfPlusTypeSE) ?
+                                     MfPlusSize1K :
+                                     mf_plus_size_from_atqa(iso4_data->iso14443_3a_data->atqa);
             mf_plus_data->security_level = MfPlusSecurityLevel3;
             FURI_LOG_D(TAG, "Mifare Plus SL3 (SAK 20, ATS-matched)");
             error = MfPlusErrorNone;

--- a/lib/nfc/protocols/mf_plus/mf_plus_i.h
+++ b/lib/nfc/protocols/mf_plus/mf_plus_i.h
@@ -6,11 +6,17 @@
 
 #define MF_PLUS_FFF_PICC_PREFIX "PICC"
 
+// probed_security_level carries the result of the poller's active SAK-0x20 probe (SL0 or SL3), or
+// MfPlusSecurityLevelUnknown when no probe applies/succeeded; it only influences the SAK-0x20 path.
 MfPlusError mf_plus_get_type_from_version(
     const Iso14443_4aData* iso14443_4a_data,
+    MfPlusSecurityLevel probed_security_level,
     MfPlusData* mf_plus_data);
 
-MfPlusError mf_plus_get_type_from_iso4(const Iso14443_4aData* iso4_data, MfPlusData* mf_plus_data);
+MfPlusError mf_plus_get_type_from_iso4(
+    const Iso14443_4aData* iso4_data,
+    MfPlusSecurityLevel probed_security_level,
+    MfPlusData* mf_plus_data);
 
 MfPlusError mf_plus_version_parse(MfPlusVersion* data, const BitBuffer* buf);
 

--- a/lib/nfc/protocols/mf_plus/mf_plus_poller.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_poller.c
@@ -41,6 +41,32 @@ MfPlusPoller* mf_plus_poller_alloc(Iso14443_4aPoller* iso14443_4a_poller) {
     return instance;
 }
 
+// SAK 0x20 (ISO14443-4) is the only case where SL0/SL3 (and Plus vs DESFire) cannot be told apart
+// passively, so probe it actively. Other SAKs carry the level in their bits and need no probe.
+// Returns the resolved level, or MfPlusSecurityLevelUnknown when no probe applies or it could not
+// confirm a Plus (a DESFire/unsupported reply) — callers then keep their DESFire-safe fallback.
+static MfPlusSecurityLevel mf_plus_poller_probe_sak20_security_level(MfPlusPoller* instance) {
+    const Iso14443_4aData* iso14443_4a_data =
+        iso14443_4a_poller_get_data(instance->iso14443_4a_poller);
+    if(iso14443_4a_data->iso14443_3a_data->sak != 0x20) {
+        return MfPlusSecurityLevelUnknown;
+    }
+
+    MfPlusProbeResult probe;
+    if(mf_plus_poller_probe_security_level(instance, &probe) != MfPlusErrorNone) {
+        return MfPlusSecurityLevelUnknown;
+    }
+
+    switch(probe) {
+    case MfPlusProbeResultSl0:
+        return MfPlusSecurityLevel0;
+    case MfPlusProbeResultSl3:
+        return MfPlusSecurityLevel3;
+    default: // MfPlusProbeResultNotPlus
+        return MfPlusSecurityLevelUnknown;
+    }
+}
+
 static NfcCommand mf_plus_poller_handler_idle(MfPlusPoller* instance) {
     furi_assert(instance);
 
@@ -71,8 +97,9 @@ static NfcCommand mf_plus_poller_handler_read_version(MfPlusPoller* instance) {
 static NfcCommand mf_plus_poller_handler_parse_version(MfPlusPoller* instance) {
     furi_assert(instance);
 
+    const MfPlusSecurityLevel probed_sl = mf_plus_poller_probe_sak20_security_level(instance);
     MfPlusError error = mf_plus_get_type_from_version(
-        iso14443_4a_poller_get_data(instance->iso14443_4a_poller), instance->data);
+        iso14443_4a_poller_get_data(instance->iso14443_4a_poller), probed_sl, instance->data);
     if(error == MfPlusErrorNone) {
         instance->state = MfPlusPollerStateReadSuccess;
     } else {
@@ -86,8 +113,9 @@ static NfcCommand mf_plus_poller_handler_parse_version(MfPlusPoller* instance) {
 static NfcCommand mf_plus_poller_handler_parse_iso4(MfPlusPoller* instance) {
     furi_assert(instance);
 
+    const MfPlusSecurityLevel probed_sl = mf_plus_poller_probe_sak20_security_level(instance);
     MfPlusError error = mf_plus_get_type_from_iso4(
-        iso14443_4a_poller_get_data(instance->iso14443_4a_poller), instance->data);
+        iso14443_4a_poller_get_data(instance->iso14443_4a_poller), probed_sl, instance->data);
     if(error == MfPlusErrorNone) {
         instance->state = MfPlusPollerStateReadSuccess;
     } else {
@@ -188,12 +216,17 @@ static bool mf_plus_poller_detect(NfcGenericEvent event, void* context) {
 
     if(iso14443_4a_event->type == Iso14443_4aPollerEventTypeReady) {
         error = mf_plus_poller_read_version(instance, &instance->data->version);
+        const MfPlusSecurityLevel probed_sl = mf_plus_poller_probe_sak20_security_level(instance);
         if(error == MfPlusErrorNone) {
             error = mf_plus_get_type_from_version(
-                iso14443_4a_poller_get_data(instance->iso14443_4a_poller), instance->data);
+                iso14443_4a_poller_get_data(instance->iso14443_4a_poller),
+                probed_sl,
+                instance->data);
         } else {
             error = mf_plus_get_type_from_iso4(
-                iso14443_4a_poller_get_data(instance->iso14443_4a_poller), instance->data);
+                iso14443_4a_poller_get_data(instance->iso14443_4a_poller),
+                probed_sl,
+                instance->data);
         }
     }
 

--- a/lib/nfc/protocols/mf_plus/mf_plus_poller.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_poller.c
@@ -215,14 +215,19 @@ static bool mf_plus_poller_detect(NfcGenericEvent event, void* context) {
 
     if(iso14443_4a_event->type == Iso14443_4aPollerEventTypeReady) {
         error = mf_plus_poller_read_version(instance, &instance->data->version);
-        const MfPlusSecurityLevel probed_sl =
-            mf_plus_poller_resolve_sak20_security_level(instance);
         if(error == MfPlusErrorNone) {
+            // Version path already excludes DESFire (family nibble) and the SL chosen here is
+            // discarded with this throwaway detect poller, so skip the probe round-trip; the read
+            // phase resolves the real SL0/SL3.
             error = mf_plus_get_type_from_version(
                 iso14443_4a_poller_get_data(instance->iso14443_4a_poller),
-                probed_sl,
+                MfPlusSecurityLevelUnknown,
                 instance->data);
         } else {
+            // iso4 fallback: the probe is what confirms Plus-not-DESFire and lifts an untabled ATS
+            // out of Unknown, so it is required for detection coverage here.
+            const MfPlusSecurityLevel probed_sl =
+                mf_plus_poller_resolve_sak20_security_level(instance);
             error = mf_plus_get_type_from_iso4(
                 iso14443_4a_poller_get_data(instance->iso14443_4a_poller),
                 probed_sl,

--- a/lib/nfc/protocols/mf_plus/mf_plus_poller.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_poller.c
@@ -41,18 +41,17 @@ MfPlusPoller* mf_plus_poller_alloc(Iso14443_4aPoller* iso14443_4a_poller) {
     return instance;
 }
 
-// SAK 0x20 (ISO14443-4) is the only case where SL0/SL3 (and Plus vs DESFire) cannot be told apart
-// passively, so probe it actively. Other SAKs carry the level in their bits and need no probe.
-// Returns the resolved level, or MfPlusSecurityLevelUnknown when no probe applies or it could not
-// confirm a Plus (a DESFire/unsupported reply) — callers then keep their DESFire-safe fallback.
-static MfPlusSecurityLevel mf_plus_poller_probe_sak20_security_level(MfPlusPoller* instance) {
+// Resolve the SL for a SAK-0x20 card via the active probe (the only case SL0/SL3/DESFire can't be
+// told apart passively — see MfPlusProbeResult). Returns Unknown for any other SAK, a probe error,
+// or a non-Plus reply, so callers keep their DESFire-safe fallback.
+static MfPlusSecurityLevel mf_plus_poller_resolve_sak20_security_level(MfPlusPoller* instance) {
     const Iso14443_4aData* iso14443_4a_data =
         iso14443_4a_poller_get_data(instance->iso14443_4a_poller);
     if(iso14443_4a_data->iso14443_3a_data->sak != 0x20) {
         return MfPlusSecurityLevelUnknown;
     }
 
-    MfPlusProbeResult probe;
+    MfPlusProbeResult probe = MfPlusProbeResultNotPlus;
     if(mf_plus_poller_probe_security_level(instance, &probe) != MfPlusErrorNone) {
         return MfPlusSecurityLevelUnknown;
     }
@@ -97,7 +96,7 @@ static NfcCommand mf_plus_poller_handler_read_version(MfPlusPoller* instance) {
 static NfcCommand mf_plus_poller_handler_parse_version(MfPlusPoller* instance) {
     furi_assert(instance);
 
-    const MfPlusSecurityLevel probed_sl = mf_plus_poller_probe_sak20_security_level(instance);
+    const MfPlusSecurityLevel probed_sl = mf_plus_poller_resolve_sak20_security_level(instance);
     MfPlusError error = mf_plus_get_type_from_version(
         iso14443_4a_poller_get_data(instance->iso14443_4a_poller), probed_sl, instance->data);
     if(error == MfPlusErrorNone) {
@@ -113,7 +112,7 @@ static NfcCommand mf_plus_poller_handler_parse_version(MfPlusPoller* instance) {
 static NfcCommand mf_plus_poller_handler_parse_iso4(MfPlusPoller* instance) {
     furi_assert(instance);
 
-    const MfPlusSecurityLevel probed_sl = mf_plus_poller_probe_sak20_security_level(instance);
+    const MfPlusSecurityLevel probed_sl = mf_plus_poller_resolve_sak20_security_level(instance);
     MfPlusError error = mf_plus_get_type_from_iso4(
         iso14443_4a_poller_get_data(instance->iso14443_4a_poller), probed_sl, instance->data);
     if(error == MfPlusErrorNone) {
@@ -216,7 +215,8 @@ static bool mf_plus_poller_detect(NfcGenericEvent event, void* context) {
 
     if(iso14443_4a_event->type == Iso14443_4aPollerEventTypeReady) {
         error = mf_plus_poller_read_version(instance, &instance->data->version);
-        const MfPlusSecurityLevel probed_sl = mf_plus_poller_probe_sak20_security_level(instance);
+        const MfPlusSecurityLevel probed_sl =
+            mf_plus_poller_resolve_sak20_security_level(instance);
         if(error == MfPlusErrorNone) {
             error = mf_plus_get_type_from_version(
                 iso14443_4a_poller_get_data(instance->iso14443_4a_poller),

--- a/lib/nfc/protocols/mf_plus/mf_plus_poller_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_poller_i.c
@@ -108,12 +108,22 @@ MfPlusError mf_plus_poller_read_version(MfPlusPoller* instance, MfPlusVersion* d
 
     bit_buffer_reset(instance->input_buffer);
     bit_buffer_append_byte(instance->input_buffer, MF_PLUS_CMD_GET_VERSION);
+    // Clear the result buffer first: nxp_native_command only clears it once its first frame
+    // succeeds, so a first-frame failure could leave stale bytes the trust check below would accept.
+    bit_buffer_reset(instance->result_buffer);
 
     MfPlusError error =
         mf_plus_poller_send_chunks(instance, instance->input_buffer, instance->result_buffer);
-    if(error == MfPlusErrorNone) {
-        error = mf_plus_version_parse(data, instance->result_buffer);
+
+    // A genuine Plus EV1/EV2 returns the full 28-byte GetVersion block but ends the native frame with
+    // a non-zero status (unlike DESFire), so send_chunks flags MfPlusErrorProtocol on a complete,
+    // correct reply. Trust it when it parses as an NXP Plus (vendor 0x04, family nibble 0x02);
+    // otherwise fail so the caller falls back to ATS (EV1/EV2 share the Plus-X ATS, so GetVersion is
+    // their only tell).
+    if(mf_plus_version_parse(data, instance->result_buffer) == MfPlusErrorNone &&
+       data->hw_vendor == 0x04 && (data->hw_type & 0x0F) == 0x02) {
+        return MfPlusErrorNone;
     }
 
-    return error;
+    return (error != MfPlusErrorNone) ? error : MfPlusErrorProtocol;
 }

--- a/lib/nfc/protocols/mf_plus/mf_plus_poller_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_poller_i.c
@@ -51,6 +51,57 @@ MfPlusError mf_plus_poller_send_chunks(
     return mf_plus_process_status_code(status_code);
 }
 
+// WritePerso (0xA8) targeting block 0x9090, which is intentionally invalid: a card still in SL0
+// rejects the block with 0x09 instead of writing anything (so the probe never mutates the card),
+// while an SL3 card rejects the command itself and DESFire/other answer with their own status.
+// Same discriminator PM3 uses in `hf mfp info` (client/src/cmdhfmfp.c).
+#define MF_PLUS_CMD_WRITE_PERSO       (0xA8)
+#define MF_PLUS_WRITE_PERSO_PROBE_LEN (1 + 2 + 16) // cmd + invalid block addr + 16 data bytes
+
+MfPlusError
+    mf_plus_poller_probe_security_level(MfPlusPoller* instance, MfPlusProbeResult* result) {
+    furi_check(instance);
+    furi_check(result);
+
+    bit_buffer_reset(instance->input_buffer);
+    bit_buffer_append_byte(instance->input_buffer, MF_PLUS_CMD_WRITE_PERSO);
+    bit_buffer_append_byte(instance->input_buffer, 0x90); // block addr LSB \_ 0x9090, invalid
+    bit_buffer_append_byte(instance->input_buffer, 0x90); // block addr MSB /
+    for(size_t i = 0; i < MF_PLUS_WRITE_PERSO_PROBE_LEN - 3; i++) {
+        bit_buffer_append_byte(instance->input_buffer, 0x00);
+    }
+
+    Iso14443_4aError error = iso14443_4a_poller_send_block(
+        instance->iso14443_4a_poller, instance->input_buffer, instance->result_buffer);
+    if(error != Iso14443_4aErrorNone) {
+        return mf_plus_process_error(error);
+    }
+
+    const size_t len = bit_buffer_get_size_bytes(instance->result_buffer);
+    if(len == 0) {
+        return MfPlusErrorProtocol;
+    }
+
+    const uint8_t b0 = bit_buffer_get_byte(instance->result_buffer, 0);
+    if(len >= 2) {
+        const uint8_t b1 = bit_buffer_get_byte(instance->result_buffer, 1);
+        // DESFire answers 67 00 (wrong length) or 1C 83 0C; 6D 00 is "INS not supported".
+        const bool desfire_67 = (b0 == 0x67 && b1 == 0x00);
+        const bool desfire_1c =
+            (len >= 3 && b0 == 0x1C && b1 == 0x83 &&
+             bit_buffer_get_byte(instance->result_buffer, 2) == 0x0C);
+        const bool ins_unsupported = (b0 == 0x6D && b1 == 0x00);
+        if(desfire_67 || desfire_1c || ins_unsupported) {
+            *result = MfPlusProbeResultNotPlus;
+            return MfPlusErrorNone;
+        }
+    }
+
+    // 0x09 (block invalid) is returned only by a card still in SL0; anything else is a Plus in SL3.
+    *result = (len > 1 && b0 == 0x09) ? MfPlusProbeResultSl0 : MfPlusProbeResultSl3;
+    return MfPlusErrorNone;
+}
+
 MfPlusError mf_plus_poller_read_version(MfPlusPoller* instance, MfPlusVersion* data) {
     furi_check(instance);
 

--- a/lib/nfc/protocols/mf_plus/mf_plus_poller_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_poller_i.c
@@ -70,21 +70,23 @@ MfPlusError
         bit_buffer_append_byte(instance->input_buffer, 0x00);
     }
 
-    Iso14443_4aError error = iso14443_4a_poller_send_block(
-        instance->iso14443_4a_poller, instance->input_buffer, instance->result_buffer);
+    NxpNativeCommandStatus status = NXP_NATIVE_COMMAND_STATUS_OPERATION_OK;
+    Iso14443_4aError error = nxp_native_command_iso14443_4a_poller(
+        instance->iso14443_4a_poller,
+        &status,
+        instance->input_buffer,
+        instance->result_buffer,
+        NxpNativeCommandModePlain,
+        instance->tx_buffer,
+        instance->rx_buffer);
     if(error != Iso14443_4aErrorNone) {
         return mf_plus_process_error(error);
     }
 
-    if(bit_buffer_get_size_bytes(instance->result_buffer) == 0) {
-        return MfPlusErrorProtocol;
-    }
-
     // MIFARE Plus answers WritePerso with a single status byte: 0x09 = invalid block rejected (still
     // in SL0 personalization), 0x06/0x0B = the documented SL3 rejections. Treat any other reply
-    // (DESFire status words, unsupported-INS, ...) as not-a-Plus so the caller keeps its
-    // DESFire-safe fallback -- no real DESFire status code is 0x06/0x09/0x0B. (PM3 hf mfp info.)
-    const uint8_t status = bit_buffer_get_byte(instance->result_buffer, 0);
+    // (DESFire status words, length error, ...) as not-a-Plus so the caller keeps its DESFire-safe
+    // fallback -- no real DESFire status code is 0x06/0x09/0x0B. (PM3 hf mfp info.)
     FURI_LOG_D(TAG, "SL probe (SAK 20) WritePerso status 0x%02X", status);
     switch(status) {
     case 0x09:

--- a/lib/nfc/protocols/mf_plus/mf_plus_poller_i.c
+++ b/lib/nfc/protocols/mf_plus/mf_plus_poller_i.c
@@ -51,10 +51,9 @@ MfPlusError mf_plus_poller_send_chunks(
     return mf_plus_process_status_code(status_code);
 }
 
-// WritePerso (0xA8) targeting block 0x9090, which is intentionally invalid: a card still in SL0
-// rejects the block with 0x09 instead of writing anything (so the probe never mutates the card),
-// while an SL3 card rejects the command itself and DESFire/other answer with their own status.
-// Same discriminator PM3 uses in `hf mfp info` (client/src/cmdhfmfp.c).
+// WritePerso (0xA8) to the intentionally-invalid block 0x9090: the block is always rejected (no
+// write happens), only the status byte varies by card state -- the discriminator PM3 uses in
+// `hf mfp info`. Classified in mf_plus_poller_probe_security_level below.
 #define MF_PLUS_CMD_WRITE_PERSO       (0xA8)
 #define MF_PLUS_WRITE_PERSO_PROBE_LEN (1 + 2 + 16) // cmd + invalid block addr + 16 data bytes
 
@@ -65,8 +64,8 @@ MfPlusError
 
     bit_buffer_reset(instance->input_buffer);
     bit_buffer_append_byte(instance->input_buffer, MF_PLUS_CMD_WRITE_PERSO);
-    bit_buffer_append_byte(instance->input_buffer, 0x90); // block addr LSB \_ 0x9090, invalid
-    bit_buffer_append_byte(instance->input_buffer, 0x90); // block addr MSB /
+    bit_buffer_append_byte(instance->input_buffer, 0x90); // block 0x9090 (little-endian), invalid
+    bit_buffer_append_byte(instance->input_buffer, 0x90);
     for(size_t i = 0; i < MF_PLUS_WRITE_PERSO_PROBE_LEN - 3; i++) {
         bit_buffer_append_byte(instance->input_buffer, 0x00);
     }
@@ -77,28 +76,28 @@ MfPlusError
         return mf_plus_process_error(error);
     }
 
-    const size_t len = bit_buffer_get_size_bytes(instance->result_buffer);
-    if(len == 0) {
+    if(bit_buffer_get_size_bytes(instance->result_buffer) == 0) {
         return MfPlusErrorProtocol;
     }
 
-    const uint8_t b0 = bit_buffer_get_byte(instance->result_buffer, 0);
-    if(len >= 2) {
-        const uint8_t b1 = bit_buffer_get_byte(instance->result_buffer, 1);
-        // DESFire answers 67 00 (wrong length) or 1C 83 0C; 6D 00 is "INS not supported".
-        const bool desfire_67 = (b0 == 0x67 && b1 == 0x00);
-        const bool desfire_1c =
-            (len >= 3 && b0 == 0x1C && b1 == 0x83 &&
-             bit_buffer_get_byte(instance->result_buffer, 2) == 0x0C);
-        const bool ins_unsupported = (b0 == 0x6D && b1 == 0x00);
-        if(desfire_67 || desfire_1c || ins_unsupported) {
-            *result = MfPlusProbeResultNotPlus;
-            return MfPlusErrorNone;
-        }
+    // MIFARE Plus answers WritePerso with a single status byte: 0x09 = invalid block rejected (still
+    // in SL0 personalization), 0x06/0x0B = the documented SL3 rejections. Treat any other reply
+    // (DESFire status words, unsupported-INS, ...) as not-a-Plus so the caller keeps its
+    // DESFire-safe fallback -- no real DESFire status code is 0x06/0x09/0x0B. (PM3 hf mfp info.)
+    const uint8_t status = bit_buffer_get_byte(instance->result_buffer, 0);
+    FURI_LOG_D(TAG, "SL probe (SAK 20) WritePerso status 0x%02X", status);
+    switch(status) {
+    case 0x09:
+        *result = MfPlusProbeResultSl0;
+        break;
+    case 0x06:
+    case 0x0B:
+        *result = MfPlusProbeResultSl3;
+        break;
+    default:
+        *result = MfPlusProbeResultNotPlus;
+        break;
     }
-
-    // 0x09 (block invalid) is returned only by a card still in SL0; anything else is a Plus in SL3.
-    *result = (len > 1 && b0 == 0x09) ? MfPlusProbeResultSl0 : MfPlusProbeResultSl3;
     return MfPlusErrorNone;
 }
 

--- a/lib/nfc/protocols/mf_plus/mf_plus_poller_i.h
+++ b/lib/nfc/protocols/mf_plus/mf_plus_poller_i.h
@@ -45,7 +45,20 @@ struct MfPlusPoller {
     void* context;
 };
 
+// Result of the active SAK-0x20 disambiguation probe. AN10833 gives no passive way to separate a
+// Plus in SL0 from one in SL3, nor a Plus from a DESFire (both answer SAK 0x20 + ATS), so the
+// poller sends a command and classifies the reply.
+typedef enum {
+    MfPlusProbeResultSl0, // answered 0x09: still in personalization (SL0)
+    MfPlusProbeResultSl3, // answered as a Plus but not SL0
+    MfPlusProbeResultNotPlus, // DESFire / unsupported: let the poller chain continue
+} MfPlusProbeResult;
+
 MfPlusError mf_plus_process_error(Iso14443_4aError error);
+
+// Sends WritePerso to an intentionally invalid block and classifies the reply (mirrors PM3
+// `hf mfp info`). Returns MfPlusErrorNone with *result set on a clean exchange, an error otherwise.
+MfPlusError mf_plus_poller_probe_security_level(MfPlusPoller* instance, MfPlusProbeResult* result);
 
 MfPlusPoller* mf_plus_poller_alloc(Iso14443_4aPoller* iso14443_4a_poller);
 

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
@@ -175,9 +175,9 @@ static const MfUltralightFeatures mf_ultralight_features[MfUltralightTypeNum] = 
         },
     [MfUltralightTypeUltralightAES] =
         {
-            // Read-only label: AES authentication is not implemented, so only the
-            // unauthenticated area is captured. Page count is conservative pending datasheet
-            // validation (MF0AES20 user memory is 144 bytes / pages 4-39).
+            // Read-only label: AES authentication is not implemented, so only the unauthenticated
+            // area is captured and the read is never reported complete (see is_all_data_read).
+            // TODO: confirm page count against the MF0AES20 datasheet (user memory 144 B, pages 4-39).
             .device_name = "Mifare Ultralight AES",
             .total_pages = 40,
             .config_page = 0,
@@ -684,9 +684,14 @@ bool mf_ultralight_is_all_data_read(const MfUltralightData* data) {
         if((data->type == MfUltralightTypeMfulC) &&
            mf_ultralight_support_feature(feature_set, MfUltralightFeatureSupportAuthenticate)) {
             all_read = true;
-        } else if(!mf_ultralight_support_feature(
-                      feature_set, MfUltralightFeatureSupportPasswordAuth)) {
+        } else if(
+            data->type != MfUltralightTypeUltralightAES &&
+            !mf_ultralight_support_feature(feature_set, MfUltralightFeatureSupportPasswordAuth)) {
             all_read = true;
+        } else if(data->type == MfUltralightTypeUltralightAES) {
+            // AES-protected memory is never fully captured without AES auth (not implemented),
+            // so the read is never complete even after all advertised pages are read.
+            all_read = false;
         } else {
             // Having read all the pages doesn't mean that we've got everything.
             // By default PWD is 0xFFFFFFFF, but if read back it is always 0x00000000,

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
@@ -610,9 +610,7 @@ bool mf_ultralight_detect_protocol(const Iso14443_3aData* iso14443_3a_data) {
     // NOT checked: it encodes UID size (0x44 for 7-byte, 0x04 for 4-byte), so a 4-byte-UID UL is
     // still UL. Matches PM3 (rejects only atqa[1] != 0x00 || sak != 0x00); non-zero SAK (Classic and
     // its magic clones) is excluded by the SAK term.
-    bool mfu_detected = (iso14443_3a_data->atqa[1] == 0x00) && (iso14443_3a_data->sak == 0x00);
-
-    return mfu_detected;
+    return (iso14443_3a_data->atqa[1] == 0x00) && (iso14443_3a_data->sak == 0x00);
 }
 
 uint16_t mf_ultralight_get_config_page_num(MfUltralightType type) {

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
@@ -150,6 +150,16 @@ static const MfUltralightFeatures mf_ultralight_features[MfUltralightTypeNum] = 
                 MfUltralightFeatureSupportSectorSelect | MfUltralightFeatureSupportFastWrite |
                 MfUltralightFeatureSupportDynamicLock,
         },
+    [MfUltralightTypeUnknown] =
+        {
+            // Conservative, identical to Origin: read the basic 16 pages and offer no Write
+            // (the app's write allow-list omits this type), so an unmodelled IC is captured
+            // safely without over-claiming a layout we do not know.
+            .device_name = "NTAG/Ultralight (Unknown)",
+            .total_pages = 16,
+            .config_page = 0,
+            .feature_set = MfUltralightFeatureSupportCompatibleWrite,
+        },
 };
 
 const NfcDeviceBase nfc_device_mf_ultralight = {
@@ -512,7 +522,10 @@ Iso14443_3aData* mf_ultralight_get_base_data(const MfUltralightData* data) {
 MfUltralightType mf_ultralight_get_type_by_version(MfUltralightVersion* version) {
     furi_check(version);
 
-    MfUltralightType type = MfUltralightTypeOrigin;
+    // Default to Unknown, not Origin: reaching here means GetVersion succeeded, so the IC is never
+    // a true original Ultralight (which has no GetVersion). An unrecognized storage_size therefore
+    // means "GetVersion-capable but unmodelled" (e.g. Ultralight AES), not "original".
+    MfUltralightType type = MfUltralightTypeUnknown;
 
     if(version->storage_size == 0x0B || version->storage_size == 0x00) {
         type = MfUltralightTypeUL11;

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
@@ -150,6 +150,41 @@ static const MfUltralightFeatures mf_ultralight_features[MfUltralightTypeNum] = 
                 MfUltralightFeatureSupportSectorSelect | MfUltralightFeatureSupportFastWrite |
                 MfUltralightFeatureSupportDynamicLock,
         },
+    [MfUltralightTypeNTAG210] =
+        {
+            // Same memory layout as MF0UL11 (48-byte, 20 pages, config at 16); NTAG family,
+            // so no EV1 one-way counters. Read-only here (omitted from the app write allow-list).
+            .device_name = "NTAG210",
+            .total_pages = 20,
+            .config_page = 16,
+            .feature_set =
+                MfUltralightFeatureSupportReadVersion | MfUltralightFeatureSupportReadSignature |
+                MfUltralightFeatureSupportFastRead | MfUltralightFeatureSupportPasswordAuth |
+                MfUltralightFeatureSupportCompatibleWrite,
+        },
+    [MfUltralightTypeNTAG212] =
+        {
+            // Same memory layout as MF0UL21 (128-byte, 41 pages, config at 37, dynamic lock).
+            .device_name = "NTAG212",
+            .total_pages = 41,
+            .config_page = 37,
+            .feature_set =
+                MfUltralightFeatureSupportReadVersion | MfUltralightFeatureSupportReadSignature |
+                MfUltralightFeatureSupportFastRead | MfUltralightFeatureSupportPasswordAuth |
+                MfUltralightFeatureSupportCompatibleWrite | MfUltralightFeatureSupportDynamicLock,
+        },
+    [MfUltralightTypeUltralightAES] =
+        {
+            // Read-only label: AES authentication is not implemented, so only the
+            // unauthenticated area is captured. Page count is conservative pending datasheet
+            // validation (MF0AES20 user memory is 144 bytes / pages 4-39).
+            .device_name = "Mifare Ultralight AES",
+            .total_pages = 40,
+            .config_page = 0,
+            .feature_set = MfUltralightFeatureSupportReadVersion |
+                           MfUltralightFeatureSupportReadSignature |
+                           MfUltralightFeatureSupportFastRead,
+        },
     [MfUltralightTypeUnknown] =
         {
             // Conservative, identical to Origin: read the basic 16 pages and offer no Write
@@ -522,38 +557,42 @@ Iso14443_3aData* mf_ultralight_get_base_data(const MfUltralightData* data) {
 MfUltralightType mf_ultralight_get_type_by_version(MfUltralightVersion* version) {
     furi_check(version);
 
-    // Default to Unknown, not Origin: reaching here means GetVersion succeeded, so the IC is never
-    // a true original Ultralight (which has no GetVersion). An unrecognized storage_size therefore
-    // means "GetVersion-capable but unmodelled" (e.g. Ultralight AES), not "original".
-    MfUltralightType type = MfUltralightTypeUnknown;
-
-    if(version->storage_size == 0x0B || version->storage_size == 0x00) {
-        type = MfUltralightTypeUL11;
-    } else if(version->storage_size == 0x0E) {
-        type = MfUltralightTypeUL21;
-    } else if(version->storage_size == 0x0F) {
-        type = MfUltralightTypeNTAG213;
-    } else if(version->storage_size == 0x11) {
-        type = MfUltralightTypeNTAG215;
-    } else if(version->prod_subtype == 5 && version->prod_ver_major == 2) {
+    // NTAG I2C is matched on subtype/major, NOT the product-type nibble: real silicon reports
+    // family 0x07 here while the firmware's own data generator emits 0x04, so the nibble is
+    // unreliable for this family. No other modelled IC uses subtype 5 + major 2.
+    if(version->prod_subtype == 5 && version->prod_ver_major == 2) {
         if(version->prod_ver_minor == 1) {
-            if(version->storage_size == 0x13) {
-                type = MfUltralightTypeNTAGI2C1K;
-            } else if(version->storage_size == 0x15) {
-                type = MfUltralightTypeNTAGI2C2K;
-            }
+            if(version->storage_size == 0x13) return MfUltralightTypeNTAGI2C1K;
+            if(version->storage_size == 0x15) return MfUltralightTypeNTAGI2C2K;
         } else if(version->prod_ver_minor == 2) {
-            if(version->storage_size == 0x13) {
-                type = MfUltralightTypeNTAGI2CPlus1K;
-            } else if(version->storage_size == 0x15) {
-                type = MfUltralightTypeNTAGI2CPlus2K;
-            }
+            if(version->storage_size == 0x13) return MfUltralightTypeNTAGI2CPlus1K;
+            if(version->storage_size == 0x15) return MfUltralightTypeNTAGI2CPlus2K;
         }
-    } else if(version->storage_size == 0x13) {
-        type = MfUltralightTypeNTAG216;
+        return MfUltralightTypeUnknown;
     }
 
-    return type;
+    // AN10833: the product family is the low nibble of GetVersion byte 2 (prod_type); size within
+    // the family from storage_size. Gating on the family first separates ICs that share a
+    // storage_size across families: NTAG210/UL11 (0x0B), NTAG212/UL21 (0x0E), NTAG213/Ultralight
+    // AES (0x0F). Default to Unknown, never Origin: reaching here means GetVersion succeeded, so
+    // the IC is never a true original Ultralight (which has no GetVersion).
+    switch(version->prod_type & 0x0F) {
+    case 0x03: // MIFARE Ultralight family
+        if(version->storage_size == 0x0B || version->storage_size == 0x00)
+            return MfUltralightTypeUL11;
+        if(version->storage_size == 0x0E) return MfUltralightTypeUL21;
+        if(version->storage_size == 0x0F) return MfUltralightTypeUltralightAES;
+        return MfUltralightTypeUnknown;
+    case 0x04: // NTAG family
+        if(version->storage_size == 0x0B) return MfUltralightTypeNTAG210;
+        if(version->storage_size == 0x0E) return MfUltralightTypeNTAG212;
+        if(version->storage_size == 0x0F) return MfUltralightTypeNTAG213;
+        if(version->storage_size == 0x11) return MfUltralightTypeNTAG215;
+        if(version->storage_size == 0x13) return MfUltralightTypeNTAG216;
+        return MfUltralightTypeUnknown;
+    default:
+        return MfUltralightTypeUnknown;
+    }
 }
 
 uint16_t mf_ultralight_get_pages_total(MfUltralightType type) {

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
@@ -568,23 +568,24 @@ MfUltralightType mf_ultralight_get_type_by_version(MfUltralightVersion* version)
         return MfUltralightTypeUnknown;
     }
 
-    // AN10833: gate on the product family (low nibble of prod_type) before storage_size, which
-    // collides across families (0x0B, 0x0E, 0x0F). Default Unknown not Origin -- GetVersion
-    // succeeded, so this is never a true original Ultralight.
-    switch(version->prod_type & 0x0F) {
-    case 0x03: // MIFARE Ultralight family
-        if(version->storage_size == 0x0B || version->storage_size == 0x00)
-            return MfUltralightTypeUL11;
-        if(version->storage_size == 0x0E) return MfUltralightTypeUL21;
-        if(version->storage_size == 0x0F) return MfUltralightTypeUltralightAES;
-        return MfUltralightTypeUnknown;
-    case 0x04: // NTAG family
-        if(version->storage_size == 0x0B) return MfUltralightTypeNTAG210;
-        if(version->storage_size == 0x0E) return MfUltralightTypeNTAG212;
-        if(version->storage_size == 0x0F) return MfUltralightTypeNTAG213;
-        if(version->storage_size == 0x11) return MfUltralightTypeNTAG215;
-        if(version->storage_size == 0x13) return MfUltralightTypeNTAG216;
-        return MfUltralightTypeUnknown;
+    // Size from storage_size (lenient, as the legacy logic did). AN10833 names the product family
+    // in the low nibble of prod_type; consult it ONLY to split the storage_size values that collide
+    // across families (NTAG210/UL11 0x0B, NTAG212/UL21 0x0E, NTAG213/Ultralight AES 0x0F), so a
+    // clone with a non-standard prod_type still types by storage as before. Default Unknown not
+    // Origin: GetVersion succeeded, so this is never a true original Ultralight.
+    const uint8_t family = version->prod_type & 0x0F; // 0x03 = Ultralight, 0x04 = NTAG
+    switch(version->storage_size) {
+    case 0x00:
+    case 0x0B:
+        return (family == 0x04) ? MfUltralightTypeNTAG210 : MfUltralightTypeUL11;
+    case 0x0E:
+        return (family == 0x04) ? MfUltralightTypeNTAG212 : MfUltralightTypeUL21;
+    case 0x0F:
+        return (family == 0x03) ? MfUltralightTypeUltralightAES : MfUltralightTypeNTAG213;
+    case 0x11:
+        return MfUltralightTypeNTAG215;
+    case 0x13:
+        return MfUltralightTypeNTAG216;
     default:
         return MfUltralightTypeUnknown;
     }

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
@@ -152,8 +152,7 @@ static const MfUltralightFeatures mf_ultralight_features[MfUltralightTypeNum] = 
         },
     [MfUltralightTypeNTAG210] =
         {
-            // Same memory layout as MF0UL11 (48-byte, 20 pages, config at 16); NTAG family,
-            // so no EV1 one-way counters. Read-only here (omitted from the app write allow-list).
+            // Same layout as MF0UL11 (20 pages, config 16) but NTAG (no EV1 counters); read-only.
             .device_name = "NTAG210",
             .total_pages = 20,
             .config_page = 16,
@@ -175,8 +174,8 @@ static const MfUltralightFeatures mf_ultralight_features[MfUltralightTypeNum] = 
         },
     [MfUltralightTypeUltralightAES] =
         {
-            // Read-only label: AES authentication is not implemented, so only the unauthenticated
-            // area is captured and the read is never reported complete (see is_all_data_read).
+            // Read-only: AES auth is not implemented, so only the unauthenticated area is captured
+            // and the read is never reported complete.
             // TODO: confirm page count against the MF0AES20 datasheet (user memory 144 B, pages 4-39).
             .device_name = "Mifare Ultralight AES",
             .total_pages = 40,
@@ -187,9 +186,7 @@ static const MfUltralightFeatures mf_ultralight_features[MfUltralightTypeNum] = 
         },
     [MfUltralightTypeUnknown] =
         {
-            // Conservative, identical to Origin: read the basic 16 pages and offer no Write
-            // (the app's write allow-list omits this type), so an unmodelled IC is captured
-            // safely without over-claiming a layout we do not know.
+            // Unmodelled IC: conservative 16-page read, no Write (omitted from the app allow-list).
             .device_name = "NTAG/Ultralight (Unknown)",
             .total_pages = 16,
             .config_page = 0,
@@ -571,11 +568,9 @@ MfUltralightType mf_ultralight_get_type_by_version(MfUltralightVersion* version)
         return MfUltralightTypeUnknown;
     }
 
-    // AN10833: the product family is the low nibble of GetVersion byte 2 (prod_type); size within
-    // the family from storage_size. Gating on the family first separates ICs that share a
-    // storage_size across families: NTAG210/UL11 (0x0B), NTAG212/UL21 (0x0E), NTAG213/Ultralight
-    // AES (0x0F). Default to Unknown, never Origin: reaching here means GetVersion succeeded, so
-    // the IC is never a true original Ultralight (which has no GetVersion).
+    // AN10833: gate on the product family (low nibble of prod_type) before storage_size, which
+    // collides across families (0x0B, 0x0E, 0x0F). Default Unknown not Origin -- GetVersion
+    // succeeded, so this is never a true original Ultralight.
     switch(version->prod_type & 0x0F) {
     case 0x03: // MIFARE Ultralight family
         if(version->storage_size == 0x0B || version->storage_size == 0x00)

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
@@ -606,8 +606,11 @@ uint32_t mf_ultralight_get_feature_support_set(MfUltralightType type) {
 bool mf_ultralight_detect_protocol(const Iso14443_3aData* iso14443_3a_data) {
     furi_check(iso14443_3a_data);
 
-    bool mfu_detected = (iso14443_3a_data->atqa[0] == 0x44) &&
-                        (iso14443_3a_data->atqa[1] == 0x00) && (iso14443_3a_data->sak == 0x00);
+    // Ultralight/NTAG advertise SAK 0x00 with ATQA high byte 0x00. The ATQA low byte is deliberately
+    // NOT checked: it encodes UID size (0x44 for 7-byte, 0x04 for 4-byte), so a 4-byte-UID UL is
+    // still UL. Matches PM3 (rejects only atqa[1] != 0x00 || sak != 0x00); non-zero SAK (Classic and
+    // its magic clones) is excluded by the SAK term.
+    bool mfu_detected = (iso14443_3a_data->atqa[1] == 0x00) && (iso14443_3a_data->sak == 0x00);
 
     return mfu_detected;
 }

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.h
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.h
@@ -69,6 +69,9 @@ typedef enum {
     MfUltralightTypeNTAGI2C2K,
     MfUltralightTypeNTAGI2CPlus1K,
     MfUltralightTypeNTAGI2CPlus2K,
+    // GetVersion succeeded but the IC is not one we model (e.g. Ultralight AES / Nano / NTAG210);
+    // distinct from Origin, which means "no GetVersion -> original Ultralight".
+    MfUltralightTypeUnknown,
 
     MfUltralightTypeNum,
 } MfUltralightType;

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.h
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.h
@@ -69,8 +69,11 @@ typedef enum {
     MfUltralightTypeNTAGI2C2K,
     MfUltralightTypeNTAGI2CPlus1K,
     MfUltralightTypeNTAGI2CPlus2K,
-    // GetVersion succeeded but the IC is not one we model (e.g. Ultralight AES / Nano / NTAG210);
-    // distinct from Origin, which means "no GetVersion -> original Ultralight".
+    MfUltralightTypeNTAG210,
+    MfUltralightTypeNTAG212,
+    MfUltralightTypeUltralightAES,
+    // GetVersion succeeded but the IC is not one we model; distinct from Origin, which means
+    // "no GetVersion -> original Ultralight".
     MfUltralightTypeUnknown,
 
     MfUltralightTypeNum,

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_listener_i.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_listener_i.c
@@ -497,6 +497,7 @@ void mf_ultralight_dynamic_lock_bytes_write(
 static uint8_t mf_ultralight_dynamic_lock_granularity(MfUltralightType type) {
     switch(type) {
     case MfUltralightTypeUL21:
+    case MfUltralightTypeNTAG212:
     case MfUltralightTypeNTAG213:
         return 2;
     case MfUltralightTypeNTAG215:

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
@@ -300,7 +300,13 @@ static NfcCommand mf_ultralight_poller_handler_get_feature_set(MfUltralightPolle
         mf_ultralight_get_device_name(instance->data, NfcDeviceNameTypeFull),
         instance->pages_total);
 
-    instance->state = MfUltralightPollerStateReadSignature;
+    // UL-AES protects its signature (48-byte, and our reader expects 32) and every page behind AES
+    // auth we don't implement, so both reads fail -> ReadFailed -> the app retries, looping forever
+    // on "Don't move". Treat it identify-only like MIFARE Plus: report the GetVersion identification
+    // and stop.
+    instance->state = (instance->data->type == MfUltralightTypeUltralightAES) ?
+                          MfUltralightPollerStateReadSuccess :
+                          MfUltralightPollerStateReadSignature;
     return NfcCommandContinue;
 }
 

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
@@ -958,9 +958,17 @@ static bool mf_ultralight_poller_detect(NfcGenericEvent event, void* context) {
     const Iso14443_3aPollerEvent* iso14443_3a_event = event.event_data;
 
     if(iso14443_3a_event->type == Iso14443_3aPollerEventTypeReady) {
-        MfUltralightPageReadCommandData read_page_cmd_data = {};
-        MfUltralightError error = mf_ultralight_poller_read_page(instance, 0, &read_page_cmd_data);
-        protocol_detected = (error == MfUltralightErrorNone);
+        // Gate on the Ultralight SAK/ATQA before the probe read: a magic Classic clone answers an
+        // unauthenticated READ (0x30) exactly like Ultralight does, so without this gate a Chinese
+        // Mini/1K is offered as Ultralight too. Mirrors PM3, which routes only SAK 0x00 to the
+        // Ultralight path (a genuine Classic NAKs the unauth read, hence only clones misfire).
+        if(mf_ultralight_detect_protocol(
+               iso14443_3a_poller_get_data(instance->iso14443_3a_poller))) {
+            MfUltralightPageReadCommandData read_page_cmd_data = {};
+            MfUltralightError error =
+                mf_ultralight_poller_read_page(instance, 0, &read_page_cmd_data);
+            protocol_detected = (error == MfUltralightErrorNone);
+        }
         iso14443_3a_poller_halt(instance->iso14443_3a_poller);
     }
 

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
@@ -959,9 +959,8 @@ static bool mf_ultralight_poller_detect(NfcGenericEvent event, void* context) {
 
     if(iso14443_3a_event->type == Iso14443_3aPollerEventTypeReady) {
         // Gate on the Ultralight SAK/ATQA before the probe read: a magic Classic clone answers an
-        // unauthenticated READ (0x30) exactly like Ultralight does, so without this gate a Chinese
-        // Mini/1K is offered as Ultralight too. Mirrors PM3, which routes only SAK 0x00 to the
-        // Ultralight path (a genuine Classic NAKs the unauth read, hence only clones misfire).
+        // unauth READ 0x30 like Ultralight, so without this a Chinese Mini/1K also misfires as
+        // Ultralight. Mirrors PM3 (routes SAK 0x00 + ATQA hi 0x00 to the UL path).
         if(mf_ultralight_detect_protocol(
                iso14443_3a_poller_get_data(instance->iso14443_3a_poller))) {
             MfUltralightPageReadCommandData read_page_cmd_data = {};


### PR DESCRIPTION
﻿## Summary

Aligns the built-in NFC app's MIFARE **type identification** with NXP **AN10833** ("MIFARE type identification procedure"), cross-checked against Proxmark3. Fixes several mis-detections and two read hangs.

**Scope:** main app + core `lib/nfc` only. The NFC Magic app is out of scope. No authenticated memory read is added (identify-only where auth is required).

### Changes by family

**MIFARE Classic**
- Size from **SAK** (Mini `0x09`, 4K when bit `0x10` set, else 1K) instead of the behavioral block-254/62 probe (kept only as a fallback for unrecognized SAKs). Fixes a "Perfect CUID (with ATS)" magic card being mis-sized as 4K.

**MIFARE Ultralight / NTAG**
- Type from **GetVersion** `storage_size`, with the product-family nibble only as a collision tiebreak — fixes NTAG212↔UL21 and Ultralight-AES↔NTAG213 collisions.
- Added **NTAG210**, **NTAG212**, **Ultralight AES**, and an **"NTAG/Ultralight (Unknown)"** fallback for unmodelled GetVersion silicon (read-only, off the write allow-list).
- **Detection gated on the Ultralight SAK/ATQA** (`sak==0x00 && atqa[1]==0x00`) so a magic MIFARE Classic clone — which answers an unauthenticated READ `0x30` through its backdoor — is no longer *also* offered as Ultralight. (Loosened from the strict `atqa==0x0044` so 4-byte-UID Ultralight still detects, matching PM3.)
- **Ultralight AES**: handled **identity-only** (like MIFARE Plus) — no more "Don't move" freeze (its 48-byte signature + AES-gated pages can't be read); UID-only emulate; no misleading Unlock/More views.

**MIFARE Plus**
- Active **WritePerso (`0xA8`) probe** distinguishes **SL0 vs SL3** (and rules out DESFire) where SAK/ATS cannot.
- Security level from the SAK bit map; **EV1/EV2 via GetVersion** (trusts a complete, valid version block even when the native frame ends with a non-`0x00` status); **2K/4K size from ATQA** for SL0/SL3.
- Dropped the AN10833-forbidden ATS/ATQA over-claims from the fallback path (generic "Plus" instead of guessing S/X).

Full rationale is in the 17 commit messages.

### Not included (deliberate)
- Authenticated **memory read** for MIFARE Plus / Ultralight AES (needs Crypto1 / AES-128 auth) — identify-only by design.
- `mf_classic_poller_sync_detect_type` parity gap — a second, still-behavioral Classic sizing path used by ~25 `supported_cards` parsers — deferred to a follow-up.

## Test matrix

Grouped per family as checkable lists (GitHub task-list checkboxes are clickable; table cells are not). **Pre-ticked = confirmed on real hardware during development; please adjust as you re-verify.**

### MIFARE Classic
- [x] Mini (SAK `0x09`) → "Mifare Mini 0.3K"
- [x] 1K (SAK `0x08`) → "MIFARE Classic 1K"
- [x] 4K (SAK `0x18`) → "MIFARE Classic 4K"
- [x] Chinese/magic **Mini** clone (4b & 7b UID) → now correctly detected as **Mifare Mini** and **no longer (also) offered as Ultralight** — fixes the documented *"Mifare Mini clones reading is broken"* post-refactor regression
- [x] Magic CUID / gen1a **1K** with ATS → 1K (not 4K)
- [x] SmartMX with MIFARE Classic 1K

### MIFARE Ultralight / NTAG
- [x] Ultralight (original MF0ICU1)
- [x] Ultralight C
- [x] Ultralight EV1 — **UL11** (20 pages)
- [x] Ultralight EV1 — **UL21** (41 pages)
- [x] **Ultralight AES** → identity-only (Tech + UID), no hang, "Emulate UID", no Unlock/"More"
- [x] NTAG203
- [ ] **NTAG210** (new)
- [ ] **NTAG212** (new)
- [x] NTAG213
- [x] NTAG215
- [x] NTAG216
- [ ] NTAG I2C 1K / 2K
- [ ] NTAG I2C Plus 1K / 2K

### MIFARE Plus
- [x] Plus S / X / SE — SL1
- [x] Plus S / X — SL3
- [x] Plus **EV1 4K** — **SL0** → "MIFARE Plus EV1 4K SL0" (was mis-read as "Plus X")
- [x] Plus EV1 — SL1 / SL2 / SL3
- [ ] Plus EV1 **2K**
- [ ] Plus **EV2** (2K / 4K)
- [x] SL0 vs SL3 correctly distinguished (WritePerso probe)

### MIFARE DESFire (regression guard — each must still be detected as **DESFire**, not Plus/Ultralight)
- [ ] DESFire (original / MF3ICD40)
- [x] DESFire EV1
- [ ] DESFire EV2
- [ ] DESFire EV3
- [ ] DESFire Light

🤖 Generated with [Claude Code](https://claude.com/claude-code)


