### PR TITLE
[NFC] Bound card-controlled TLV lengths in the EMV poller

### DIFF
--- a/lib/nfc/protocols/emv/emv.h
+++ b/lib/nfc/protocols/emv/emv.h
@@ -87,7 +87,8 @@ typedef struct {
     uint8_t application_interchange_profile[2];
     char application_name[16 + 1];
     char application_label[16 + 1];
-    char cardholder_name[24 + 1];
+    // EMV Book 3 Annex A gives 5F20 an ans length of 2-26
+    char cardholder_name[26 + 1];
     uint8_t pan[10]; // card_number
     uint8_t pan_len;
     uint8_t exp_day;

--- a/lib/nfc/protocols/emv/emv.h
+++ b/lib/nfc/protocols/emv/emv.h
@@ -54,6 +54,8 @@ extern "C" {
 
 typedef struct {
     uint16_t tag;
+    // The card asks for a length of its own, so the terminal has to know how much it holds
+    uint8_t size;
     uint8_t data[];
 } PDOLValue;
 

--- a/lib/nfc/protocols/emv/emv_poller_i.c
+++ b/lib/nfc/protocols/emv/emv_poller_i.c
@@ -17,10 +17,9 @@ const PDOLValue pdol_term_trans_qualifies = {
     0x9F66,
     4,
     {0x79, 0x00, 0x40, 0x80}}; // Terminal transaction qualifiers
-const PDOLValue pdol_addtnl_term_qualifies = {
-    0x9F40,
-    4,
-    {0x79, 0x00, 0x40, 0x80}}; // Terminal transaction qualifiers
+// Additional terminal capabilities. EMV gives 9F40 five bytes, so a card asking for all
+// of them gets the last one zero-filled rather than read from the neighbouring value.
+const PDOLValue pdol_addtnl_term_qualifies = {0x9F40, 4, {0x79, 0x00, 0x40, 0x80}};
 const PDOLValue pdol_amount_authorise = {
     0x9F02,
     6,
@@ -113,6 +112,10 @@ static bool
     uint8_t i = 0;
     bool success = false;
 
+    // Every case below bounds tlen against sizeof(the destination it writes to), in one of
+    // three forms: != for a fixed-width value, >= where the last byte is reserved for the
+    // NUL written at dest[tlen], and > where the whole field is usable because a separate
+    // *_len records how much of it is valid.
     switch(tag) {
     case EMV_TAG_LOG_FMT:
         if(tlen > sizeof(app->log_fmt)) return emv_tag_rejected(tag, tlen);
@@ -377,8 +380,9 @@ static bool
     uint8_t tlen = 0;
     bool success = false;
 
-    // Every byte read below comes from the card, so the header has to be
-    // checked against the response length before it is dereferenced.
+    // Whichever buffer the caller is parsing -- response, log format or PDOL -- it is
+    // card-controlled, so the header has to be checked against its length before it is
+    // dereferenced. Only the caller knows where the matching value bytes live.
     if(i >= len) return success;
 
     first_byte = buff[i];
@@ -434,13 +438,20 @@ static bool emv_decode_tl(
         // The format only names tags and lengths: the values live in the record, so that is
         // what the length has to be bounded against.
         if((uint16_t)i + tlen > len) {
-            emv_tag_rejected(tag, tlen);
-            break;
+            // Stop the sweep: a half-filled transaction would be counted as one that
+            // never happened, which is worse than ending the log early.
+            FURI_LOG_W(
+                TAG,
+                "Log record too short for tag %04X: %d bytes at offset %d of %d",
+                tag,
+                tlen,
+                i,
+                len);
+            return false;
         }
         emv_decode_tlv_tag(&buff[i], tag, tlen, app);
         i += tlen;
     }
-    success = true;
     return success;
 }
 

--- a/lib/nfc/protocols/emv/emv_poller_i.c
+++ b/lib/nfc/protocols/emv/emv_poller_i.c
@@ -243,6 +243,9 @@ static bool
     case EMV_TAG_CARDHOLDER_NAME: {
         // The previous contents' length says nothing about how much room is left.
         if(tlen >= sizeof(app->cardholder_name)) return emv_tag_rejected(tag, tlen);
+        // A bruteforced read sees 5F20 in several records, so don't let a later
+        // shorter or empty one replace a name already found.
+        if(strlen(app->cardholder_name) > tlen) break;
         memcpy(app->cardholder_name, &buff[i], tlen);
         app->cardholder_name[tlen] = '\0';
 

--- a/lib/nfc/protocols/emv/emv_poller_i.c
+++ b/lib/nfc/protocols/emv/emv_poller_i.c
@@ -3,6 +3,9 @@
 
 #define TAG "EMVPoller"
 
+// 256 B ISO14443-4 poller buffer, less 1 PCB + 4 header + Lc + 83 + len + Le
+#define EMV_PDOL_MAX_SIZE (256U - 9U)
+
 // "Terminal" parameters, which could be requested by card
 const PDOLValue pdol_term_info = {
     0x9F59,
@@ -478,13 +481,14 @@ static void emv_prepare_pdol(APDU* dest, APDU* src) {
     while(i < src->size) {
         bool tag_found = false;
         if(!emv_parse_tag(src->data, src->size, &tag, &tlen, &i)) {
-            FURI_LOG_T(TAG, "Parsing PDOL failed at 0x%x", i);
+            FURI_LOG_W(TAG, "Parsing PDOL failed at 0x%x", i);
             dest->size = 0;
             return;
         }
 
-        // The running total is driven by the card as well, so it can outgrow the APDU
-        if((uint16_t)dest->size + tlen >= sizeof(dest->data)) {
+        // The running total is driven by the card as well, and the GPO carrying it is re-encoded
+        // into the ISO14443-4 poller's buffer, which is the narrower of the two limits.
+        if((uint16_t)dest->size + tlen > EMV_PDOL_MAX_SIZE) {
             emv_tag_rejected(tag, tlen);
             dest->size = 0;
             return;

--- a/lib/nfc/protocols/emv/emv_poller_i.c
+++ b/lib/nfc/protocols/emv/emv_poller_i.c
@@ -89,7 +89,7 @@ static bool
 
     switch(tag) {
     case EMV_TAG_LOG_FMT:
-        furi_check(tlen < sizeof(app->log_fmt));
+        if(tlen > sizeof(app->log_fmt)) break;
         memcpy(app->log_fmt, &buff[i], tlen);
         app->log_fmt_len = tlen;
         success = true;
@@ -97,15 +97,16 @@ static bool
         break;
     case EMV_TAG_GPO_FMT1:
         // skip AIP
+        if(tlen < 2) break;
         i += 2;
         tlen -= 2;
-        furi_check(tlen < sizeof(app->afl.data));
         memcpy(app->afl.data, &buff[i], tlen);
         app->afl.size = tlen;
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_GPO_FMT1 %X: ", tag);
         break;
     case EMV_TAG_AID:
+        if(tlen > sizeof(app->aid)) break;
         app->aid_len = tlen;
         memcpy(app->aid, &buff[i], tlen);
         success = true;
@@ -121,7 +122,7 @@ static bool
         FURI_LOG_T(TAG, "found EMV_TAG_APP_PRIORITY %X: %d", tag, app->priority);
         break;
     case EMV_TAG_APPL_INTERCHANGE_PROFILE:
-        furi_check(tlen == 2);
+        if(tlen != sizeof(app->application_interchange_profile)) break;
         memcpy(app->application_interchange_profile, &buff[i], tlen);
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_APPL_INTERCHANGE_PROFILE %x: ", tag);
@@ -131,13 +132,14 @@ static bool
         FURI_LOG_RAW_T("\r\n");
         break;
     case EMV_TAG_APPL_LABEL:
+        if(tlen >= sizeof(app->application_label)) break;
         memcpy(app->application_label, &buff[i], tlen);
         app->application_label[tlen] = '\0';
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_APPL_LABEL %x: %s", tag, app->application_label);
         break;
     case EMV_TAG_APPL_NAME:
-        furi_check(tlen < sizeof(app->application_name));
+        if(tlen >= sizeof(app->application_name)) break;
         memcpy(app->application_name, &buff[i], tlen);
         app->application_name[tlen] = '\0';
         success = true;
@@ -166,6 +168,7 @@ static bool
     case EMV_TAG_TRACK_1_EQUIV: {
         // Contain PAN and expire date
         char track_1_equiv[80];
+        if(tlen >= sizeof(track_1_equiv)) break;
         memcpy(track_1_equiv, &buff[i], tlen);
         track_1_equiv[tlen] = '\0';
         success = true;
@@ -175,8 +178,9 @@ static bool
     case EMV_TAG_TRACK_2_DATA:
     case EMV_TAG_TRACK_2_EQUIV: {
         FURI_LOG_T(TAG, "found EMV_TAG_TRACK_2 %X", tag);
-        // 0xD0 delimits PAN from expiry (YYMM)
-        for(int x = 1; x < tlen; x++) {
+        // 0xD0 delimits PAN from expiry (YYMM). The delimiter is followed by two
+        // more value bytes, and the PAN cannot be longer than the field holding it.
+        for(int x = 1; x + 3 < tlen && x < (int)sizeof(app->pan); x++) {
             if(buff[i + x + 1] > 0xD0) {
                 memcpy(app->pan, &buff[i], x + 1);
                 app->pan_len = x + 1;
@@ -190,7 +194,9 @@ static bool
 #ifndef LOGS_RELEASE_BUILD
         char track_2_equiv[41];
         uint8_t track_2_equiv_len = 0;
-        for(int x = 0; x < tlen; x++) {
+        // Each value byte expands to two characters, and one byte is kept for the
+        // terminator written after the loop.
+        for(int x = 0; x < tlen && (size_t)(x * 2 + 2) < sizeof(track_2_equiv); x++) {
             char top = (buff[i + x] >> 4) + '0';
             char bottom = (buff[i + x] & 0x0F) + '0';
             track_2_equiv[x * 2] = top;
@@ -207,7 +213,8 @@ static bool
         break;
     }
     case EMV_TAG_CARDHOLDER_NAME: {
-        if(strlen(app->cardholder_name) > tlen) break;
+        // The previous contents' length says nothing about how much room is left.
+        if(tlen >= sizeof(app->cardholder_name)) break;
         memcpy(app->cardholder_name, &buff[i], tlen);
         app->cardholder_name[tlen] = '\0';
 
@@ -223,6 +230,7 @@ static bool
         break;
     }
     case EMV_TAG_PAN:
+        if(tlen > sizeof(app->pan)) break;
         memcpy(app->pan, &buff[i], tlen);
         app->pan_len = tlen;
         success = true;
@@ -268,6 +276,7 @@ static bool
         success = true;
         break;
     case EMV_TAG_LOG_AMOUNT:
+        if(tlen > sizeof(app->trans[app->active_tr].amount)) break;
         memcpy(&app->trans[app->active_tr].amount, &buff[i], tlen);
         success = true;
         break;
@@ -280,10 +289,12 @@ static bool
         success = true;
         break;
     case EMV_TAG_LOG_DATE:
+        if(tlen > sizeof(app->trans[app->active_tr].date)) break;
         memcpy(&app->trans[app->active_tr].date, &buff[i], tlen);
         success = true;
         break;
     case EMV_TAG_LOG_TIME:
+        if(tlen > sizeof(app->trans[app->active_tr].time)) break;
         memcpy(&app->trans[app->active_tr].time, &buff[i], tlen);
         success = true;
         break;
@@ -330,11 +341,16 @@ static bool
     uint8_t tlen = 0;
     bool success = false;
 
+    // Every byte read below comes from the card, so the header has to be
+    // checked against the response length before it is dereferenced.
+    if(i >= len) return success;
+
     first_byte = buff[i];
 
     if(emv_response_error(buff, len)) return success;
 
     if((first_byte & 31) == 31) { // 2-byte tag
+        if(i + 1 >= len) return success;
         tag = buff[i] << 8 | buff[i + 1];
         i++;
         FURI_LOG_T(TAG, " 2-byte TLV EMV tag: %x", tag);
@@ -343,15 +359,23 @@ static bool
         FURI_LOG_T(TAG, " 1-byte TLV EMV tag: %x", tag);
     }
     i++;
+    if(i >= len) return success;
     tlen = buff[i];
     if((tlen & 128) == 128) { // long length value
         i++;
+        if(i >= len) return success;
         tlen = buff[i];
         FURI_LOG_T(TAG, " 2-byte TLV length: %d", tlen);
     } else {
         FURI_LOG_T(TAG, " 1-byte TLV length: %d", tlen);
     }
     i++;
+
+    // A tag may not claim more value bytes than the card actually sent.
+    if((uint16_t)i + tlen > len) {
+        FURI_LOG_T(TAG, " TLV length %d overruns response length %d", tlen, len);
+        return success;
+    }
 
     *off = i;
     *t = tag;
@@ -790,9 +814,13 @@ EmvError emv_poller_read_log_entry(EmvPoller* instance) {
         }
 
         instance->data->emv_application.active_tr++;
-        furi_check(
-            instance->data->emv_application.active_tr <
-            COUNT_OF(instance->data->emv_application.trans));
+        // The record count comes from the card, so stop at the end of the array
+        // instead of panicking on a card that advertises more records than fit.
+        if(instance->data->emv_application.active_tr >=
+           COUNT_OF(instance->data->emv_application.trans)) {
+            FURI_LOG_D(TAG, "Transaction log full, ignoring the remaining records");
+            break;
+        }
     }
 
     instance->data->emv_application.saving_trans_list = false;

--- a/lib/nfc/protocols/emv/emv_poller_i.c
+++ b/lib/nfc/protocols/emv/emv_poller_i.c
@@ -4,29 +4,39 @@
 #define TAG "EMVPoller"
 
 // "Terminal" parameters, which could be requested by card
-const PDOLValue pdol_term_info = {0x9F59, {0xC8, 0x80, 0x00}}; // Terminal transaction information
-const PDOLValue pdol_term_type = {0x9F5A, {0x00}}; // Terminal transaction type
-const PDOLValue pdol_merchant_type = {0x9F58, {0x01}}; // Merchant type indicator
+const PDOLValue pdol_term_info = {
+    0x9F59,
+    3,
+    {0xC8, 0x80, 0x00}}; // Terminal transaction information
+const PDOLValue pdol_term_type = {0x9F5A, 1, {0x00}}; // Terminal transaction type
+const PDOLValue pdol_merchant_type = {0x9F58, 1, {0x01}}; // Merchant type indicator
 const PDOLValue pdol_term_trans_qualifies = {
     0x9F66,
+    4,
     {0x79, 0x00, 0x40, 0x80}}; // Terminal transaction qualifiers
 const PDOLValue pdol_addtnl_term_qualifies = {
     0x9F40,
+    4,
     {0x79, 0x00, 0x40, 0x80}}; // Terminal transaction qualifiers
 const PDOLValue pdol_amount_authorise = {
     0x9F02,
+    6,
     {0x00, 0x00, 0x00, 0x10, 0x00, 0x00}}; // Amount, authorised
-const PDOLValue pdol_amount = {0x9F03, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}; // Amount
-const PDOLValue pdol_country_code = {0x9F1A, {0x01, 0x24}}; // Terminal country code
-const PDOLValue pdol_currency_code = {0x5F2A, {0x01, 0x24}}; // Transaction currency code
+const PDOLValue pdol_amount = {0x9F03, 6, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}; // Amount
+const PDOLValue pdol_country_code = {0x9F1A, 2, {0x01, 0x24}}; // Terminal country code
+const PDOLValue pdol_currency_code = {0x5F2A, 2, {0x01, 0x24}}; // Transaction currency code
 const PDOLValue pdol_term_verification = {
     0x95,
+    5,
     {0x00, 0x00, 0x00, 0x00, 0x00}}; // Terminal verification results
-const PDOLValue pdol_transaction_date = {0x9A, {0x19, 0x01, 0x01}}; // Transaction date
-const PDOLValue pdol_transaction_type = {0x9C, {0x00}}; // Transaction type
-const PDOLValue pdol_transaction_cert = {0x98, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}; // Transaction cert
-const PDOLValue pdol_unpredict_number = {0x9F37, {0x82, 0x3D, 0xDE, 0x7A}}; // Unpredictable number
+const PDOLValue pdol_transaction_date = {0x9A, 3, {0x19, 0x01, 0x01}}; // Transaction date
+const PDOLValue pdol_transaction_type = {0x9C, 1, {0x00}}; // Transaction type
+const PDOLValue pdol_transaction_cert = {0x98, 20, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                    0, 0, 0, 0, 0, 0, 0, 0, 0}}; // Transaction cert
+const PDOLValue pdol_unpredict_number = {
+    0x9F37,
+    4,
+    {0x82, 0x3D, 0xDE, 0x7A}}; // Unpredictable number
 
 const PDOLValue* const pdol_values[] = {
     &pdol_term_info,
@@ -82,6 +92,19 @@ static void emv_trace(EmvPoller* instance, const char* message) {
 #endif
 }
 
+// The transaction being filled in is indexed by a counter the card drives, so a card that
+// advertises more records than fit leaves it one past the end of the array.
+static bool emv_trans_writable(const EmvApplication* app) {
+    return app->saving_trans_list && app->active_tr < COUNT_OF(app->trans);
+}
+
+// Every rejected tag goes through here, so that a card that reads blank leaves one line behind
+// in a release build, where FURI_LOG_T and FURI_LOG_D are compiled out.
+static bool emv_tag_rejected(uint16_t tag, uint8_t tlen) {
+    FURI_LOG_W(TAG, "Rejected tag %04X of length %d", tag, tlen);
+    return false;
+}
+
 static bool
     emv_decode_tlv_tag(const uint8_t* buff, uint16_t tag, uint8_t tlen, EmvApplication* app) {
     uint8_t i = 0;
@@ -89,7 +112,7 @@ static bool
 
     switch(tag) {
     case EMV_TAG_LOG_FMT:
-        if(tlen > sizeof(app->log_fmt)) break;
+        if(tlen > sizeof(app->log_fmt)) return emv_tag_rejected(tag, tlen);
         memcpy(app->log_fmt, &buff[i], tlen);
         app->log_fmt_len = tlen;
         success = true;
@@ -97,7 +120,7 @@ static bool
         break;
     case EMV_TAG_GPO_FMT1:
         // skip AIP
-        if(tlen < 2) break;
+        if(tlen < 2) return emv_tag_rejected(tag, tlen);
         i += 2;
         tlen -= 2;
         memcpy(app->afl.data, &buff[i], tlen);
@@ -106,7 +129,7 @@ static bool
         FURI_LOG_T(TAG, "found EMV_TAG_GPO_FMT1 %X: ", tag);
         break;
     case EMV_TAG_AID:
-        if(tlen > sizeof(app->aid)) break;
+        if(tlen > sizeof(app->aid)) return emv_tag_rejected(tag, tlen);
         app->aid_len = tlen;
         memcpy(app->aid, &buff[i], tlen);
         success = true;
@@ -117,12 +140,14 @@ static bool
         FURI_LOG_RAW_T("\r\n");
         break;
     case EMV_TAG_PRIORITY:
+        if(tlen != sizeof(app->priority)) return emv_tag_rejected(tag, tlen);
         memcpy(&app->priority, &buff[i], tlen);
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_APP_PRIORITY %X: %d", tag, app->priority);
         break;
     case EMV_TAG_APPL_INTERCHANGE_PROFILE:
-        if(tlen != sizeof(app->application_interchange_profile)) break;
+        if(tlen != sizeof(app->application_interchange_profile))
+            return emv_tag_rejected(tag, tlen);
         memcpy(app->application_interchange_profile, &buff[i], tlen);
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_APPL_INTERCHANGE_PROFILE %x: ", tag);
@@ -132,14 +157,14 @@ static bool
         FURI_LOG_RAW_T("\r\n");
         break;
     case EMV_TAG_APPL_LABEL:
-        if(tlen >= sizeof(app->application_label)) break;
+        if(tlen >= sizeof(app->application_label)) return emv_tag_rejected(tag, tlen);
         memcpy(app->application_label, &buff[i], tlen);
         app->application_label[tlen] = '\0';
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_APPL_LABEL %x: %s", tag, app->application_label);
         break;
     case EMV_TAG_APPL_NAME:
-        if(tlen >= sizeof(app->application_name)) break;
+        if(tlen >= sizeof(app->application_name)) return emv_tag_rejected(tag, tlen);
         memcpy(app->application_name, &buff[i], tlen);
         app->application_name[tlen] = '\0';
         success = true;
@@ -168,7 +193,7 @@ static bool
     case EMV_TAG_TRACK_1_EQUIV: {
         // Contain PAN and expire date
         char track_1_equiv[80];
-        if(tlen >= sizeof(track_1_equiv)) break;
+        if(tlen >= sizeof(track_1_equiv)) return emv_tag_rejected(tag, tlen);
         memcpy(track_1_equiv, &buff[i], tlen);
         track_1_equiv[tlen] = '\0';
         success = true;
@@ -214,7 +239,7 @@ static bool
     }
     case EMV_TAG_CARDHOLDER_NAME: {
         // The previous contents' length says nothing about how much room is left.
-        if(tlen >= sizeof(app->cardholder_name)) break;
+        if(tlen >= sizeof(app->cardholder_name)) return emv_tag_rejected(tag, tlen);
         memcpy(app->cardholder_name, &buff[i], tlen);
         app->cardholder_name[tlen] = '\0';
 
@@ -230,7 +255,7 @@ static bool
         break;
     }
     case EMV_TAG_PAN:
-        if(tlen > sizeof(app->pan)) break;
+        if(tlen > sizeof(app->pan)) return emv_tag_rejected(tag, tlen);
         memcpy(app->pan, &buff[i], tlen);
         app->pan_len = tlen;
         success = true;
@@ -269,32 +294,37 @@ static bool
         success = true;
         break;
     case EMV_TAG_ATC:
-        if(app->saving_trans_list)
+        if(emv_trans_writable(app))
             app->trans[app->active_tr].atc = (buff[i] << 8 | buff[i + 1]);
         else
             app->transaction_counter = (buff[i] << 8 | buff[i + 1]);
         success = true;
         break;
     case EMV_TAG_LOG_AMOUNT:
-        if(tlen > sizeof(app->trans[app->active_tr].amount)) break;
+        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].amount))
+            return emv_tag_rejected(tag, tlen);
         memcpy(&app->trans[app->active_tr].amount, &buff[i], tlen);
         success = true;
         break;
     case EMV_TAG_LOG_COUNTRY:
+        if(!emv_trans_writable(app)) return emv_tag_rejected(tag, tlen);
         app->trans[app->active_tr].country = (buff[i] << 8 | buff[i + 1]);
         success = true;
         break;
     case EMV_TAG_LOG_CURRENCY:
+        if(!emv_trans_writable(app)) return emv_tag_rejected(tag, tlen);
         app->trans[app->active_tr].currency = (buff[i] << 8 | buff[i + 1]);
         success = true;
         break;
     case EMV_TAG_LOG_DATE:
-        if(tlen > sizeof(app->trans[app->active_tr].date)) break;
+        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].date))
+            return emv_tag_rejected(tag, tlen);
         memcpy(&app->trans[app->active_tr].date, &buff[i], tlen);
         success = true;
         break;
     case EMV_TAG_LOG_TIME:
-        if(tlen > sizeof(app->trans[app->active_tr].time)) break;
+        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].time))
+            return emv_tag_rejected(tag, tlen);
         memcpy(&app->trans[app->active_tr].time, &buff[i], tlen);
         success = true;
         break;
@@ -371,12 +401,6 @@ static bool
     }
     i++;
 
-    // A tag may not claim more value bytes than the card actually sent.
-    if((uint16_t)i + tlen > len) {
-        FURI_LOG_T(TAG, " TLV length %d overruns response length %d", tlen, len);
-        return success;
-    }
-
     *off = i;
     *t = tag;
     *tl = tlen;
@@ -401,6 +425,12 @@ static bool emv_decode_tl(
     while(f < fmt_len && i < len) {
         success = emv_parse_tag(fmt, fmt_len, &tag, &tlen, &f);
         if(!success) return success;
+        // The format only names tags and lengths: the values live in the record, so that is
+        // what the length has to be bounded against.
+        if((uint16_t)i + tlen > len) {
+            emv_tag_rejected(tag, tlen);
+            break;
+        }
         emv_decode_tlv_tag(&buff[i], tag, tlen, app);
         i += tlen;
     }
@@ -420,6 +450,10 @@ static bool emv_decode_response_tlv(const uint8_t* buff, uint8_t len, EmvApplica
 
         success = emv_parse_tag(buff, len, &tag, &tlen, &i);
         if(!success) return success;
+
+        // This is the caller whose value bytes are in the buffer being parsed, so a tag may
+        // not claim more of them than the card actually sent.
+        if((uint16_t)i + tlen > len) return emv_tag_rejected(tag, tlen);
 
         if((first_byte & 32) == 32) { // "Constructed" -- contains more TLV data to parse
             FURI_LOG_T(TAG, "Constructed TLV %x", tag);
@@ -449,10 +483,20 @@ static void emv_prepare_pdol(APDU* dest, APDU* src) {
             return;
         }
 
-        furi_check(dest->size + tlen < sizeof(dest->data));
+        // The running total is driven by the card as well, so it can outgrow the APDU
+        if((uint16_t)dest->size + tlen >= sizeof(dest->data)) {
+            emv_tag_rejected(tag, tlen);
+            dest->size = 0;
+            return;
+        }
+
         for(uint8_t j = 0; j < COUNT_OF(pdol_values); j++) {
             if(tag == pdol_values[j]->tag) {
-                memcpy(dest->data + dest->size, pdol_values[j]->data, tlen);
+                // The card names the length it wants, which is not what the terminal holds:
+                // copying that many bytes would read past the value and send it to the card.
+                uint8_t copy_len = MIN(tlen, pdol_values[j]->size);
+                memcpy(dest->data + dest->size, pdol_values[j]->data, copy_len);
+                memset(dest->data + dest->size + copy_len, 0, tlen - copy_len);
                 dest->size += tlen;
                 tag_found = true;
                 break;


### PR DESCRIPTION
## Description

`emv_parse_tag()` takes each TLV length straight off the card and passes it through without validating it:

```c
tlen = buff[i];
if((tlen & 128) == 128) { // long length value
    i++;
    tlen = buff[i];       // next byte verbatim
}
...
*tl = tlen;
```

`emv_decode_tlv_tag()` then uses that value as the size of a `memcpy` into fixed-size fields. Four tags are guarded with `furi_check(tlen < sizeof(...))`; the rest are not guarded at all. `len` is `bit_buffer_get_size_bytes(instance->rx_buffer)`, and `emv_response_error()` only rejects a 2-byte status word, so any longer response is parsed. No file needs to be loaded — tapping a card that returns a crafted response is enough.

Destinations reached with an unvalidated length:

| crafted response | destination | size | writes |
|---|---|---|---|
| `5A 20` + 32 B | `app->pan` | 10 | 32 |
| `4F 40` + 64 B | `app->aid` | 16 | 64 |
| `57 30` + 48 B | `track_2_equiv` (stack) | 41 | 97 |
| `57 30` + 48 B | `app->pan` | 10 | 48 |
| `5F 20 60` + 96 B | `app->cardholder_name` | 25 | 97 |
| `5A 81 FF` + … | `app->pan` | 10 | 255 |

`track_2_equiv` is the worst of these: the conversion loop writes `track_2_equiv[x * 2]` and `[x * 2 + 1]` for `x < tlen`, so a 48-byte value writes ~97 bytes into a 41-byte stack buffer. In this repo that block sits under `#ifndef LOGS_RELEASE_BUILD`, so it is excluded from `COMPACT` release builds and only affects debug builds. Everything else in the table is outside any `#ifndef` and applies to release builds too.

Also in the same function:

- `EMV_TAG_GPO_FMT1` does `tlen -= 2` on a `uint8_t` without checking `tlen >= 2`, underflowing to ~254.
- `EMV_TAG_CARDHOLDER_NAME`'s guard is `if(strlen(app->cardholder_name) > tlen) break;`, which compares the *previous* contents' length and bounds nothing.
- `EMV_TAG_TRACK_2_*` reads `buff[i + x + 2]` and `buff[i + x + 3]`, up to three bytes past the value.
- `emv_parse_tag` dereferences `buff[i]` and `buff[i + 1]` before `i` is bounded by `len`.
- `emv_poller_read_log_entry` increments `active_tr` and then `furi_check`s it, so a card advertising more log records than `trans[]` holds panics the device.

## Fix

Reject cleanly rather than panic, since all of this is attacker-controlled input:

- `emv_parse_tag` bounds `i` against `len` before every read, and rejects a tag whose value overruns the response (`i + tlen > len`). That removes the reads past the end and stops a length claiming more than the card sent.
- Every copy into a fixed-size field is bounded. An over-long field `break`s out of its `case`, so the tag is skipped and the rest of the card still parses.
- The four existing `furi_check`s became the same graceful reject. Panicking on a malformed card turns memory corruption into a remote crash, which is the same class of bug.
- The `track_2_equiv` loop is bounded to the buffer, and the PAN scan to `sizeof(app->pan)` plus the three bytes it reads ahead.
- The `active_tr` `furi_check` became a loop break.

Deliberately not added: bounds for `EMV_TAG_PDOL` and `EMV_TAG_AFL`. Both destinations are `APDU.data[MAX_APDU_LEN]`, i.e. 255 bytes, and `tlen` is a `uint8_t`, so a check there is provably always false and would only add dead code.

## Verification

`./fbt firmware_all` builds clean (`f7-firmware-D`, 221 flash pages, DFU produced).

Related: Next-Flip/Momentum-Firmware#553 asked about a private channel for an EMV overflow in the `.nfc` loading path and was told public handling is fine and a PR would be welcome. That reporter never opened one. Momentum and RogueMaster carry a byte-identical copy of this file, where the `track_2_equiv` block is *not* behind `#ifndef LOGS_RELEASE_BUILD`, so it applies to their release builds as well — happy to send the same change there if useful.

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

 I used AI assistance to help to prepare the change.