### PR TITLE
ci: post Build & analyze report on fork PRs via workflow_run

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,9 +14,10 @@
 #     changes without targets/*/api_symbols.csv being updated + version-bumped.
 #
 # Artifacts/reports are named by branch + short SHA, so manual runs from dev work too.
-# PR comment assumes PRs originate from this repo (not forks): the default token can
-# post. The same report is always written to the Actions job summary. (Fork PRs get a
-# read-only token; commenting there would need a `workflow_run` job.)
+# The PR report comment is posted by a separate workflow (pr-comment.yml) triggered on
+# `workflow_run`: this job only builds and uploads the report as an artifact, so it needs
+# no write access and works for fork PRs (whose token here is read-only). The same report
+# is always written to the Actions job summary regardless.
 
 name: Build & analyze
 
@@ -33,8 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: write # for the PR report comment (same-repo PRs)
+  contents: read # commenting is delegated to pr-comment.yml (workflow_run); no write needed here
 
 env:
   FBT_NO_SYNC: 0
@@ -148,21 +148,22 @@ jobs:
           } > pr_report.md
           cat pr_report.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Comment PR report
+      # ---------- Hand the report off to the privileged commenter ----------
+      # This job's token is read-only on fork PRs, so it can't comment itself. It uploads
+      # the assembled report + PR number; pr-comment.yml (triggered on workflow_run) posts
+      # it with a read-write token from the base-repo context. The PR number must travel
+      # via the artifact — github.event.workflow_run.pull_requests is empty for fork PRs.
+      - name: Save PR number
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      - name: Upload PR report artifact
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
         with:
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- unleashed-pr-report -->';
-            const body = fs.readFileSync('pr_report.md', 'utf8');
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-            const comments = await github.paginate(github.rest.issues.listComments,
-              { owner, repo, issue_number });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
+          name: pr-report
+          path: |
+            pr_report.md
+            pr_number.txt
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,7 +1,8 @@
 # Build & analyze: build the firmware on each PR, on pushes to dev, and on-demand
 # ("Run workflow"); publish it as a downloadable artifact, and on PRs post a unified
 # report comment (build status + flash budget + public-API changes). Push/dispatch
-# runs (no PR) put the same report in the Actions job summary only.
+# runs (no PR) put the same report — minus the PR-only public-API section — in the
+# Actions job summary only.
 #
 # Scope (deliberately minimal):
 #   * Builds the f7 "clean" flavor only (firmware + in-tree apps). The default/extra
@@ -27,8 +28,8 @@ on:
   pull_request:
   workflow_dispatch: # manual "Run workflow" button (appears once this is on the default branch)
 
-# Cancel an in-flight run when a newer commit (per PR) or dispatch (per ref)
-# supersedes it.
+# Cancel an in-flight run when superseded: per PR for PRs, else per ref (pushes to dev
+# and manual dispatches).
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -157,8 +158,12 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
 
+      # continue-on-error: a report/upload hiccup must not redden an otherwise-green build
+      # (the whole point of moving commenting out of this job). if-no-files-found still
+      # records the failure on the step; pr-comment.yml warns if the artifact never arrives.
       - name: Upload PR report artifact
         if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: pr-report

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -4,8 +4,8 @@
 # a read-only token, so it cannot comment itself. It instead uploads the assembled report
 # as the `pr-report` artifact. This workflow is triggered by `workflow_run` when that build
 # completes: because `workflow_run` always runs the copy of this file on the DEFAULT BRANCH,
-# in the base-repo context, it receives a normal read-write token even for fork-triggered
-# builds. It downloads the artifact and posts/updates the comment.
+# in the base-repo context, its requested write permissions are actually granted (unlike the
+# fork's read-only `pull_request` token). It downloads the artifact and posts the comment.
 #
 # Security: this job must NOT check out or execute the PR's code. Its only untrusted input
 # is the report artifact, which it treats strictly as text to post.
@@ -20,18 +20,33 @@ on:
     workflows: ["Build & analyze"] # must match pr-build.yml's `name:`
     types: [completed]
 
+# Cross-run artifact download needs `actions: read`; posting the comment needs
+# `pull-requests: write`. An explicit block sets every unlisted scope to `none`.
 permissions:
+  actions: read
   pull-requests: write # honored here: this runs in the base-repo context, not the fork's
+
+# Serialize comment runs for the same build so a re-run can't race the find-or-create
+# below into duplicate comments. workflow_run.pull_requests is empty for fork PRs, so key
+# on the run id (unique per triggering build) rather than the PR number.
+concurrency:
+  group: pr-comment-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
 
 jobs:
   comment:
     name: Post report comment
     runs-on: ubuntu-latest
-    # Only for PR-triggered builds; push/dispatch builds have no PR to comment on.
-    if: github.event.workflow_run.event == 'pull_request'
+    # Only PR builds that actually produced a report: skip push/dispatch (no PR) and
+    # cancelled/skipped builds (no artifact — would otherwise warn spuriously below).
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled' &&
+      github.event.workflow_run.conclusion != 'skipped'
     steps:
-      # Cross-run download: run-id + github-token pull the artifact from the build run.
-      # Missing artifact (e.g. the build died before uploading) must not fail this job.
+      # Cross-run: pulls the artifact from the build's run, not this workflow's.
+      # continue-on-error so a missing/expired artifact doesn't fail the job; the next
+      # step surfaces it as a warning instead of silently dropping the comment.
       - name: Download report artifact
         id: dl
         continue-on-error: true
@@ -41,6 +56,10 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
+      - name: Warn if report unavailable
+        if: steps.dl.outcome != 'success'
+        run: echo "::warning::pr-report artifact could not be downloaded (outcome=${{ steps.dl.outcome }}); no PR comment posted."
+
       - name: Post or update comment
         if: steps.dl.outcome == 'success'
         uses: actions/github-script@v9
@@ -48,7 +67,7 @@ jobs:
           script: |
             const fs = require('fs');
             if (!fs.existsSync('pr_report.md') || !fs.existsSync('pr_number.txt')) {
-              core.info('Report artifact incomplete; nothing to post.');
+              core.warning('Report artifact incomplete; nothing to post.');
               return;
             }
             const marker = '<!-- unleashed-pr-report -->';
@@ -60,7 +79,7 @@ jobs:
             }
             const { owner, repo } = context.repo;
             const comments = await github.paginate(github.rest.issues.listComments,
-              { owner, repo, issue_number });
+              { owner, repo, issue_number, per_page: 100 });
             const existing = comments.find(c => c.body && c.body.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,69 @@
+# Post the "Build & analyze" report as a PR comment — including on fork PRs.
+#
+# The build workflow (pr-build.yml) runs on `pull_request`; for fork PRs GitHub hands it
+# a read-only token, so it cannot comment itself. It instead uploads the assembled report
+# as the `pr-report` artifact. This workflow is triggered by `workflow_run` when that build
+# completes: because `workflow_run` always runs the copy of this file on the DEFAULT BRANCH,
+# in the base-repo context, it receives a normal read-write token even for fork-triggered
+# builds. It downloads the artifact and posts/updates the comment.
+#
+# Security: this job must NOT check out or execute the PR's code. Its only untrusted input
+# is the report artifact, which it treats strictly as text to post.
+#
+# Note: `workflow_run` workflows only ever run from the default branch, so changes here take
+# effect once merged to dev and can't be exercised from a PR branch.
+
+name: PR report comment
+
+on:
+  workflow_run:
+    workflows: ["Build & analyze"] # must match pr-build.yml's `name:`
+    types: [completed]
+
+permissions:
+  pull-requests: write # honored here: this runs in the base-repo context, not the fork's
+
+jobs:
+  comment:
+    name: Post report comment
+    runs-on: ubuntu-latest
+    # Only for PR-triggered builds; push/dispatch builds have no PR to comment on.
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      # Cross-run download: run-id + github-token pull the artifact from the build run.
+      # Missing artifact (e.g. the build died before uploading) must not fail this job.
+      - name: Download report artifact
+        id: dl
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: pr-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Post or update comment
+        if: steps.dl.outcome == 'success'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('pr_report.md') || !fs.existsSync('pr_number.txt')) {
+              core.info('Report artifact incomplete; nothing to post.');
+              return;
+            }
+            const marker = '<!-- unleashed-pr-report -->';
+            const body = fs.readFileSync('pr_report.md', 'utf8');
+            const issue_number = parseInt(fs.readFileSync('pr_number.txt', 'utf8').trim(), 10);
+            if (!Number.isInteger(issue_number)) {
+              core.setFailed('Invalid PR number in artifact.');
+              return;
+            }
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments,
+              { owner, repo, issue_number });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }


### PR DESCRIPTION
# What's new

The **Build & analyze** workflow posts a unified report (build status + flash budget + public-API diff) as a PR comment. On **fork PRs** that comment step failed with `403 Resource not accessible by integration`: GitHub gives `pull_request` runs from forks a **read-only** `GITHUB_TOKEN` (they build untrusted code), so `issues.createComment` is forbidden and the whole `f7 firmware` check went red **even though the firmware built fine** (seen on #1020). This affected *every* fork PR.

This splits delivery from analysis using the GitHub-recommended `workflow_run` pattern:

- **`pr-build.yml`** keeps all build/size/API analysis on the fork's code with the read-only token, but instead of commenting it uploads the assembled report + PR number as the `pr-report` artifact. Drops `pull-requests: write`; the report upload is `continue-on-error` so a transient upload hiccup can't redden a green build.
- **`pr-comment.yml`** (new) is triggered on `workflow_run` when the build completes. It runs from the **default branch** in the base-repo context, so its `pull-requests: write` (plus `actions: read` for the cross-run artifact download) is actually granted even for fork-triggered builds. It downloads the artifact and posts/updates the comment. It never checks out or executes PR code — the report is treated strictly as text.

Net effect: same-repo PRs work exactly as before; fork PRs now get the report comment (posted a few seconds later by the second workflow), and the build check is no longer falsely red.

`pull_request_target` was deliberately **not** used: this job compiles the PR's code, and running untrusted code under `pull_request_target`'s read-write, secret-bearing token is the classic pwn-request hole. The repo already uses `pull_request_target` in `labeler.yml` precisely *because* that job never runs PR code — this applies the correct opposite pattern for a job that does.

Closes #1026.

# Notes / caveats

- **`workflow_run` only ever runs the copy of the workflow on the default branch**, so `pr-comment.yml` takes effect once this merges to `dev` and cannot be exercised from this PR branch. The `pr-build.yml` half *does* run on this PR, so you can confirm the build still builds + uploads the `pr-report` artifact here; the comment side is validated post-merge with a throwaway fork PR.
- The job skips `cancelled`/`skipped` builds and emits a job-annotation warning if the artifact can't be downloaded, so a genuine failure is never a green check with no comment and no signal.

# Verification

1. On this PR: confirm the `Build & analyze` / `f7 firmware` check builds and that the run uploads a `pr-report` artifact (Actions run → Artifacts). No comment is expected here (see caveat).
2. After merge to `dev`: open a small PR from a fork and confirm the report comment appears and updates on push, and that the `f7 firmware` check is green.

# AI usage disclosure

- Fully AI assisted (Claude Opus 4.8, via Claude Code): diagnosed the 403 from the failed run logs, authored the `workflow_run` split, and hardened it after a multi-agent review + simplify pass (added `actions: read`, cancelled-build skip, download-failure warning, concurrency guard, `continue-on-error` on upload). Changes are limited to the two workflow YAML files.
