### PR TITLE
[SubGHz] Fix Frequency Analyzer leaving the radio in a degraded state after exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Current API: 88.0
 * SubGHz: **Fix endless TX causing RAW files to be transmitted and crash the system** (via RPC / Mobile App) (Fixes issue #1008)
 * SubGHz: **Fix crash when exiting CLI `subghz chat` with an external CC1101** - pressing Ctrl+C dereferenced the just-freed external CC1101 radio plugin during chat worker shutdown; internal CC1101 was unaffected (by @mishamyte | PR #1036 | Fixes #829)
+* SubGHz: **Fix Frequency Analyzer leaving the radio in a degraded state** - the worker parked the internal CC1101 with the antenna isolated and its near-field AGC profile still loaded; apps driving the radio HAL directly (without a full re-init) inherited a "sticky" sensitivity loss - the radio is now reset to its boot state on exit (by @mishamyte | PR #1045 | Fixes #1044)
 * SubGHz: **Add Telcoma/Cardin EDGE protocol** (32bit, Static) (by @half2me | PR #1001)
 * LFRFID: **Support of Hitag Micro chips** (8265/8210/H5.5) (by @mishamyte | PR #1002)
 * LFRFID: **Wipe T5577** (reset to blank, with read-back verification) (by @mishamyte | PR #1003)

--- a/applications/main/subghz/helpers/subghz_frequency_analyzer_worker.c
+++ b/applications/main/subghz/helpers/subghz_frequency_analyzer_worker.c
@@ -260,6 +260,10 @@ static int32_t subghz_frequency_analyzer_worker_thread(void* context) {
 
     //Stop CC1101
     furi_hal_subghz_idle();
+    // Reset drops FA's custom AGC/BW config; SRES reverts IOCFG2, so re-park
+    // the RF switch — leaves the radio in the same state as after boot
+    furi_hal_subghz_reset();
+    furi_hal_subghz_set_path(FuriHalSubGhzPathIsolate);
     furi_hal_subghz_sleep();
 
     return 0;


### PR DESCRIPTION
## What & why

Fixes #1044. After using the **Frequency Analyzer**, the internal CC1101 was left parked in the worst possible state: **antenna disconnected (RF path = Isolate) + FA's near-field AGC profile still loaded**. This is the mechanism behind the old #256 (2022, closed as stale) — the "sticky" sensitivity loss was never an external-module topic, it lives entirely in the internal-radio path.

## Root cause

The FA worker deliberately degrades the RX chain while it runs (that's how its near-field detection works): custom `MDMCFG3/4` + `AGCCTRL0–2`, and `furi_hal_subghz_set_path(FuriHalSubGhzPathIsolate)`. But its exit was only:

```c
//Stop CC1101
furi_hal_subghz_idle();
furi_hal_subghz_sleep();
```

- CC1101 `SPWD` retains all configuration registers (only `TEST0–2` + PATABLE tail are lost) → the AGC/BW tweaks survive sleep
- `gpio_rf_sw_0 = 0` + `IOCFG2 = HW→0` keep their last state → the RF path stays **Isolate**

Every other flow parks the radio with a sane preset and a live band path — FA was the only feature leaving a pathological state behind.

**Who was affected:** apps driving `furi_hal_subghz_*` directly old-style (plain `set_frequency()` without a path, register writes without a reset) inherited the isolated antenna + AGC leftovers until something fully re-initialized the radio — matching #256 exactly, including the workaround (debug carrier test with manual path selection). The built-in app and `subghz_devices`-API FAPs (incl. today's Spectrum Analyzer) rebuild the full state every session (`reset` → `load_custom_preset` (SRES) → `set_frequency_and_path`) and were immune.

## Fix

Re-create the boot parked state (what `furi_hal_subghz_init()` establishes) on worker exit:

```c
furi_hal_subghz_reset();
furi_hal_subghz_set_path(FuriHalSubGhzPathIsolate);
furi_hal_subghz_sleep();
```

The explicit `set_path(Isolate)` matters: after SRES, `IOCFG2` reverts to its `CHIP_RDYn` default, which deasserts once the chip sleeps — the RF switch would sit half-selected on the 433 path instead of isolated.

Zero behavior change for the built-in app and devices-API FAPs (they rebuild state anyway); direct-HAL FAPs now see "fresh boot" instead of "whatever FA left".

## Testing

- Full `fbt firmware_all` build from this branch passes.
- Not HW-tested: the fix is not observable from the built-in app (immune by construction). Verifying on hardware would require a direct-HAL FAP or dumping `AGCCTRL*`/`IOCFG2` after FA exit.

## Note

OFW `dev` has byte-identical FA worker code, so this is upstreamable as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
