### PR TITLE
[NFC]: Read MIFARE Plus 2K (SL1) as full 32 sectors / 64 keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * NFC: Show MIFARE Ultralight/NTAG PWD & PACK in full info view / on read screen too (by @mishamyte | PR #1010 #1011)
 * NFC: **Add Bambu Lab filament spool parser** (type, color, code, temps, spool specs) (ported from [uzyn/flipper-bambu](https://github.com/uzyn/flipper-bambu), GPL-3.0)
 * NFC: **Align MIFARE type detection with NXP AN10833** - Classic/Ultralight/NTAG/Plus sizing & security level; fixes Mifare Mini clone mis-detection and Ultralight AES read hang (by @mishamyte | PR #1014)
+* NFC: **Read MIFARE Plus 2K in SL1 as full 32 sectors / 64 keys** - a Plus 2K in SL1 is byte-identical to a Classic 1K in SAK/ATQA and was mis-sized as 1K; it is now told apart by its ISO14443-4 ATS (Plus S/X signature), while Plus SE, SmartMX, magic "Perfect CUID" and plain 1K stay 1K (by @mishamyte | PR #1016)
 * RPC: **Add Network and GPS RPC services** (by @apfxtech (Network based on @noproto code and idea) | PR #1013)
 * Apps: **NFC Magic** - Gen2 CUID/static-nonce detection, Gen1 4b/7b UID, length-aware wipe & write guard (by @mishamyte)
 * Apps: Build tag (**2jul2026**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)

--- a/applications/main/nfc/plugins/supported_cards/ndef.c
+++ b/applications/main/nfc/plugins/supported_cards/ndef.c
@@ -894,7 +894,7 @@ static bool ndef_mfc_parse(const NfcDevice* device, FuriString* parsed_data) {
 
     // Check card type can contain NDEF
     if(data->type != MfClassicType1k && data->type != MfClassicType4k &&
-       data->type != MfClassicTypeMini) {
+       data->type != MfClassicTypeMini && data->type != MfClassicType2k) {
         return false;
     }
 

--- a/lib/nfc/nfc_scanner.c
+++ b/lib/nfc/nfc_scanner.c
@@ -173,7 +173,10 @@ static void nfc_scanner_filter_detected_protocols(NfcScanner* instance) {
     }
 
     instance->detected_protocols_num = filtered_protocols_num;
-    memcpy(instance->detected_protocols, filtered_protocols, filtered_protocols_num);
+    memcpy(
+        instance->detected_protocols,
+        filtered_protocols,
+        filtered_protocols_num * sizeof(NfcProtocol));
 }
 
 void nfc_scanner_state_handler_complete(NfcScanner* instance) {

--- a/lib/nfc/protocols/mf_classic/mf_classic.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic.c
@@ -38,6 +38,14 @@ static const MfClassicFeatures mf_classic_features[MfClassicTypeNum] = {
             .full_name = "Mifare Classic 4K",
             .type_name = "4K",
         },
+    [MfClassicType2k] =
+        {
+            // No Classic 2K product exists -- a MIFARE Plus 2K in SL1 (the lower half of a 4K).
+            .sectors_total = 32,
+            .blocks_total = 128,
+            .full_name = "Mifare Plus 2K (SL1)",
+            .type_name = "2K",
+        },
 };
 
 const NfcDeviceBase nfc_device_mf_classic = {

--- a/lib/nfc/protocols/mf_classic/mf_classic.h
+++ b/lib/nfc/protocols/mf_classic/mf_classic.h
@@ -49,6 +49,9 @@ typedef enum {
     MfClassicTypeMini,
     MfClassicType1k,
     MfClassicType4k,
+    // Appended last on purpose: keeps Mini/1k/4k values stable for precompiled FAPs and any
+    // type-indexed array. Not a Classic product -- a MIFARE Plus 2K in SL1 (see the poller).
+    MfClassicType2k,
 
     MfClassicTypeNum,
 } MfClassicType;

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller.c
@@ -124,6 +124,76 @@ static void mf_classic_poller_check_key_b_is_readable(
     } while(false);
 }
 
+// A Classic 1K and a MIFARE Plus 2K SL1 share SAK 0x08 + ATQA 0x0004; only the ISO14443-4 ATS
+// separates them (a Plus answers RATS, a 1K never does). Plus SE and any forged/absent ATS ("Perfect
+// CUID" magic) match nothing here, so they stay 1K. DUPLICATED from mf_plus_ats_t1_tk_values[0..1] in
+// mf_plus_i.c -- keep in sync (not header-shared, to keep the Classic poller off the mf_plus stack).
+static const uint8_t mf_classic_plus_2k_sl1_ats_tk[][7] = {
+    {0xC1, 0x05, 0x2F, 0x2F, 0x00, 0x35, 0xC7}, // Mifare Plus S 2K
+    {0xC1, 0x05, 0x2F, 0x2F, 0x01, 0xBC, 0xD6}, // Mifare Plus X 2K (EV1/EV2 share this ATS)
+};
+
+// RATS (Request for Answer To Select). Param byte: FSDI = 8 (256-byte frame), CID = 0. FWT is the
+// ISO14443-4 default for ATS (= ISO14443_4A_POLLER_ATS_FWT_FC; copied to avoid the 4a dependency).
+#define MF_CLASSIC_RATS_CMD    (0xE0)
+#define MF_CLASSIC_RATS_PARAM  (0x80)
+#define MF_CLASSIC_RATS_FWT_FC (40000)
+
+// ATS T0 optional interface-byte presence bits (ISO14443-4).
+#define MF_CLASSIC_ATS_T0_TA1 (1U << 4)
+#define MF_CLASSIC_ATS_T0_TB1 (1U << 5)
+#define MF_CLASSIC_ATS_T0_TC1 (1U << 6)
+
+// Do the historical bytes of an ATS (CRC already trimmed by the caller) identify a MIFARE Plus 2K
+// SL1? Bounds-safe against a lying/short/oversized TL.
+static bool mf_classic_ats_is_plus_2k_sl1(const uint8_t* ats, size_t ats_size) {
+    if(ats_size < 2) return false;
+
+    // TL counts the ATS bytes up to (not including) the CRC; clamp to what we actually received.
+    size_t tl = ats[0];
+    if(tl > ats_size) tl = ats_size;
+
+    // Skip TL, T0 and the optional interface bytes to reach the historical bytes T1..Tk.
+    size_t offset = 2;
+    const uint8_t t0 = ats[1];
+    if(t0 & MF_CLASSIC_ATS_T0_TA1) offset++;
+    if(t0 & MF_CLASSIC_ATS_T0_TB1) offset++;
+    if(t0 & MF_CLASSIC_ATS_T0_TC1) offset++;
+    if(offset > tl) return false;
+
+    const size_t tk_len = sizeof(mf_classic_plus_2k_sl1_ats_tk[0]);
+    if(tl - offset != tk_len) return false;
+    for(size_t i = 0; i < COUNT_OF(mf_classic_plus_2k_sl1_ats_tk); i++) {
+        if(memcmp(&ats[offset], mf_classic_plus_2k_sl1_ats_tk[i], tk_len) == 0) return true;
+    }
+    return false;
+}
+
+// Send RATS and classify the ATS. Leaving the card in ISO14443-4 afterwards is safe: DetectType
+// returns NfcCommandReset, which power-cycles the field and re-activates the card before the next
+// poller phase.
+static bool mf_classic_poller_is_plus_2k_sl1(MfClassicPoller* instance) {
+    bit_buffer_reset(instance->tx_plain_buffer);
+    bit_buffer_append_byte(instance->tx_plain_buffer, MF_CLASSIC_RATS_CMD);
+    bit_buffer_append_byte(instance->tx_plain_buffer, MF_CLASSIC_RATS_PARAM);
+
+    Iso14443_3aError error = iso14443_3a_poller_send_standard_frame(
+        instance->iso14443_3a_poller,
+        instance->tx_plain_buffer,
+        instance->rx_plain_buffer,
+        MF_CLASSIC_RATS_FWT_FC);
+    if(error != Iso14443_3aErrorNone) return false; // no ATS -> not a Plus
+
+    const size_t ats_size = bit_buffer_get_size_bytes(instance->rx_plain_buffer);
+    if(mf_classic_ats_is_plus_2k_sl1(bit_buffer_get_data(instance->rx_plain_buffer), ats_size)) {
+        return true;
+    }
+
+    // Answered RATS but ATS isn't a known Plus 2K sig (Plus SE, SL0/SL3, variant, or clone); stay 1K.
+    FURI_LOG_D(TAG, "RATS answered but ATS not Plus 2K (%u B); staying 1K", (unsigned)ats_size);
+    return false;
+}
+
 NfcCommand mf_classic_poller_handler_detect_type(MfClassicPoller* instance) {
     NfcCommand command = NfcCommandReset;
 
@@ -146,10 +216,16 @@ NfcCommand mf_classic_poller_handler_detect_type(MfClassicPoller* instance) {
         instance->state = MfClassicPollerStateStart;
         FURI_LOG_D(TAG, "4K detected (SAK)");
     } else if(sak & 0x08) { // bit3 -> 1K (0x08, SmartMX+Classic 0x28)
-        instance->data->type = MfClassicType1k;
+        // SAK 0x08 is also MIFARE Plus 2K SL1; only a matching ATS promotes to 2K (see above).
+        if(mf_classic_poller_is_plus_2k_sl1(instance)) {
+            instance->data->type = MfClassicType2k;
+            FURI_LOG_D(TAG, "Plus 2K SL1 detected (SAK 08 + ATS)");
+        } else {
+            instance->data->type = MfClassicType1k;
+            FURI_LOG_D(TAG, "1K detected (SAK)");
+        }
         instance->current_type_check = MfClassicType4k;
         instance->state = MfClassicPollerStateStart;
-        FURI_LOG_D(TAG, "1K detected (SAK)");
     } else if(instance->current_type_check == MfClassicType4k) {
         MfClassicError error =
             mf_classic_poller_get_nt(instance, 254, MfClassicKeyTypeA, NULL, false);

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller_sync.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller_sync.c
@@ -504,18 +504,24 @@ MfClassicError mf_classic_poller_sync_detect_type(Nfc* nfc, MfClassicType* type)
 
     MfClassicError error = MfClassicErrorNone;
 
-    const uint8_t mf_classic_verify_block[MfClassicTypeNum] = {
-        [MfClassicTypeMini] = 0,
-        [MfClassicType1k] = 62,
-        [MfClassicType4k] = 254,
+    // Probe a block unique to each size, largest first (block 0 is the always-present Mini fallback).
+    // 2K is intentionally absent: block presence can't separate a Plus 2K SL1 from a magic 1K that
+    // answers every block, so this path reports only Mini/1K/4K -- a genuine 2K is ATS-sized in the
+    // read poller (mf_classic_poller_handler_detect_type).
+    static const struct {
+        uint8_t verify_block;
+        MfClassicType type;
+    } mf_classic_verify[] = {
+        {254, MfClassicType4k},
+        {62, MfClassicType1k},
+        {0, MfClassicTypeMini},
     };
 
-    size_t i = 0;
-    for(i = 0; i < COUNT_OF(mf_classic_verify_block); i++) {
+    for(size_t i = 0; i < COUNT_OF(mf_classic_verify); i++) {
         error = mf_classic_poller_sync_collect_nt(
-            nfc, mf_classic_verify_block[MfClassicTypeNum - i - 1], MfClassicKeyTypeA, NULL);
+            nfc, mf_classic_verify[i].verify_block, MfClassicKeyTypeA, NULL);
         if(error == MfClassicErrorNone) {
-            *type = MfClassicTypeNum - i - 1;
+            *type = mf_classic_verify[i].type;
             break;
         }
     }


### PR DESCRIPTION
## What

MIFARE Plus **2K** cards running in **Security Level 1 (SL1)** are now read as their full **32 sectors / 64 keys**, instead of being mis-sized as a MIFARE Classic **1K** (16 sectors / 32 keys).

## Why

In SL1 a MIFARE Plus is a drop-in MIFARE Classic and is dumped over the Classic command set. But a Plus 2K in SL1 is **byte-identical to a Classic 1K** in both SAK (`0x08`) and ATQA (`0x0004`), so the poller sized it as 1K and read only the lower half of the card. MIFARE Classic also had no 2K type at all. (Fixes #917.)

## How

- Add a `MfClassicType2k` — 32 sectors / 128 blocks / 64 keys (the lower half of a 4K's geometry).
- In the Classic poller's `sak & 0x08` branch, probe **RATS**: a genuine Plus answers with an ATS, a Classic 1K never does. Promote to 2K **only** when the ATS historical bytes are an exact match for a Plus **S/X** signature (`C1 05 2F 2F 00/01`). This is content-based, not mere RATS-presence, so:
  - Plus **SE** (1K, distinct ATS `C1 05 21 30`) stays 1K,
  - a magic "Perfect CUID" or a SmartMX (both answer RATS, but with a non-Plus ATS) stays 1K,
  - a plain Classic 1K (no ATS) stays 1K.
- Harden the sync detector so appending the enum value can't make every card mis-probe as 2K.
- Accept 2K in the NDEF supported-card guard.
- Fix a pre-existing `memcpy` size bug in `nfc_scanner` (`NfcProtocol[]` copied as a byte count) that multi-protocol Classic + Plus cards exercise.

The Classic poller stays on the ISO14443-3 layer (no new dependency on the `mf_plus` / ISO14443-4 modules); the two Plus S/X ATS signatures are duplicated with a keep-in-sync note.

## Known limitations

- **Emulation identity** — the Classic listener is ISO14443-3 only, so an emulated 2K answers no RATS/ATS and a re-reading device auto-detects it as a **1K (16 sectors)**. All 32 sectors of data are present and served (per-sector reads of sectors 16–31 work); only the auto-sizing degrades. Full-fidelity 2K emulation would need a RATS→ATS handler in the listener — out of scope here.
- **Cross-firmware** — a saved 2K `.nfc` uses `Mifare Classic type: 2K`; firmware without this feature can't load it (unknown type → clean load-fail, no crash).

## Verification — manual QA

Validated on hardware (release build). Cases exercise every branch of the MIFARE Classic `detect_type` sizing path, both false-positive guards (cards that answer RATS but are not a Plus 2K), and the full dump → save → load → emulate lifecycle.

### Read — detection & sizing

| # | Card | Expected | Result |
|---|---|---|---|
| R1 | MIFARE Classic 1K (4-byte UID) | Detected correctly, 16 sectors | ✅ Pass |
| R2 | MIFARE Classic 1K (7-byte UID) | Detected correctly, 16 sectors | ✅ Pass |
| R3 | MIFARE Classic 4K (4-byte UID) | Detected correctly, 40 sectors | ✅ Pass |
| R4 | MIFARE Classic 4K (7-byte UID) | Detected correctly, 40 sectors | ✅ Pass |
| R5 | MIFARE Mini (4-byte UID) | Detected correctly, 5 sectors | ✅ Pass |
| R6 | MIFARE Mini (7-byte UID) | Detected correctly, 5 sectors | ✅ Pass |
| R7 | Perfect CUID magic 1K (with ATS) | Multiprotocol; read as MFC → 16 sectors | ✅ Pass |
| R8 | SmartMX + MFC 1K (SAK 0x28) | Multiprotocol; read as MFC → 16 sectors | ✅ Pass |
| R9 | **MIFARE Plus S/X 2K, SL1** | Multiprotocol; read as MFC → **32 sectors** | ✅ Pass |
| R10 | MIFARE Plus S/X 4K, SL1 | Multiprotocol; read as MFC → 40 sectors | ✅ Pass |
| R11 | MIFARE Plus SE 1K, SL1 | Multiprotocol; read as MFC → 16 sectors (distinct ATS, excluded) | ⚠️ Not tested — no card ¹ |

### Dump — full read → save → load

| # | Card | Expected | Result |
|---|---|---|---|
| D1 | MIFARE Plus S/X 2K, SL1 | Dump saved; `Device type` = Mifare Classic, `Mifare Classic type` = 2K; all blocks 0–127 present (full read) | ✅ Pass |
| D2 | MIFARE Plus S/X 2K, SL1 (saved dump) | Dump loads; Sectors Read = 32; "Show Keys" correct for all 32 sectors | ✅ Pass |
| D3 | Same dump on **old FW** (pre-feature) | Can't load unknown type "2K"; no crash; clear error message | ✅ Pass |

### Emulate

| # | Scenario | Expected | Result |
|---|---|---|---|
| E1 | Emulate 2K dump, read back with a 2nd device | Detected as MFC 1K, 16/16 sectors read (no ATS emitted — expected limitation ²) | ✅ Pass |
| E2 | Emulate 2K dump; per-sector read of sectors 16–31 | Upper-half sectors served & read correctly — emulation is data-complete | ✅ Pass |

**Result: 15/16 pass, 1 documented not-tested** (Plus SE — no card on hand).

<sub>¹ The SE-exclusion is exercised on hardware by R7/R8 (a card that answers RATS with a non-S/X ATS stays 1K) and holds by construction (the matcher requires an exact 7-byte match against the Plus S/X signatures only); SE's own HW confirmation is pending a card.</sub>
<sub>² The Classic listener is ISO14443-3 only (no RATS/ATS), so an emulated 2K auto-detects as 1K. Full-fidelity 2K emulation would need a RATS→ATS handler in the listener — out of scope for this read fix.</sub>

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)
