### PR TITLE
Fix deprecated CodeQL action, harden the PR report commenter [ci skip]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,12 @@ on:
     branches: ["dev"]
   workflow_dispatch:
 
+# A full firmware build plus CodeQL analysis is expensive; back-to-back pushes to
+# dev shouldn't run several at once. Matches the other workflows in this repo.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze
@@ -50,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout Firmware Files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           clean: "true"
           submodules: "true"
@@ -58,13 +64,12 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          setup-python-dependencies: true
 
       - name: Resolve CodeQL Build Env
-        uses: github/codeql-action/resolve-environment@v2
+        uses: github/codeql-action/resolve-environment@v4
         with:
           language: ${{ matrix.language }}
           #debug: true
@@ -76,7 +81,7 @@ jobs:
           ./fbt COMPACT=1 DEBUG=0 FBT_NO_SYNC=${{ env.FBT_NO_SYNC }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4
         if: ${{ success() }}
         with:
           threads: 4
@@ -99,7 +104,7 @@ jobs:
           output: "${{ env.PATH_SARIF_FILE }}"
 
       - name: Upload CodeQL SARIF
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         if: ${{ success() }}
         with:
           category: "${{ env.LANG_CATEGORY }}"

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -8,7 +8,9 @@
 # fork's read-only `pull_request` token). It downloads the artifact and posts the comment.
 #
 # Security: this job must NOT check out or execute the PR's code. Its only untrusted input
-# is the report artifact, which it treats strictly as text to post.
+# is the report artifact, whose body it treats strictly as text to post - and whose PR
+# number it does not trust at all: the destination is checked against the triggering run's
+# head SHA before commenting, so a PR cannot redirect the comment onto another thread.
 #
 # Note: `workflow_run` workflows only ever run from the default branch, so changes here take
 # effect once merged to dev and can't be exercised from a PR branch.
@@ -73,11 +75,33 @@ jobs:
             const marker = '<!-- unleashed-pr-report -->';
             const body = fs.readFileSync('pr_report.md', 'utf8');
             const issue_number = parseInt(fs.readFileSync('pr_number.txt', 'utf8').trim(), 10);
-            if (!Number.isInteger(issue_number)) {
+            if (!Number.isInteger(issue_number) || issue_number < 1) {
               core.setFailed('Invalid PR number in artifact.');
               return;
             }
             const { owner, repo } = context.repo;
+
+            // The artifact is written by a job that checked out and ran the PR's own
+            // code, so the number inside it is attacker-controlled: on its own it
+            // would let a malicious PR aim this privileged comment at any other
+            // thread in the repo. workflow_run.head_sha comes from the event payload
+            // and cannot be forged, so require the named PR to actually be the one
+            // that was built before posting anything.
+            const headSha = context.payload.workflow_run.head_sha;
+            let pr;
+            try {
+              ({ data: pr } = await github.rest.pulls.get(
+                { owner, repo, pull_number: issue_number }));
+            } catch (e) {
+              core.setFailed(`Could not load PR #${issue_number}: ${e.message}`);
+              return;
+            }
+            if (pr.head.sha !== headSha) {
+              core.setFailed(
+                `PR #${issue_number} is at ${pr.head.sha} but this build ran ${headSha}; ` +
+                'refusing to comment.');
+              return;
+            }
             const comments = await github.paginate(github.rest.issues.listComments,
               { owner, repo, issue_number, per_page: 100 });
             const existing = comments.find(c => c.body && c.body.includes(marker));


### PR DESCRIPTION
Two unrelated CI issues found while reviewing the workflows.

## CodeQL is running on a deprecation shim

Runs report green, but every one of them carries a **failure-level** annotation. From the latest run:

```
[failure] CodeQL Action major versions v1 and v2 have been deprecated.
          Please update all occurrences of the CodeQL Action in your
          workflow files to v3.
[warning] Node.js 20 is deprecated. The following actions target Node.js 20
          but are being forced to run on Node.js 24: actions/checkout@v3,
          github/codeql-action/analyze@v2, github/codeql-action/init@v2, ...
[warning] The setup-python-dependencies input is deprecated and no longer
          has any effect.
```

So:

- All four `github/codeql-action/*` pins go `@v2` to `@v4`. v4 is the current major; v3 is still maintained (v4.37.3 and v3.37.3 both shipped 2026-07-22) if a smaller jump is preferred.
- `actions/checkout` `@v3` to `@v6`, matching `pr-build.yml` and `bump-issue-template-version.yml` and clearing the Node 20 warning.
- Dropped `setup-python-dependencies`, confirmed a no-op by the annotation above.
- Added a `concurrency` group. It was the only workflow here without one, so back-to-back pushes to dev could run several full firmware builds plus CodeQL analyses at once.

## The PR report commenter trusted an attacker-controlled destination

`pr-comment.yml` read the target PR number from `pr_number.txt` in the report artifact and validated it only with `Number.isInteger`. That artifact is produced by the build job, which checks out the PR merge ref and runs `.github/scripts/fw_size_report.py` **from the PR**. So a fork PR controlled both the comment body and where it went, and could make `github-actions[bot]` post arbitrary markdown onto any open thread in the repo.

No secret access and no code execution - comment spoofing only, and first-time-contributor approval blunts it further. But the destination was never checked.

Now the named PR's head SHA has to match `workflow_run.head_sha`, which comes from the event payload and cannot be forged. Mismatch, or a PR number that will not load, fails the job instead of commenting.

The file's own header said its untrusted input was "treated strictly as text to post" - true of the body, but the destination was untrusted too. Comment updated to match.

## Verification

Both files parse. The `github-script` block was extracted and syntax-checked with `node --check`. The runtime path cannot be exercised until this is on the default branch, since `workflow_run` workflows only ever run from there - so the first fork PR after merge is the real test of the SHA check.

One thing I left alone: the commented-out debug block at the bottom of `codeql.yml` still references `actions/upload-artifact@v3`, which no longer works. Harmless while commented, but a trap if anyone uncomments it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
