### PR TITLE
[CI]: Auto-label PRs with area/* based on changed paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,126 @@
+# Auto-applies area/* labels to PRs based on the paths they touch.
+# Used by .github/workflows/labeler.yml (actions/labeler@v5).
+# sync-labels is off, so these only ADD labels — manual labels are never stripped.
+
+"area/nfc":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "lib/nfc/**"
+          - "applications/main/nfc/**"
+
+"area/subghz":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "lib/subghz/**"
+          - "applications/main/subghz/**"
+          - "applications/main/subghz_remote/**"
+          - "applications/debug/subghz_test/**"
+
+"area/lf-rfid":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "lib/lfrfid/**"
+          - "applications/main/lfrfid/**"
+          - "applications/debug/lfrfid_debug/**"
+
+"area/infrared":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "lib/infrared/**"
+          - "applications/main/infrared/**"
+          - "applications/debug/infrared_test/**"
+
+"area/ibutton":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "lib/ibutton/**"
+          - "lib/one_wire/**"
+          - "applications/main/ibutton/**"
+          - "applications/main/onewire/**"
+
+"area/gpio":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "applications/main/gpio/**"
+          - "applications/debug/uart_echo/**"
+
+"area/bluetooth":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "applications/services/bt/**"
+          - "applications/settings/bt_settings_app/**"
+          - "applications/debug/bt_debug_app/**"
+          - "lib/ble_profile/**"
+          - "lib/stm32wb_copro/**"
+
+"area/ui":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "applications/services/gui/**"
+          - "applications/services/desktop/**"
+          - "applications/services/notification/**"
+          - "applications/services/dolphin/**"
+          - "applications/settings/desktop_settings/**"
+          - "applications/settings/notification_settings/**"
+          - "applications/settings/dolphin_passport/**"
+          - "assets/dolphin/**"
+          - "assets/icons/**"
+          - "assets/slideshow/**"
+
+"area/apps":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "lib/mjs/**"
+          - "lib/flipper_application/**"
+          - "applications/system/js_app/**"
+          - "applications/examples/**"
+
+"area/storage":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "applications/services/storage/**"
+          - "applications/settings/storage_settings/**"
+          - "lib/fatfs/**"
+          - "lib/flipper_format/**"
+
+"area/rpc":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "applications/services/rpc/**"
+          - "applications/services/cli/**"
+          - "applications/services/network/**"
+          - "applications/services/gps/**"
+          - "applications/debug/rpc_debug_app/**"
+          - "lib/nanopb/**"
+          - "assets/protobuf/**"
+
+"area/badusb":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "applications/main/bad_usb/**"
+
+"area/ci-build":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - ".ci_files/**"
+          - "scripts/**"
+          - "site_scons/**"
+          - "SConstruct"
+          - "firmware.scons"
+          - "fbt"
+          - "fbt.cmd"
+          - "fbt_options.py"
+
+"area/system":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "furi/**"
+          - "targets/**"
+          - "lib/update_util/**"
+          - "lib/toolbox/**"
+          - "applications/system/updater/**"
+          - "applications/services/power/**"
+          - "applications/services/input/**"
+          - "applications/services/loader/**"
+          - "applications/services/expansion/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,21 @@
+name: "PR Labeler"
+
+# Auto-labels PRs with area/* based on the files they touch (see .github/labeler.yml).
+# pull_request_target is used so PRs from forks can be labeled too — this workflow
+# never checks out or runs PR code, so it is safe against the usual _target risks.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          # Only add labels; never strip labels applied by hand.
+          sync-labels: false


### PR DESCRIPTION
## What

Adds an [`actions/labeler`](https://github.com/actions/labeler) config + workflow that automatically applies the `area/*` labels to a PR based on which files it changes. This keeps the new subsystem taxonomy applied to PRs going forward without anyone tagging them by hand.

- **`.github/labeler.yml`** — maps source paths to each of the 14 `area/*` labels (e.g. `lib/nfc/**` + `applications/main/nfc/**` → `area/nfc`).
- **`.github/workflows/labeler.yml`** — runs the labeler on PR open/sync/reopen.

## Notes

- `sync-labels: false` — the workflow **only adds** labels, it never removes ones applied by hand.
- Triggered via `pull_request_target` so PRs from forks can be labeled (the default `pull_request` token from a fork is read-only). The workflow **never checks out or executes PR code**, so it is not exposed to the usual `pull_request_target` code-injection risk — it only reads the changed-file list and applies labels.

## Follow-up ideas (not in this PR)

- A companion `release-drafter` config could then group release notes by these labels, making a release cut close to one click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)