### PR TITLE
[NFC]: Show a loading screen while a large CUID dictionary loads on Read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * NFC: **Add Bambu Lab filament spool parser** (type, color, code, temps, spool specs) (ported from [uzyn/flipper-bambu](https://github.com/uzyn/flipper-bambu), GPL-3.0)
 * NFC: **Align MIFARE type detection with NXP AN10833** - Classic/Ultralight/NTAG/Plus sizing & security level; fixes Mifare Mini clone mis-detection and Ultralight AES read hang (by @mishamyte | PR #1014)
 * NFC: **Read MIFARE Plus 2K in SL1 as full 32 sectors / 64 keys** - a Plus 2K in SL1 is byte-identical to a Classic 1K in SAK/ATQA and was mis-sized as 1K; it is now told apart by its ISO14443-4 ATS (Plus S/X signature), while Plus SE, SmartMX, magic "Perfect CUID" and plain 1K stay 1K (by @mishamyte | PR #1016)
+* NFC: **Show a loading screen while a large CUID dictionary loads on Read** - animated spinner + "CUID dictionary is loading" label instead of a blank/frozen-looking screen while a per-UID (MFKey-recovered) dictionary is scanned (by @mishamyte | PR #1022)
 * RPC: **Add Network and GPS RPC services** (by @apfxtech (Network based on @noproto code and idea) | PR #1013)
 * Apps: **NFC Magic** - Gen2 CUID/static-nonce detection, Gen1 4b/7b UID, length-aware wipe & write guard (by @mishamyte)
 * Apps: Build tag (**2jul2026**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)

--- a/applications/main/nfc/nfc_app.c
+++ b/applications/main/nfc/nfc_app.c
@@ -98,6 +98,13 @@ NfcApp* nfc_app_alloc(void) {
     view_dispatcher_add_view(
         instance->view_dispatcher, NfcViewLoading, loading_get_view(instance->loading));
 
+    // Loading with label
+    instance->loading_label = loading_label_alloc();
+    view_dispatcher_add_view(
+        instance->view_dispatcher,
+        NfcViewLoadingLabel,
+        loading_label_get_view(instance->loading_label));
+
     // Text Input
     instance->text_input = text_input_alloc();
     view_dispatcher_add_view(
@@ -176,6 +183,10 @@ void nfc_app_free(NfcApp* instance) {
     // Loading
     view_dispatcher_remove_view(instance->view_dispatcher, NfcViewLoading);
     loading_free(instance->loading);
+
+    // Loading with label
+    view_dispatcher_remove_view(instance->view_dispatcher, NfcViewLoadingLabel);
+    loading_label_free(instance->loading_label);
 
     // TextInput
     view_dispatcher_remove_view(instance->view_dispatcher, NfcViewTextInput);
@@ -435,17 +446,27 @@ bool nfc_load_from_file_select(NfcApp* instance) {
     return success;
 }
 
-void nfc_show_loading_popup(void* context, bool show) {
-    NfcApp* nfc = context;
-
+// Show a loading view (raising timer priority so its animation plays) or restore priority on hide.
+static void nfc_show_loading_view(NfcApp* nfc, NfcView view, bool show) {
     if(show) {
         // Raise timer priority so that animations can play
         furi_timer_set_thread_priority(FuriTimerThreadPriorityElevated);
-        view_dispatcher_switch_to_view(nfc->view_dispatcher, NfcViewLoading);
+        view_dispatcher_switch_to_view(nfc->view_dispatcher, view);
     } else {
         // Restore default timer priority
         furi_timer_set_thread_priority(FuriTimerThreadPriorityNormal);
     }
+}
+
+void nfc_show_loading_popup(void* context, bool show) {
+    NfcApp* nfc = context;
+    nfc_show_loading_view(nfc, NfcViewLoading, show);
+}
+
+void nfc_show_loading_label_popup(void* context, const char* text, bool show) {
+    NfcApp* nfc = context;
+    if(show) loading_label_set_text(nfc->loading_label, text);
+    nfc_show_loading_view(nfc, NfcViewLoadingLabel, show);
 }
 
 void nfc_append_filename_string_when_present(NfcApp* instance, FuriString* string) {

--- a/applications/main/nfc/nfc_app_i.h
+++ b/applications/main/nfc/nfc_app_i.h
@@ -23,6 +23,7 @@
 #include "views/dict_attack.h"
 #include "views/detect_reader.h"
 #include "views/dict_attack.h"
+#include "views/loading_label.h"
 
 #include <nfc/scenes/nfc_scene.h>
 #include "helpers/nfc_detected_protocols.h"
@@ -160,6 +161,7 @@ struct NfcApp {
     DialogEx* dialog_ex;
     Popup* popup;
     Loading* loading;
+    LoadingLabel* loading_label;
     TextInput* text_input;
     ByteInput* byte_input;
     TextBox* text_box;
@@ -203,6 +205,7 @@ typedef enum {
     NfcViewWidget,
     NfcViewDictAttack,
     NfcViewDetectReader,
+    NfcViewLoadingLabel,
 } NfcView;
 
 typedef enum {
@@ -229,6 +232,9 @@ void nfc_blink_detect_start(NfcApp* nfc);
 void nfc_blink_stop(NfcApp* nfc);
 
 void nfc_show_loading_popup(void* context, bool show);
+
+// Like nfc_show_loading_popup, but with a text label beside the spinner (e.g. naming a slow load).
+void nfc_show_loading_label_popup(void* context, const char* text, bool show);
 
 bool nfc_has_shadow_file(NfcApp* instance);
 

--- a/applications/main/nfc/scenes/nfc_scene_mf_classic_dict_attack.c
+++ b/applications/main/nfc/scenes/nfc_scene_mf_classic_dict_attack.c
@@ -354,15 +354,15 @@ void nfc_scene_mf_classic_dict_attack_on_enter(void* context) {
     scene_manager_set_scene_state(
         instance->scene_manager, NfcSceneMfClassicDictAttack, DictAttackStateCUIDDictInProgress);
 
-    // A per-UID ("CUID") dictionary can be large; scanning it in prepare_view blocks the UI,
-    // so show the animated loading popup meanwhile (as nfc_scene_read does for its cache load).
+    // A per-UID ("CUID") dictionary can be large; scanning it in prepare_view blocks the UI, so
+    // show a labelled animated loading view meanwhile.
     FuriString* cuid_dict_path = nfc_scene_mf_classic_dict_attack_cuid_dict_path(instance);
     bool show_loading = keys_dict_check_presence(furi_string_get_cstr(cuid_dict_path));
     furi_string_free(cuid_dict_path);
 
-    if(show_loading) nfc_show_loading_popup(instance, true);
+    if(show_loading) nfc_show_loading_label_popup(instance, "CUID dictionary\nis loading", true);
     nfc_scene_mf_classic_dict_attack_prepare_view(instance);
-    if(show_loading) nfc_show_loading_popup(instance, false);
+    if(show_loading) nfc_show_loading_label_popup(instance, NULL, false);
 
     dict_attack_set_card_state(instance->dict_attack, true);
     view_dispatcher_switch_to_view(instance->view_dispatcher, NfcViewDictAttack);

--- a/applications/main/nfc/scenes/nfc_scene_mf_classic_dict_attack.c
+++ b/applications/main/nfc/scenes/nfc_scene_mf_classic_dict_attack.c
@@ -219,16 +219,21 @@ static void nfc_scene_mf_classic_dict_attack_update_view(NfcApp* instance) {
     }
 }
 
+// Per-UID ("CUID") dictionary path for the detected card (MFKey-recovered keys live here).
+static FuriString* nfc_scene_mf_classic_dict_attack_cuid_dict_path(NfcApp* instance) {
+    size_t cuid_len = 0;
+    const uint8_t* cuid = nfc_device_get_uid(instance->nfc_device, &cuid_len);
+    return furi_string_alloc_printf(
+        "%s/mf_classic_dict_%08lx.nfc",
+        EXT_PATH("nfc/assets"),
+        (uint32_t)bit_lib_bytes_to_num_be(cuid + (cuid_len - 4), 4));
+}
+
 static void nfc_scene_mf_classic_dict_attack_prepare_view(NfcApp* instance) {
     uint32_t state =
         scene_manager_get_scene_state(instance->scene_manager, NfcSceneMfClassicDictAttack);
     if(state == DictAttackStateCUIDDictInProgress) {
-        size_t cuid_len = 0;
-        const uint8_t* cuid = nfc_device_get_uid(instance->nfc_device, &cuid_len);
-        FuriString* cuid_dict_path = furi_string_alloc_printf(
-            "%s/mf_classic_dict_%08lx.nfc",
-            EXT_PATH("nfc/assets"),
-            (uint32_t)bit_lib_bytes_to_num_be(cuid + (cuid_len - 4), 4));
+        FuriString* cuid_dict_path = nfc_scene_mf_classic_dict_attack_cuid_dict_path(instance);
 
         do {
             if(!keys_dict_check_presence(furi_string_get_cstr(cuid_dict_path))) {
@@ -348,7 +353,17 @@ void nfc_scene_mf_classic_dict_attack_on_enter(void* context) {
 
     scene_manager_set_scene_state(
         instance->scene_manager, NfcSceneMfClassicDictAttack, DictAttackStateCUIDDictInProgress);
+
+    // A per-UID ("CUID") dictionary can be large; scanning it in prepare_view blocks the UI,
+    // so show the animated loading popup meanwhile (as nfc_scene_read does for its cache load).
+    FuriString* cuid_dict_path = nfc_scene_mf_classic_dict_attack_cuid_dict_path(instance);
+    bool show_loading = keys_dict_check_presence(furi_string_get_cstr(cuid_dict_path));
+    furi_string_free(cuid_dict_path);
+
+    if(show_loading) nfc_show_loading_popup(instance, true);
     nfc_scene_mf_classic_dict_attack_prepare_view(instance);
+    if(show_loading) nfc_show_loading_popup(instance, false);
+
     dict_attack_set_card_state(instance->dict_attack, true);
     view_dispatcher_switch_to_view(instance->view_dispatcher, NfcViewDictAttack);
     nfc_blink_read_start(instance);

--- a/applications/main/nfc/views/loading_label.c
+++ b/applications/main/nfc/views/loading_label.c
@@ -1,0 +1,106 @@
+#include "loading_label.h"
+
+#include <gui/icon_animation.h>
+#include <gui/elements.h>
+#include <gui/canvas.h>
+#include <gui/view.h>
+#include <input/input.h>
+
+#include <furi.h>
+#include <assets_icons.h>
+
+struct LoadingLabel {
+    View* view;
+};
+
+typedef struct {
+    IconAnimation* icon;
+    const char* text;
+} LoadingLabelModel;
+
+static void loading_label_draw_callback(Canvas* canvas, void* _model) {
+    LoadingLabelModel* model = _model;
+
+    canvas_set_color(canvas, ColorWhite);
+    canvas_draw_box(canvas, 0, 0, canvas_width(canvas), canvas_height(canvas));
+    canvas_set_color(canvas, ColorBlack);
+
+    // Spinner on the left, vertically centered
+    const uint8_t icon_x = 12;
+    const uint8_t icon_y = canvas_height(canvas) / 2 - 24 / 2;
+    canvas_draw_icon(canvas, icon_x, icon_y, &A_Loading_24);
+    canvas_draw_icon_animation(canvas, icon_x, icon_y, model->icon);
+
+    // Label to the right of the spinner
+    if(model->text) {
+        canvas_set_font(canvas, FontPrimary);
+        elements_multiline_text_aligned(
+            canvas, 82, canvas_height(canvas) / 2, AlignCenter, AlignCenter, model->text);
+    }
+}
+
+static bool loading_label_input_callback(InputEvent* event, void* context) {
+    UNUSED(event);
+    furi_assert(context);
+    // Consume all input while loading
+    return true;
+}
+
+static void loading_label_enter_callback(void* context) {
+    furi_assert(context);
+    LoadingLabel* instance = context;
+    LoadingLabelModel* model = view_get_model(instance->view);
+    view_tie_icon_animation(instance->view, model->icon);
+    icon_animation_start(model->icon);
+    view_commit_model(instance->view, false);
+}
+
+static void loading_label_exit_callback(void* context) {
+    furi_assert(context);
+    LoadingLabel* instance = context;
+    LoadingLabelModel* model = view_get_model(instance->view);
+    icon_animation_stop(model->icon);
+    view_commit_model(instance->view, false);
+}
+
+LoadingLabel* loading_label_alloc(void) {
+    LoadingLabel* instance = malloc(sizeof(LoadingLabel));
+    instance->view = view_alloc();
+    view_allocate_model(instance->view, ViewModelTypeLocking, sizeof(LoadingLabelModel));
+    LoadingLabelModel* model = view_get_model(instance->view);
+    model->icon = icon_animation_alloc(&A_Loading_24);
+    model->text = NULL;
+    view_tie_icon_animation(instance->view, model->icon);
+    view_commit_model(instance->view, false);
+
+    view_set_context(instance->view, instance);
+    view_set_draw_callback(instance->view, loading_label_draw_callback);
+    view_set_input_callback(instance->view, loading_label_input_callback);
+    view_set_enter_callback(instance->view, loading_label_enter_callback);
+    view_set_exit_callback(instance->view, loading_label_exit_callback);
+
+    return instance;
+}
+
+void loading_label_free(LoadingLabel* instance) {
+    furi_check(instance);
+
+    LoadingLabelModel* model = view_get_model(instance->view);
+    icon_animation_free(model->icon);
+    view_commit_model(instance->view, false);
+
+    view_free(instance->view);
+    free(instance);
+}
+
+View* loading_label_get_view(LoadingLabel* instance) {
+    furi_check(instance);
+    return instance->view;
+}
+
+void loading_label_set_text(LoadingLabel* instance, const char* text) {
+    furi_check(instance);
+    LoadingLabelModel* model = view_get_model(instance->view);
+    model->text = text;
+    view_commit_model(instance->view, true);
+}

--- a/applications/main/nfc/views/loading_label.h
+++ b/applications/main/nfc/views/loading_label.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <gui/view.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** LoadingLabel anonymous structure */
+typedef struct LoadingLabel LoadingLabel;
+
+/** Allocate and initialize
+ *
+ * Like the Loading view, but draws the animated spinner on the left with a text
+ * label to its right (e.g. to name the slow operation in progress).
+ *
+ * @return     LoadingLabel View instance
+ */
+LoadingLabel* loading_label_alloc(void);
+
+/** Deinitialize and free LoadingLabel View
+ *
+ * @param      instance  LoadingLabel instance
+ */
+void loading_label_free(LoadingLabel* instance);
+
+/** Get LoadingLabel view
+ *
+ * @param      instance  LoadingLabel instance
+ *
+ * @return     View instance that can be used for embedding
+ */
+View* loading_label_get_view(LoadingLabel* instance);
+
+/** Set the label shown next to the spinner
+ *
+ * @param      instance  LoadingLabel instance
+ * @param      text      Text to show (caller-owned, must outlive the view); may be multiline
+ */
+void loading_label_set_text(LoadingLabel* instance, const char* text);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## What

Reading a MIFARE Classic tag that has a per-UID (**"CUID"**) key dictionary on disk — e.g. keys recovered from a static-encrypted-nonce Fudan tag via the **MFKey** app — no longer sits on a blank/frozen-looking screen while that dictionary loads. An animated loading view with a **"CUID dictionary is loading"** label is shown during the scan.

## Why

Entering the MIFARE Classic dictionary attack scans the whole `nfc/assets/mf_classic_dict_<cuid>.nfc` up front (to count keys + build the key-index bitmap) in `prepare_view()`, which runs from `on_enter` **before** the dictionary-attack progress view is switched in. For a large CUID dictionary that blocking scan makes the screen look like the app has hung. (Closes #1021.)

## How

- **Gated on presence:** `on_enter` stats the CUID dict (`keys_dict_check_presence`) and shows the loading view **only when one exists** — ordinary MIFARE Classic reads are unchanged (no spinner flicker). The CUID-dict path build is factored into a small helper.
- **New dedicated NFC view `loading_label`** (`views/loading_label.{c,h}`): animated `A_Loading_24` spinner on the left + a bold text label on the right, shown via `nfc_show_loading_label_popup()`. Like the existing `nfc_show_loading_popup`, it elevates the timer-thread priority so the icon keeps spinning while the app thread is blocked in the scan; both helpers now share a private `nfc_show_loading_view()`.

## Notes

- **No API changes.** The NFC app is a FAP, so the labelled loading view is implemented locally using only already-exported symbols rather than extending the shared `gui` `Loading` module (which would need an `api_symbols.csv` change + API-version bump). The spinner is drawn animated via `canvas_draw_icon_animation` — the shared `Popup`/`Widget` icon elements draw statically, which is why a small custom view is used.
- clang-format / lint clean.

## Verification

1. Collect + crack a static-encrypted-nonce MIFARE Classic (Fudan) tag with the **MFKey** app, so a sizable `mf_classic_dict_<cuid>.nfc` is written to `nfc/assets`.
2. **NFC → Read**, present the same tag.
3. During the CUID-dictionary load you should now see the animated spinner + **"CUID dictionary is loading"** label instead of a blank screen, before the dictionary-attack progress view appears. The bigger the dictionary, the more visible the difference.
4. Read an ordinary MIFARE Classic tag (no CUID dict) — behavior unchanged, no loading label.

Deployed to hardware via `fbt launch` (builds + loads clean).

Closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)
