### PR TITLE
[Power] Recover battery gauge after VGM flashing

### DIFF
--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -263,7 +263,8 @@ static bool power_update_info(Power* power) {
     };
 
     const bool need_refresh = (power->info.charge != info.charge) ||
-                              (power->info.is_charging != info.is_charging);
+                              (power->info.is_charging != info.is_charging) ||
+                              (power->info.gauge_is_ok != info.gauge_is_ok);
     power->info = info;
     return need_refresh;
 }
@@ -489,6 +490,7 @@ static void power_loader_callback(const void* message, void* context) {
         // arm timer if some apps was not loaded or was stoped
     } else if(event->type == LoaderEventTypeNoMoreAppsInQueue) {
         power->app_running = false;
+        power->gauge_recovery_pending = true;
         power_auto_poweroff_arm(power);
     }
 }
@@ -599,7 +601,15 @@ static void power_tick_callback(void* context) {
     Power* power = context;
 
     // Update data from gauge and charger
-    const bool need_refresh = power_update_info(power);
+    bool need_refresh = power_update_info(power);
+    if(power->gauge_recovery_pending && !power->app_running) {
+        power->gauge_recovery_pending = false;
+        if(!power->info.gauge_is_ok) {
+            FURI_LOG_W(TAG, "Recovering fuel gauge after application exit");
+            furi_hal_power_gauge_reinit();
+            need_refresh |= power_update_info(power);
+        }
+    }
     // Check low battery level
     power_check_low_battery(power);
     // Check and notify about charging state
@@ -665,6 +675,7 @@ static Power* power_alloc(void) {
     // State initialization
     power->power_off_timeout = POWER_OFF_TIMEOUT_S;
     power->show_battery_low_warning = true;
+    power->gauge_recovery_pending = false;
 
     // Load UI settings
     DesktopSettings* settings = malloc(sizeof(DesktopSettings));

--- a/applications/services/power/power_service/power_i.h
+++ b/applications/services/power/power_service/power_i.h
@@ -11,6 +11,8 @@
 #include "views/power_off.h"
 #include "views/power_unplug_usb.h"
 
+bool furi_hal_power_gauge_reinit(void);
+
 typedef enum {
     PowerStateNotCharging,
     PowerStateCharging,
@@ -40,6 +42,7 @@ struct Power {
     PowerSettings settings;
     FuriTimer* auto_poweroff_timer;
     bool app_running;
+    bool gauge_recovery_pending;
     FuriPubSub* input_events_pubsub;
     FuriPubSubSubscription* input_events_subscription;
     bool charge_is_supressed;

--- a/targets/f7/furi_hal/furi_hal_power.c
+++ b/targets/f7/furi_hal/furi_hal_power.c
@@ -125,6 +125,30 @@ bool furi_hal_power_gauge_is_ok(void) {
     return ret;
 }
 
+bool furi_hal_power_gauge_reinit(void) {
+    bool result = false;
+    Bq27220BatteryStatus battery_status;
+    Bq27220OperationStatus operation_status;
+
+    furi_hal_i2c_acquire(&furi_hal_i2c_handle_power);
+
+    if(bq27220_get_battery_status(&furi_hal_i2c_handle_power, &battery_status) &&
+       bq27220_get_operation_status(&furi_hal_i2c_handle_power, &operation_status) &&
+       battery_status.BATTPRES) {
+        if(operation_status.INITCOMP) {
+            result = furi_hal_power.gauge_ok;
+        } else {
+            FURI_LOG_W(TAG, "Fuel gauge initialization lost, reinitializing");
+            furi_hal_power.gauge_ok =
+                bq27220_init(&furi_hal_i2c_handle_power, furi_hal_power_gauge_data_memory);
+            result = furi_hal_power.gauge_ok;
+        }
+    }
+
+    furi_hal_i2c_release(&furi_hal_i2c_handle_power);
+    return result;
+}
+
 bool furi_hal_power_is_shutdown_requested(void) {
     bool ret = false;
 


### PR DESCRIPTION
## Summary

Fixes #961.

Flashing official firmware to the Video Game Module can leave the BQ27220 fuel gauge with `INITCOMP=0`. Battery telemetry remains readable, but `furi_hal_power_gauge_is_ok()` correctly reports the gauge as unavailable, so Desktop shows `-` until Flipper is rebooted.

## Changes

- refresh the battery viewport when `gauge_is_ok` changes;
- arm a one-shot gauge recovery after the last application exits;
- run recovery only when no app is active and the gauge is unhealthy;
- verify I2C communication and `BATTPRES` before recovery;
- reuse the existing boot-time `bq27220_init()` path only when `INITCOMP=0`.

The recovery does not run for a healthy gauge or on an I2C read failure. No public API symbols were added or changed.

## Root-cause evidence

Immediately after reproducing the issue, before reboot:

- Desktop battery indicator: `-`;
- `gauge.initcomp: 0`;
- `gauge.battpres: 1`;
- SOC: `100`;
- voltage: approximately `4.15 V`;
- temperature: `30 C`.

A reboot restored `INITCOMP=1`, matching the boot-time BQ27220 initialization behavior.

## Verification

- `./fbt -j4 firmware_all`
- API check: `88.0` unchanged
- hardware: Flipper Zero with Video Game Module
- flashed official VGM firmware using Video Game Module Tool
- exited the tool without rebooting Flipper
- battery indicator recovered to `100%`
- `info power_debug` confirmed `gauge.initcomp: 1`, `gauge.battpres: 1`, and valid telemetry

## Risk

The existing BQ27220 initialization can briefly delay the power service, but the new path is one-shot, application-exit gated, and only entered for the confirmed `BATTPRES=1 && INITCOMP=0` state.