### PR TITLE
chore: align issue-template labels with new namespaced taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: File a bug reports regarding the firmware.
-labels: ["bug"]
+labels: ["type/bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02_enhancements.yml
+++ b/.github/ISSUE_TEMPLATE/02_enhancements.yml
@@ -1,5 +1,6 @@
 name: Enhancements
 description: Suggest improvements for any existing functionality within the firmware.
+labels: ["type/enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/03_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/03_feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: For feature requests regarding the firmware.
-labels: ["feature request"]
+labels: ["type/feature"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## What

The repository labels were reorganized into consistent namespaces — `type/*`, `status/*`, `resolution/*`, and `area/*`. This updates the three issue templates so their auto-applied labels match the new names.

| template | before | after |
|---|---|---|
| `01_bug_report.yml` | `bug` | `type/bug` |
| `03_feature_request.yml` | `feature request` | `type/feature` |
| `02_enhancements.yml` | *(none)* | `type/enhancement` |

## Why

The label renames were done via the API (assignments are preserved on rename), but the templates still referenced the old flat names. Until this merges, new bug/feature reports won't be auto-labeled. The enhancements template previously applied no label at all — now fixed.

No functional/firmware changes; issue templates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)