### PR TITLE
[NFC] Fix Type 4 Tag writes that start inside the NLEN field

### DIFF
--- a/lib/nfc/protocols/type_4_tag/type_4_tag_listener_i.c
+++ b/lib/nfc/protocols/type_4_tag/type_4_tag_listener_i.c
@@ -208,11 +208,12 @@ static Type4TagError type_4_tag_listener_iso_write(
 
         const size_t ndef_file_len = simple_array_get_count(instance->data->ndef_data);
         size_t ndef_file_len_new = ndef_file_len;
+        // NDEF file = 2-byte BE length header + payload; a write can start inside the header
         if(offset < sizeof(uint16_t)) {
             const uint8_t write_len = sizeof(uint16_t) - offset;
             ndef_file_len_new = bit_lib_bytes_to_num_be(data, write_len);
             offset = sizeof(uint16_t);
-            data += offset;
+            data += write_len;
             lc -= write_len;
         }
         offset -= sizeof(uint16_t);


### PR DESCRIPTION
## Description

In `type_4_tag_listener_iso_write()`, a write that starts inside the two-byte NLEN field consumes `write_len = sizeof(uint16_t) - offset` bytes for that field. The payload pointer is then advanced by `offset` instead:

```c
const uint8_t write_len = sizeof(uint16_t) - offset;
ndef_file_len_new = bit_lib_bytes_to_num_be(data, write_len);
offset = sizeof(uint16_t);
data += offset;      // offset was just reassigned to 2
lc -= write_len;
```

`offset` has already been reassigned to `sizeof(uint16_t)` on the line above, so `data` always moves forward by 2 regardless of how much was actually consumed.

With `offset == 0` the two agree (`write_len` is 2) which is why this goes unnoticed. With `offset == 1` only one byte belongs to NLEN, so:

- the NDEF payload is taken starting one byte too far in, shifting the written content by one, and
- `lc` was only reduced by 1, so the copy runs one byte past the end of the reader's APDU data.

`offset` comes straight from the command header (`offset = (p1 << 8) + p2`), so a reader only has to send `P1 = 0x00`, `P2 = 0x01` to reach it.

## Fix

Advance by the number of bytes actually consumed:

```c
data += write_len;
```

Behaviour at `offset == 0` is unchanged, since `write_len` is 2 there.

## Verification

`./fbt firmware_all` builds clean, `API version 87.10 is up to date`.

Momentum-Firmware carries a byte-identical copy of this file (`7da6fadc`); OFW does not have it. Happy to send the same one-liner there if useful.