### PR TITLE
[NFC] Fix memory leaks & double-frees in supported-card parsers, app lifecycle & DESFire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * NFC: **Align MIFARE type detection with NXP AN10833** - Classic/Ultralight/NTAG/Plus sizing & security level; fixes Mifare Mini clone mis-detection and Ultralight AES read hang (by @mishamyte | PR #1014)
 * NFC: **Read MIFARE Plus 2K in SL1 as full 32 sectors / 64 keys** - a Plus 2K in SL1 is byte-identical to a Classic 1K in SAK/ATQA and was mis-sized as 1K; it is now told apart by its ISO14443-4 ATS (Plus S/X signature), while Plus SE, SmartMX, magic "Perfect CUID" and plain 1K stay 1K (by @mishamyte | PR #1016)
 * NFC: **Show a loading screen while a large CUID dictionary loads on Read** - animated spinner + "CUID dictionary is loading" label instead of a blank/frozen-looking screen while a per-UID (MFKey-recovered) dictionary is scanned (by @mishamyte | PR #1022)
+* NFC: **Fix memory leaks & double-frees in the NFC app** - heap-corrupting double-frees in the Plantain and SZPPK/SEVPPK/SK transit parsers (crash on two-trip tickets), leaks in the Saflok parser, the app API resolver (per launch) and the CUID-dictionary error path, plus a ~15x RAM over-allocation of the MIFARE DESFire file-data array (by @mishamyte | PR #1030 | Fixes #1029)
 * RPC: **Add Network and GPS RPC services** (by @apfxtech (Network based on @noproto code and idea) | PR #1013)
 * Apps: **NFC Magic** - Gen2 CUID/static-nonce detection, Gen1 4b/7b UID, length-aware wipe & write guard (by @mishamyte)
 * Apps: Build tag (**5jul2026p2**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)

--- a/applications/main/nfc/nfc_app.c
+++ b/applications/main/nfc/nfc_app.c
@@ -161,6 +161,7 @@ void nfc_app_free(NfcApp* instance) {
     slix_unlock_free(instance->slix_unlock);
     mf_classic_key_cache_free(instance->mfc_key_cache);
     nfc_supported_cards_free(instance->nfc_supported_cards);
+    composite_api_resolver_free(instance->api_resolver);
     if(instance->protocol_support) {
         nfc_protocol_support_free(instance);
     }

--- a/applications/main/nfc/plugins/supported_cards/plantain.c
+++ b/applications/main/nfc/plugins/supported_cards/plantain.c
@@ -453,8 +453,6 @@ static void printf_plantain_data(FuriString* parsed_data, PlantainData* purse) {
         furi_string_cat_printf(parsed_data, "\nPPK keys installed:> YES");
     else
         furi_string_cat_printf(parsed_data, "\nPPK keys installed:> NO");
-
-    furi_string_free(purse->card_number_str);
 }
 
 // Function to format and print PPK ticket data

--- a/applications/main/nfc/plugins/supported_cards/saflok.c
+++ b/applications/main/nfc/plugins/supported_cards/saflok.c
@@ -476,6 +476,7 @@ bool saflok_parse(const NfcDevice* device, FuriString* parsed_data) {
         parsed = checksum_valid;
 #endif
 
+        furi_string_free(restricted_weekday_string);
     } while(false);
     return parsed;
 }

--- a/applications/main/nfc/plugins/supported_cards/sevppk_tk.c
+++ b/applications/main/nfc/plugins/supported_cards/sevppk_tk.c
@@ -368,10 +368,10 @@ static bool sev_tk_parse(const NfcDevice* device, FuriString* parsed_data) {
 
             extract_ppk_data(storage, data, &secondary_ticket, 1);
             printf_transport_card(parsed_data, &secondary_ticket, true);
-            furi_string_free(primary_ticket.departure_name);
-            furi_string_free(primary_ticket.destination_name);
-            furi_string_free(primary_ticket.trip_start_sta_name);
-            furi_string_free(primary_ticket.trip_end_sta_name);
+            furi_string_free(secondary_ticket.departure_name);
+            furi_string_free(secondary_ticket.destination_name);
+            furi_string_free(secondary_ticket.trip_start_sta_name);
+            furi_string_free(secondary_ticket.trip_end_sta_name);
         }
 
         furi_record_close(RECORD_STORAGE);

--- a/applications/main/nfc/plugins/supported_cards/sk_tk.c
+++ b/applications/main/nfc/plugins/supported_cards/sk_tk.c
@@ -375,10 +375,10 @@ static bool sk_tk_parse(const NfcDevice* device, FuriString* parsed_data) {
 
             extract_ppk_data(storage, data, &secondary_ticket, 1);
             printf_transport_card(parsed_data, &secondary_ticket, true);
-            furi_string_free(primary_ticket.departure_name);
-            furi_string_free(primary_ticket.destination_name);
-            furi_string_free(primary_ticket.trip_start_sta_name);
-            furi_string_free(primary_ticket.trip_end_sta_name);
+            furi_string_free(secondary_ticket.departure_name);
+            furi_string_free(secondary_ticket.destination_name);
+            furi_string_free(secondary_ticket.trip_start_sta_name);
+            furi_string_free(secondary_ticket.trip_end_sta_name);
         }
 
         furi_record_close(RECORD_STORAGE);

--- a/applications/main/nfc/plugins/supported_cards/szppk_so.c
+++ b/applications/main/nfc/plugins/supported_cards/szppk_so.c
@@ -417,10 +417,10 @@ static bool szppk_so_parse(const NfcDevice* device, FuriString* parsed_data) {
 
             extract_ppk_data(storage, data, &secondary_ticket, 1);
             printf_transport_card(parsed_data, &secondary_ticket, true);
-            furi_string_free(primary_ticket.departure_name);
-            furi_string_free(primary_ticket.destination_name);
-            furi_string_free(primary_ticket.trip_start_sta_name);
-            furi_string_free(primary_ticket.trip_end_sta_name);
+            furi_string_free(secondary_ticket.departure_name);
+            furi_string_free(secondary_ticket.destination_name);
+            furi_string_free(secondary_ticket.trip_start_sta_name);
+            furi_string_free(secondary_ticket.trip_end_sta_name);
         }
 
         furi_record_close(RECORD_STORAGE);

--- a/applications/main/nfc/scenes/nfc_scene_mf_classic_dict_attack.c
+++ b/applications/main/nfc/scenes/nfc_scene_mf_classic_dict_attack.c
@@ -254,8 +254,7 @@ static void nfc_scene_mf_classic_dict_attack_prepare_view(NfcApp* instance) {
                    furi_string_get_cstr(cuid_dict_path),
                    FSAM_READ_WRITE,
                    FSOM_OPEN_EXISTING)) {
-                buffered_file_stream_close(dict->stream);
-                free(dict);
+                keys_dict_free(dict);
                 state = DictAttackStateUserDictInProgress;
                 break;
             }

--- a/lib/nfc/protocols/mf_desfire/mf_desfire_i.c
+++ b/lib/nfc/protocols/mf_desfire/mf_desfire_i.c
@@ -900,7 +900,7 @@ const SimpleArrayConfig mf_desfire_file_data_array_config = {
     .init = (SimpleArrayInit)mf_desfire_file_data_init,
     .copy = (SimpleArrayCopy)mf_desfire_file_data_copy,
     .reset = (SimpleArrayReset)mf_desfire_file_data_reset,
-    .type_size = sizeof(MfDesfireData),
+    .type_size = sizeof(MfDesfireFileData),
 };
 
 const SimpleArrayConfig mf_desfire_application_array_config = {


### PR DESCRIPTION
## What

Fixes a cluster of memory-management bugs in the NFC app found during a comprehensive audit of `applications/main/nfc` + `lib/nfc` (~61k LOC). Seven memory bugs + one RAM over-allocation, one fix per commit.

Closes #1029.

## Fixes (one per commit)

| # | Area | Bug | Fix |
|---|------|-----|-----|
| 1 | `plantain.c` | **double-free** — `printf_plantain_data` freed `card_number_str`, then the caller freed it again | drop the free inside the print helper (caller owns it) |
| 2 | `szppk_so.c` | **double-free + leak** — second-ticket branch freed `primary_ticket.*` (already freed) instead of the freshly-allocated `secondary_ticket.*` | free the `secondary_ticket.*` members |
| 3 | `sevppk_tk.c` | same copy-paste bug | same |
| 4 | `sk_tk.c` | same copy-paste bug | same |
| 5 | `saflok.c` | **leak** — `restricted_weekday_string` never freed (file had zero `furi_string_free`) | free before `do/while` exits (both `SL_PROTO` builds) |
| 6 | `nfc_app.c` | **leak** — `api_resolver` (+2 list nodes) never freed; `nfc_supported_cards` only borrows it | `composite_api_resolver_free` in `nfc_app_free` |
| 7 | `nfc_scene_mf_classic_dict_attack.c` | **leak** — CUID-dict open-fail path leaked the `Stream` + a `RECORD_STORAGE` reference | `keys_dict_free(dict)` (matches the sibling `total_keys == 0` path) |
| 8 | `mf_desfire_i.c` | **~15× RAM over-allocation** — file-data array used `sizeof(MfDesfireData)` (~60 B) for a 4 B `MfDesfireFileData` element | `sizeof(MfDesfireFileData)` |

The double-frees (1–4) are heap-corrupting and user-reachable (Plantain cards; two-trip PPK transit tickets). 5–7 are leaks (per-parse / per-launch / error-path). 8 wastes heap on every DESFire read.


## Not changed (documented in #1029)

Three "uninitialized field after `malloc`" candidates were ruled out — Flipper's `malloc`→`pvPortMalloc` zero-fills every allocation. Four minor hardening items (felica_listener des3-free, mf_classic_poller memset, detect_reader on_exit, nfc_device_load_legacy dirty-state) are noted in the issue and left for a follow-up.

## Testing

Changes are minimal (+16/−17) teardown/error-path frees with unchanged control flow. `clang-format` clean; reviewed for memory-ownership correctness (no new double-free/UAF/leak, freed pointers not reused, `keys_dict_free` verified as the correct CUID teardown). Not yet compiled in CI here / not on-device tested — on-device QA of the affected transit parsers (Plantain, SZPPK/SEVPPK/SK two-trip tickets, Saflok) is welcome from anyone holding the cards.
