### PR TITLE
CI: require the AI usage disclosure, finish the #1052 injection hardening, pin third-party actions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,9 @@
 
 # AI usage disclosure (Fill this out):
 
+Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".
+
+- [ ] No AI assistance.
 - [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
 - [ ] Fully AI generated (explain what all the generated code does in moderate detail).
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -91,7 +91,8 @@ jobs:
           upload: "failure-only" # disable the upload here - we will upload in a different action
 
       - name: Filter dirs for SARIF
-        uses: advanced-security/filter-sarif@v1
+        # Third-party action pinned to a commit; mutable tags can be repointed.
+        uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1
         if: ${{ success() }}
         with:
           # filter out all test files unless they contain a sql-injection vulnerability

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -30,7 +30,9 @@ jobs:
     name: Lock inactive closed threads
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v6
+      # Third-party action pinned to a commit: this job holds issues+PRs write, and a
+      # mutable tag can be repointed at any time. Bump deliberately, not implicitly.
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6
         with:
           issue-inactive-days: "14"
           pr-inactive-days: "14"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -70,7 +70,10 @@ jobs:
             REF="$REF_NAME"
           fi
           SHORT="${SHA:0:8}"
-          SAFE_REF="${REF//\//-}"           # branch name, '/' -> '-' for artifact names
+          # Branch names may contain '$', '(', ')' and backticks, and these outputs are
+          # consumed by later steps, so reduce to a charset that is inert everywhere
+          # rather than only replacing '/' for artifact names.
+          SAFE_REF="$(printf '%s' "$REF" | tr -c 'A-Za-z0-9._-' '-')"
           echo "sha8=$SHORT"                >> "$GITHUB_OUTPUT"
           echo "ref=$SAFE_REF"              >> "$GITHUB_OUTPUT"
           echo "dist=${SAFE_REF}-${SHORT}"  >> "$GITHUB_OUTPUT"
@@ -135,13 +138,18 @@ jobs:
         shell: bash
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Derived from the branch name, so bind rather than interpolate (see #1052).
+          REF: ${{ steps.vars.outputs.ref }}
+          SHA8: ${{ steps.vars.outputs.sha8 }}
+          DIST: ${{ steps.vars.outputs.dist }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
         run: |
           {
             echo "<!-- unleashed-pr-report -->"
-            echo "## 🤖 Build & analyze — \`${{ steps.vars.outputs.ref }}\` @ \`${{ steps.vars.outputs.sha8 }}\`"
+            echo "## 🤖 Build & analyze — \`$REF\` @ \`$SHA8\`"
             echo ""
-            if [ "${{ steps.build.outcome }}" = "success" ]; then
-              echo "✅ **Firmware built** — artifact \`unleashed-fw-${{ steps.vars.outputs.dist }}\` ([run]($RUN_URL))"
+            if [ "$BUILD_OUTCOME" = "success" ]; then
+              echo "✅ **Firmware built** — artifact \`unleashed-fw-$DIST\` ([run]($RUN_URL))"
             else
               echo "❌ **Firmware build failed** — see the [run log]($RUN_URL)"
             fi

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,52 @@
+# Enforce the AI usage disclosure from .github/pull_request_template.md: exactly one of
+# the three boxes must be ticked. Leaving all three blank reads as "not filled out"
+# rather than "no AI", which is the whole point of having a "No AI assistance" option.
+#
+# Security: the PR body is attacker-controlled free text, so it is bound to an env var
+# and never interpolated into the script — the same mistake fixed in #1052. This job
+# checks out nothing and needs no token: `permissions: {}` denies every scope, which is
+# what makes plain `pull_request` (rather than `pull_request_target`) safe for fork PRs.
+#
+# `edited` is in the trigger list so a contributor only has to fix the description for
+# the check to re-run — no push, no re-run button.
+
+name: PR template check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions: {}
+
+concurrency:
+  group: pr-template-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ai-disclosure:
+    name: AI usage disclosure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Exactly one disclosure box ticked
+        shell: bash
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Tolerates '-' or '*' bullets, [x] or [X], and the CRLF line endings the web
+          # editor produces. An empty body yields 0 matches and fails with the same message.
+          ticked=$(printf '%s\n' "$BODY" |
+            grep -ciE '^[[:space:]]*[-*][[:space:]]*\[x\][[:space:]]*(No AI assistance|Partially AI assisted|Fully AI generated)' ||
+            true)
+
+          if [ "$ticked" = "1" ]; then
+            echo "AI usage disclosure: OK."
+            exit 0
+          fi
+
+          if [ "$ticked" = "0" ]; then
+            echo "::error title=AI usage disclosure not filled out::Tick exactly one box under 'AI usage disclosure' in the PR description - 'No AI assistance', 'Partially AI assisted' or 'Fully AI generated'. Leaving all three blank is treated as not filled out, not as 'no AI'. Editing the description re-runs this check."
+          else
+            echo "::error title=AI usage disclosure ambiguous::${ticked} boxes are ticked under 'AI usage disclosure' - tick exactly one. Editing the description re-runs this check."
+          fi
+          exit 1


### PR DESCRIPTION
# What's new

Closes #1053. Three related `.github/` changes.

**1. AI usage disclosure is now answerable, and required.**

Ported the third option and the intent line from [all-the-plugins#249](https://github.com/xMasterX/all-the-plugins/pull/249) verbatim so the two repos stay in sync:

```
Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (...)
- [ ] Fully AI generated (...)
```

New `pr-template-check.yml` fails the PR unless exactly one box is ticked. It goes further than ATP, which has the wording but no enforcement — and a template alone is what got us here (#1048 and #1049 both left the section blank; #1052 disclosed in prose because no box fit).

The check reads the body from the `pull_request` event payload, so it **checks out nothing and needs no token** — `permissions: {}` denies every scope, which is what makes plain `pull_request` safe for fork PRs rather than needing `pull_request_target`. `edited` is in the trigger list, so a contributor only has to fix the description for it to re-run; no push, no re-run button.

The body is attacker-controlled free text, so it is bound to `env:` rather than interpolated — the same mistake this PR is fixing elsewhere.

**2. Finished #1052's hardening.**

#1052 bound `github.head_ref`/`ref_name` to `env:`, but the branch name still reached a `run:` block through `steps.vars.outputs.ref`/`.dist`, because the sanitiser only replaced `/`:

```bash
SAFE_REF="${REF//\//-}"     # '$', '(', ')' and backticks all survive this
```

"Assemble PR report" then interpolated those outputs straight back into the shell, so `x$(id)` still executed two steps later. Fixed on both sides: those outputs are now `env:`-bound in the report step, and `SAFE_REF` is reduced to `[A-Za-z0-9._-]`, so the outputs are inert for every consumer rather than only for artifact names.

**3. Pinned the two third-party actions to commits.** `dessant/lock-threads` runs with `issues: write` + `pull-requests: write`; a mutable tag can be repointed at any time. First-party `actions/*` and `github/codeql-action/*` keep floating majors so they still get patch updates.

# Verification

**AI disclosure matcher** — 14 cases against the exact `grep` from the workflow:

| case | ticked | check |
|---|---|---|
| untouched template | 0 | fails ✅ |
| empty body | 0 | fails ✅ |
| each of the three ticked | 1 | passes ✅ |
| `[X]`, `*` bullet, extra indent, `-[x]` | 1 | passes ✅ |
| CRLF line endings | 1 | passes ✅ |
| two / three ticked | 2 / 3 | fails ✅ |
| prose disclosure, no checkbox (as in #1052) | 0 | fails ✅ |
| an unrelated ticked checkbox | 0 | fails ✅ |

**Injection fix** — the payload from #1052's description, before and after:

```
$ printf '%s' 'x$(echo PWNED)' | tr -c 'A-Za-z0-9._-' '-'
x--echo-PWNED-

$ REF='x$(echo PWNED)' bash -c 'echo "\`$REF\`"'     # env-bound, second layer
`x$(echo PWNED)`                                     # printed, not executed
```

**No behaviour change for ordinary branches** — `feat/some-branch` → `feat-some-branch`, exactly as the old `${REF//\//-}` produced, so artifact and report names are unchanged.

All seven workflow files parse as YAML. This PR is itself the first live test of the new check.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Claude Code was used to audit the workflows while reviewing #1052, which is how the residual `steps.vars.outputs.*` injection and the unpinned actions were found. It wrote the `pr-template-check.yml` matcher and the 14-case test harness above, and drafted the `pr-build.yml` changes. I verified the injection reproduction and the sanitiser output myself, and the template wording is copied from all-the-plugins#249.
