### PR TITLE
Fix CC1101 intermediate frequency register

### DIFF
--- a/lib/drivers/cc1101.c
+++ b/lib/drivers/cc1101.c
@@ -143,7 +143,7 @@ uint32_t cc1101_set_intermediate_frequency(const FuriHalSpiBusHandle* handle, ui
     uint64_t real_value = value * CC1101_IFDIV / CC1101_QUARTZ;
     assert((real_value & 0xFF) == real_value);
 
-    cc1101_write_reg(handle, CC1101_FSCTRL0, (real_value >> 0) & 0xFF);
+    cc1101_write_reg(handle, CC1101_FSCTRL1, (real_value >> 0) & 0xFF);
 
     uint64_t real_frequency = real_value * CC1101_QUARTZ / CC1101_IFDIV;
 


### PR DESCRIPTION
## Summary

- write the calculated CC1101 intermediate-frequency word to `FSCTRL1`
- leave `FSCTRL0`, the frequency-offset register, untouched
- keep the public API and calculated return value unchanged

Fixes #873.

## Verification

- Host regression harness compiled the real `lib/drivers/cc1101.c` against a mock SPI bus.
- Before the fix: `expected FSCTRL1 (0x0B), got register 0x0C`.
- After the fix: register `FSCTRL1`, IF word `6`, and synthesized result `152343 Hz` were verified.
- Compact firmware build completed with API `88.0`.
- Hardware smoke passed for Sub-GHz Read using the internal CC1101 and an external CC1101, including configuration return and clean exit.

## Risk

Low. This changes one register address in a function that is currently not used by the firmware or bundled apps. No API or storage format changes.