### PR TITLE
ci: read branch refs from env instead of interpolating them into the shell

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -58,13 +58,16 @@ jobs:
       - name: Compute version vars
         id: vars
         shell: bash
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             SHA="${{ github.event.pull_request.head.sha }}"
-            REF="${{ github.head_ref }}"
+            REF="$HEAD_REF"
           else
             SHA="${{ github.sha }}"
-            REF="${{ github.ref_name }}"
+            REF="$REF_NAME"
           fi
           SHORT="${SHA:0:8}"
           SAFE_REF="${REF//\//-}"           # branch name, '/' -> '-' for artifact names


### PR DESCRIPTION
Hi, and thanks for Unleashed.

In `.github/workflows/pr-build.yml`, the "Compute version vars" step reads the branch name by interpolation:

```yaml
run: |
  if [ "${{ github.event_name }}" = "pull_request" ]; then
    SHA="${{ github.event.pull_request.head.sha }}"
    REF="${{ github.head_ref }}"
  else
    SHA="${{ github.sha }}"
    REF="${{ github.ref_name }}"
```

Actions substitutes `${{ ... }}` into the script text before bash runs, so the branch name becomes part of the script rather than a value assigned to `REF`. Git allows `$`, `(`, `)` and backticks in branch names, and `$(...)` runs inside double quotes — so a fork PR on a branch named something like `x$(id)` would execute that.

Your header comment already says the important thing here, and it is why I think this is worth fixing rather than ignoring:

> this job only builds and uploads the report as an artifact, so it needs no write access and works for fork PRs (whose token here is read-only)

Fork PRs are explicitly in scope, which is exactly the case where the branch name is chosen by someone outside the project. The read-only token does limit the blast radius a lot, so I am raising this as hardening rather than as a live exploit.

The change binds both refs to environment variables:

```yaml
env:
  HEAD_REF: ${{ github.head_ref }}
  REF_NAME: ${{ github.ref_name }}
run: |
  ...
    REF="$HEAD_REF"
  ...
    REF="$REF_NAME"
```

I left `github.event_name`, `github.sha` and `pull_request.head.sha` interpolated on purpose — those are GitHub-controlled values with fixed shapes, not free text, so they do not carry the same problem. Artifact and report naming by branch + short SHA is unchanged.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its header notes myself.
