### PR TITLE
[RFID]: Fix reading T5577 tags that hold multiple EM4100 IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * SubGHz: **Add Telcoma/Cardin EDGE protocol** (32bit, Static) (by @half2me | PR #1001)
 * LFRFID: **Support of Hitag Micro chips** (8265/8210/H5.5) (by @mishamyte | PR #1002)
 * LFRFID: **Wipe T5577** (reset to blank, with read-back verification) (by @mishamyte | PR #1003)
+* LFRFID: **Read T5577 tags holding multiple EM4100 IDs again** - a T5577 written with several EM4100 IDs (e.g. via Multiwriter) hung on Read since the Electra protocol was added; also resets a stale PAC/Stanley decoder buffer (by @mishamyte | PR #1025 | Fixes #1024)
 * NFC: Show MIFARE Ultralight/NTAG PWD & PACK in full info view / on read screen too (by @mishamyte | PR #1010 #1011)
 * NFC: **Add Bambu Lab filament spool parser** (type, color, code, temps, spool specs) (ported from [uzyn/flipper-bambu](https://github.com/uzyn/flipper-bambu), GPL-3.0)
 * NFC: **Align MIFARE type detection with NXP AN10833** - Classic/Ultralight/NTAG/Plus sizing & security level; fixes Mifare Mini clone mis-detection and Ultralight AES read hang (by @mishamyte | PR #1014)

--- a/lib/lfrfid/protocols/protocol_em4100.c
+++ b/lib/lfrfid/protocols/protocol_em4100.c
@@ -29,7 +29,8 @@ typedef uint64_t EM4100Epilogue;
 #define EM_READ_LONG_TIME_BASE   (512)
 #define EM_READ_JITTER_TIME_BASE (100)
 
-#define EM_ENCODED_DATA_HEADER (0xFF80000000000000ULL)
+// trailing 9-bit EM4100 header that must follow a valid frame
+#define EM_EPILOGUE_HEADER (0x1FFULL)
 
 typedef struct {
     uint8_t data[EM4100_DECODED_DATA_SIZE];
@@ -172,8 +173,9 @@ static bool em4100_can_be_decoded(
     const EM4100DecodedData* card_data = (EM4100DecodedData*)encoded_data;
     const EM4100Epilogue* epilogue = (EM4100Epilogue*)encoded_epilogue;
 
-    // check first 9 bytes on epilogue (to prevent conflict with Electra protocol)
-    if((*epilogue & EM_ENCODED_DATA_HEADER) != EM_ENCODED_DATA_HEADER) return false;
+    // Require the next frame's 9-bit header (EM4100 repeats) so Electra frames aren't
+    // misread as EM4100; 9 bits not a full 64-bit frame keeps decode latency low.
+    if((*epilogue & EM_EPILOGUE_HEADER) != EM_EPILOGUE_HEADER) return false;
 
     // check header and stop bit
     if((*card_data & EM_HEADER_AND_STOP_MASK) != EM_HEADER_AND_STOP_DATA) return false;
@@ -210,6 +212,7 @@ static bool em4100_can_be_decoded(
 void protocol_em4100_decoder_start(ProtocolEM4100* proto) {
     memset(proto->data, 0, EM4100_DECODED_DATA_SIZE);
     proto->encoded_data = 0;
+    proto->encoded_epilogue = 0;
     manchester_advance(
         proto->decoder_manchester_state,
         ManchesterEventReset,
@@ -245,10 +248,11 @@ bool protocol_em4100_decoder_feed(ProtocolEM4100* proto, bool level, uint32_t du
             proto->decoder_manchester_state, event, &proto->decoder_manchester_state, &data);
 
         if(data_ok) {
-            bool carry = proto->encoded_epilogue >> 63 & 0b1;
+            // encoded_data lags the newest bit by 9; the 9 pending bits live in encoded_epilogue.
+            bool carry = (proto->encoded_epilogue >> 8) & 0b1;
 
             proto->encoded_data = (proto->encoded_data << 1) | carry;
-            proto->encoded_epilogue = (proto->encoded_epilogue << 1) | data;
+            proto->encoded_epilogue = ((proto->encoded_epilogue << 1) | data) & EM_EPILOGUE_HEADER;
 
             if(em4100_can_be_decoded(
                    (uint8_t*)&proto->encoded_data,

--- a/lib/lfrfid/protocols/protocol_pac_stanley.c
+++ b/lib/lfrfid/protocols/protocol_pac_stanley.c
@@ -87,6 +87,7 @@ static bool protocol_pac_stanley_can_be_decoded(ProtocolPACStanley* protocol) {
 
 void protocol_pac_stanley_decoder_start(ProtocolPACStanley* protocol) {
     memset(protocol->data, 0, PAC_STANLEY_DECODED_DATA_SIZE);
+    memset(protocol->encoded_data, 0, PAC_STANLEY_ENCODED_BYTE_FULL_SIZE);
     protocol->inverted = false;
     protocol->got_preamble = false;
 }


### PR DESCRIPTION
## What & why

Closes #1024.

A T5577 that emits **more than one EM4100 frame per read cycle** — e.g. two IDs written by the third-party **T5577 Multi Writer** app (`MaxBlock=4`) — **hung on `125 kHz RFID → Read`**. These tags read fine on firmware from before the Electra protocol was added.

**Root cause.** To tell EM4100 apart from **Electra** (an EM4100 base frame + a trailing epilogue), the Electra commit (`a86aeface`, 2024) gave the EM4100 decoder a **64-bit** "a valid frame must be followed by a 9-bit header" lookahead. The read worker resets the decoder after every decode and only accepts a value after `validate_count` (= 3) *consecutive* identical decodes. That 64-bit lookahead pushes each decode ~128 bits past the reset, so a two-frame tag (`A B A B …`) settles into rigid `A,B,A,B` alternation and never yields 3 in a row → Read spins forever. A single-ID tag still repeats one value, so it was unaffected.

**Fix.** Only a **9-bit** lookahead is actually needed — Electra's epilogue can never begin with 9 ones (enforced in `protocol_electra.c`). Shrinking `encoded_epilogue` to 9 bits restores the pre-Electra decode timing while keeping EM4100/Electra disambiguation **bit-for-bit identical** (the gate inspects the same 9 logical bits; it just fires sooner). Also resets `encoded_epilogue` in `decoder_start`, which the original change omitted (Electra already resets its equivalent).

**Also included (sibling, latent).** `protocol_pac_stanley.c` never reset its `encoded_data` shift buffer in `decoder_start` (missing since the protocol was added, unlike every other LF decoder). Harmless in practice — the buffer self-refreshes and decoding is preamble + per-byte parity + checksum gated — but fixed for consistency. Found while auditing all 23 LF decoders for the same class of bug; only these two had it.

## Changes

- **`protocol_em4100.c`** — Electra-gate lookahead 64 → 9 bits (`EM_EPILOGUE_HEADER = 0x1FF`); reset `encoded_epilogue` in `decoder_start`. Shared decoder → also covers EM4100/16 and EM4100/32.
- **`protocol_pac_stanley.c`** — reset `encoded_data` in `decoder_start`.

## Manual QA

Release build (`COMPACT=1 DEBUG=0`, f7) on a Flipper Zero. All cases are **Read** (R#); expected = correct read unless noted. Cross-checked with a Proxmark3 and the T5577 Multi Writer app.

| # | Area | Test case | Expected | Result |
|----|------|-----------|----------|:------:|
| R1 | EM4100 (genuine) | Read original TK4100 | Correct ID | ✅ |
| R2 | Electra (disambiguation) | Read original Electra | Identified as **Electra**, not EM4100 | ✅ |
| R3 | EM4100 (T5577) | Read T5577 written as EM4100 | Correct ID | ✅ |
| R4 | EM4100 (T5577 + PWD) | Read password-protected T5577 written as EM4100 | Correct ID | ✅ |
| R5 | **Dual-EM (the fix)** | 2×EM4100 on one T5577 via Multi Writer | Read completes, returns one of the two IDs at random (no hang) | ✅ |
| R6 | EM4100/32 | Read EM4100/32 emulated by another Flipper | Correct ID | ✅ |

R5 is the fix; R1–R4/R6 confirm no regression (R2 specifically confirms EM4100/Electra disambiguation survives the gate change).

## Notes

- For reference, Proxmark3 reads these tags fine because its EM410x path is capture-then-demod (preamble search + parity only — no following-header gate, no consecutive-repeat requirement), and Electra there is a Lua script rather than a competing C decoder, so upstream never needed this gate. It also returns just one of the two IDs.
- Reading a tag that holds two IDs is inherently "return one at random"; making a multi-frame read fully *deterministic* would be a separate worker-level change (out of scope here).
