### PR TITLE
[SubGHz] Fix crash when exiting CLI `subghz chat` with external CC1101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Main changes
 - Current API: 87.12
 * SubGHz: **Fix endless TX causing RAW files to be transmitted and crash the system** (via RPC / Mobile App) (Fixes issue #1008)
+* SubGHz: **Fix crash when exiting CLI `subghz chat` with an external CC1101** - pressing Ctrl+C dereferenced the just-freed external CC1101 radio plugin during chat worker shutdown; internal CC1101 was unaffected (by @mishamyte | PR #1036 | Fixes #829)
 * SubGHz: **Add Telcoma/Cardin EDGE protocol** (32bit, Static) (by @half2me | PR #1001)
 * LFRFID: **Support of Hitag Micro chips** (8265/8210/H5.5) (by @mishamyte | PR #1002)
 * LFRFID: **Wipe T5577** (reset to blank, with read-back verification) (by @mishamyte | PR #1003)

--- a/applications/main/subghz/subghz_cli.c
+++ b/applications/main/subghz/subghz_cli.c
@@ -966,6 +966,8 @@ static void subghz_cli_command_chat(PipeSide* pipe, FuriString* args) {
             "In your settings, only reception on this frequency (%lu) is allowed,\r\n"
             "the actual operation of the application is not possible\r\n ",
             frequency);
+        subghz_devices_deinit();
+        subghz_cli_radio_device_power_off();
         return;
     }
 
@@ -1113,16 +1115,19 @@ static void subghz_cli_command_chat(PipeSide* pipe, FuriString* args) {
     furi_string_free(output);
     furi_string_free(sysmsg);
 
+    // Stop the worker before deinit: its TxRx thread sleeps/ends the device on
+    // exit, and deinit frees that device when it's an external CC1101 plugin (UAF, #829).
+    if(subghz_chat_worker_is_running(subghz_chat)) {
+        subghz_chat_worker_stop(subghz_chat);
+        subghz_chat_worker_free(subghz_chat);
+    }
+
     subghz_devices_deinit();
     subghz_cli_radio_device_power_off();
 
     furi_hal_power_suppress_charge_exit();
     furi_record_close(RECORD_NOTIFICATION);
 
-    if(subghz_chat_worker_is_running(subghz_chat)) {
-        subghz_chat_worker_stop(subghz_chat);
-        subghz_chat_worker_free(subghz_chat);
-    }
     printf("\r\nExit chat\r\n");
 }
 


### PR DESCRIPTION
## What & why

Fixes #829. Pressing **Ctrl+C** to exit `subghz chat` while using an **external CC1101** crashed the Flipper (null-pointer dereference + reboot). The internal CC1101 was unaffected.

## Root cause

`subghz_cli_command_chat()` tore down in the wrong order:

```c
subghz_devices_deinit();          // frees the external CC1101 plugin
...
subghz_chat_worker_stop(...);     // worker thread then sleeps/ends the freed device
subghz_chat_worker_free(...);
```

`subghz_devices_deinit()` → `subghz_device_registry_deinit()` → `plugin_manager_free()` unloads the external CC1101 radio-device plugin (`apptype=FlipperAppType.PLUGIN`), freeing its `SubGhzDevice` struct and `interconnect` vtable. The TxRx worker thread calls `subghz_devices_sleep()`/`subghz_devices_end()` on that device from its **own thread** at shutdown (`lib/subghz/subghz_tx_rx_worker.c`), so joining it *after* deinit dereferenced freed plugin memory.

The **internal** CC1101 is the static `subghz_device_cc1101_int`, which `plugin_manager_free()` never frees — that's why the crash was external-only.

## Fix

- Stop & free the chat worker **before** `subghz_devices_deinit()`, so the worker's `sleep`/`end` run while the device is still valid. This matches the teardown order already used by `subghz_cli_command_rx`.
- Also add the missing `subghz_devices_deinit()` + radio power-off to the "tx not allowed" early return, so a later `subghz` command's `subghz_devices_init()` doesn't `furi_check`-fail on an already-valid registry.

## Testing

- Built **release** FW from this branch and full-flashed it to hardware (Flipper Zero + external CC1101), verified running via `device_info`.
- Ran the exact repro from the issue: `subghz chat 433920000 1` → send a message → **Ctrl+C**. It now prints `Exit chat` and returns to the CLI prompt — **no crash, no reboot**, CLI stays responsive. Running `subghz chat` again immediately also works (exercises the deinit pairing).

## Note (out of scope)

There is a pre-existing, currently-unreachable worker-start-failure path (`if(!subghz_chat_worker_start(...))`) that also omits `deinit` and mis-frees the worker. It's dead code today (the `tx-allowed` check just above guarantees the start succeeds) and can't be cleanly fixed without reworking the public `subghz_tx_rx_worker_*` start/stop API, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
