### PR TITLE
docs: building FAPs on Android with Termux (no PC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Disabled debug and trace logs in the FW binary (apps .fap's are not affected) to free up some flash space for new features
 * NFC: Fix typo in SLIX poller (by @WillyJL)
 * NFC: Internal MIFARE Plus cleanup - data-drive the "Add Manually" generator variants and unify the admin-key address mapping into one source of truth; small internal-flash saving, no functional change (by @mishamyte | PR #1035)
+* Docs: **How to build FAPs on Android with Termux** - `ufbt` on a stock phone, no PC/proot/VM (by @CamsShaft | Closes #1028)
 * NFC: Fix wrong parent protocol in the Type 4 Tag listener assert - copy-pasted from the SLIX listener, so debug builds crashed as soon as Type 4 Tag emulation received a frame; release builds were unaffected (by @mishamyte | PR #1051)
 <br><br>
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -267,6 +267,7 @@ Enhance your Flipper Zero with apps and plugins created by the community:
 
 - **Developer Documentation** - [developer.flipper.net](https://developer.flipper.net/flipperzero/doxygen)  
 - **[How to build](/documentation/HowToBuild.md#how-to-build-by-yourself) | [Project-structure](#project-structure)**
+- **[Build apps on Android with Termux](/documentation/BuildingFapsOnAndroid.md)** - compile `.fap` files on your phone, no PC needed<sub> by @CamsShaft</sub>
 - **CLion IDE** - How to setup workspace for flipper firmware development [by Savely Krasovsky](https://krasovs.ky/2022/11/01/flipper-zero-clion.html)
 - **"Hello world!"** - plugin tutorial [English<sub> by DroomOne</sub> ](https://github.com/DroomOne/Flipper-Plugin-Tutorial) | [Russian<sub> by Pavel Yakovlev</sub>](https://yakovlev.me/hello-flipper-zero)
 - [How to write your own app](https://flipper.atmanos.com/docs/overview/intro).

--- a/documentation/BuildingFapsOnAndroid.md
+++ b/documentation/BuildingFapsOnAndroid.md
@@ -1,0 +1,308 @@
+# Building FAPs on Android with Termux
+
+> Contributed by **[@CamsShaft](https://github.com/CamsShaft)**, adapted from
+> [BUILD-FLIPPER-FAPS-IN-TERMUX](https://github.com/CamsShaft/BUILD-FLIPPER-FAPS-IN-TERMUX) (MIT).
+
+Set up `ufbt` (micro Flipper Build Tool) inside [Termux](https://termux.dev/) on a stock Android phone and
+compile Flipper Zero applications (`.fap`) on-device. No PC, no proot, no virtual machine.
+
+**Scope:** this builds **applications**, not the firmware. Building the firmware itself with `fbt` is not
+covered here — see [HowToBuild.md](HowToBuild.md).
+
+Originally worked out on a Samsung Galaxy S22 (SM-S901W, aarch64). The paths below assume an **aarch64**
+device and the default Termux prefix (`$PREFIX` = `/data/data/com.termux/files/usr`). Nothing here is
+guaranteed to match your device exactly, but the failure modes are documented in
+[Troubleshooting](#troubleshooting).
+
+## Why this needs extra work
+
+ufbt downloads a prebuilt `arm-none-eabi-gcc` cross-toolchain built for ordinary Linux against glibc.
+Termux runs on Android's Bionic libc with a non-standard filesystem layout, and every ELF binary in that
+toolchain asks for `/lib/ld-linux-aarch64.so.1` as its dynamic linker — which does not exist on Android.
+
+The fix is to install Termux's glibc compatibility layer, then run each toolchain binary through glibc's
+own linker via a small wrapper script.
+
+> **Do not run `patchelf` on the toolchain binaries.** It corrupts their ELF segment layout and you get
+> segfaults out of `cc1`. The wrappers below leave the binaries byte-for-byte untouched.
+
+## Prerequisites
+
+- An aarch64 Android device
+- [Termux](https://f-droid.org/en/packages/com.termux/) installed **from F-Droid** — the Google Play build
+  is obsolete and will not work
+- An internet connection and a couple of GB free for the toolchain, SDK and glibc
+
+## 1. Base packages
+
+```sh
+pkg update && pkg upgrade -y
+pkg install python python-pip git file -y
+```
+
+`file` is not optional — the wrapper loop in step 6 uses it to tell ELF binaries apart from everything else.
+
+## 2. glibc compatibility layer
+
+```sh
+pkg install glibc-repo -y
+pkg install glibc-runner -y
+```
+
+These have to be two separate commands: `glibc-repo` is what adds the glibc repository that
+`glibc-runner` is served from. Together they install a full glibc under `$PREFIX/glibc/`, including the
+dynamic linker we need. Verify it:
+
+```sh
+ls $PREFIX/glibc/lib/ld-linux-aarch64.so.1
+```
+
+> **Never set `LD_PRELOAD` to glibc's `libc.so.6` globally.** It poisons Termux's own Bionic binaries,
+> Python included, and the breakage is not obvious. The wrappers in step 6 remove any need for it.
+
+## 3. Install ufbt and the Python build dependencies
+
+```sh
+pip install ufbt colorlog heatshrink2 pyelftools scons pillow
+```
+
+| Package | Needed for |
+|---|---|
+| `colorlog` | build script logging |
+| `heatshrink2` | icon and asset compression |
+| `pyelftools` | the `FASTFAP` post-processing step |
+| `scons` | the build system — needed as a standalone install, the toolchain's bundled copy is not usable here |
+| `pillow` | icon conversion; without it the only error you get is a bare `convert: No such file or directory` |
+
+If the `pillow` wheel fails to build, use the Termux package instead: `pkg install python-pillow`.
+
+## 4. Point ufbt at the Unleashed SDK
+
+**ufbt defaults to the official firmware SDK.** To build against Unleashed, pass this repository's update
+index:
+
+```sh
+ufbt update --index-url=https://up.unleashedflip.com/directory.json --channel=dev
+```
+
+Channels are `dev` and `release`. The index URL is also listed in the [ReadMe](../ReadMe.md#-links).
+**Every later `ufbt update` needs the same flags**, otherwise you silently fall back to the official SDK
+and your app is built against the wrong API.
+
+If `~/.ufbt/toolchain/` is still empty after that, any ufbt invocation bootstraps the toolchain:
+
+```sh
+ufbt -h
+```
+
+An error mentioning `python3` at this point is expected — step 5 fixes it. Check that the toolchain landed:
+
+```sh
+ls ~/.ufbt/toolchain/aarch64-linux/bin/arm-none-eabi-gcc
+ls ~/.ufbt/toolchain/aarch64-linux/arm-none-eabi/bin/as
+ls ~/.ufbt/toolchain/aarch64-linux/libexec/gcc/arm-none-eabi/*/cc1
+```
+
+## 5. Repoint the toolchain's Python
+
+The toolchain ships its own glibc-linked Python, which cannot run here. Point every `python3*` entry at
+Termux's Python instead:
+
+```sh
+TOOLCHAIN="$HOME/.ufbt/toolchain/aarch64-linux"
+
+for py in "$TOOLCHAIN"/bin/python3*; do
+    [ -e "$py" ] || [ -L "$py" ] || continue
+    ln -sf "$PREFIX/bin/python3" "$py"
+done
+```
+
+## 6. Wrap the toolchain binaries
+
+This is the step everything else depends on. Each wrapper invokes the real binary through glibc's dynamic
+linker with an explicit `--library-path`, so the binary itself is never modified.
+
+```sh
+TOOLCHAIN="$HOME/.ufbt/toolchain/aarch64-linux"
+GLIBC_LIB="$PREFIX/glibc/lib"
+
+wrap() {
+    for f in "$@"; do
+        [ -f "$f" ] || continue
+        case "$f" in *.real | *.so | *.so.*) continue ;; esac
+        [ -e "$f.real" ] && continue
+        file -b "$f" | grep -q '^ELF' || continue
+
+        mv "$f" "$f.real"
+        cat > "$f" <<WRAPPER
+#!$PREFIX/bin/bash
+exec "$GLIBC_LIB/ld-linux-aarch64.so.1" --library-path "$GLIBC_LIB:$TOOLCHAIN/lib" "$f.real" "\$@"
+WRAPPER
+        chmod +x "$f"
+        echo "wrapped $f"
+    done
+}
+
+wrap "$TOOLCHAIN"/bin/arm-none-eabi-*
+wrap "$TOOLCHAIN"/arm-none-eabi/bin/*
+wrap "$TOOLCHAIN"/libexec/gcc/arm-none-eabi/*/*
+```
+
+Those three globs are three separate directories of ELF binaries. Missing one gives a different failure:
+
+| Directory | Contains | Error if not wrapped |
+|---|---|---|
+| `bin/` | `arm-none-eabi-gcc`, `-g++`, ... | `cannot execute` / `No such file or directory` |
+| `arm-none-eabi/bin/` | `as`, `ld`, `ar`, `objcopy`, ... | `cannot execute as` |
+| `libexec/gcc/arm-none-eabi/<gcc-version>/` | `cc1`, `cc1plus`, `collect2`, `lto1` | `cannot execute cc1` |
+
+The guards matter, especially if you re-run this later:
+
+- `*.so` is skipped because `liblto_plugin.so` lives in `libexec/` and is a shared library, not an
+  executable. Wrapping it gives `invalid ELF header`.
+- `*.real` and the `$f.real` check keep the function idempotent, so re-running it after a toolchain update
+  cannot wrap a wrapper.
+- In `bin/` only `arm-none-eabi-*` is wrapped, deliberately: `bin/python3` now points at Termux's Bionic
+  Python and must **not** go through glibc's linker.
+
+**`ufbt update` can replace the toolchain — re-run steps 5 and 6 after every update.**
+
+## 7. Build
+
+```sh
+git clone https://github.com/<owner>/<some-flipper-app>.git
+cd <some-flipper-app>
+ufbt
+```
+
+A successful build ends like this:
+
+```
+scons: Entering directory '...'
+        CC      ...
+        LINK    ...
+        FAP     ...
+        FASTFAP ...
+        APPCHK  dist/some_app.fap
+                Target: 7, API: 88.2
+```
+
+The `.fap` is in `dist/`. Check the reported API against the firmware on your Flipper — a mismatch means
+the app will refuse to load.
+
+## 8. Getting the .fap onto the Flipper
+
+`ufbt launch` and `ufbt flash_usb` need a serial connection to the Flipper (`/dev/ttyACM*`).
+**On a stock, non-rooted Android this does not work** — Android does not expose USB CDC-ACM device nodes
+to Termux, so there is nothing for ufbt to talk to. Only a rooted device with a working CDC-ACM driver can
+use those commands.
+
+Copy the file out instead. FAPs live in `/ext/apps/<Category>/` on the microSD card
+(see [AppsOnSDCard.md](AppsOnSDCard.md)):
+
+```sh
+termux-setup-storage                        # one-time: grants Termux access to shared storage
+cp dist/some_app.fap ~/storage/downloads/
+```
+
+From `Downloads` the file is visible to every other app on the phone, so you can move it to the Flipper
+the way you normally would — the Flipper Mobile App, or a USB-C microSD card reader.
+
+## Troubleshooting
+
+### `cannot execute cc1` / `cannot execute as`
+
+One of the three directories in step 6 was not wrapped. Re-run the `wrap` calls — they are safe to repeat.
+
+### `liblto_plugin.so: invalid ELF header`
+
+A shared library got wrapped. Restore it:
+
+```sh
+LIBEXEC="$(echo "$HOME"/.ufbt/toolchain/aarch64-linux/libexec/gcc/arm-none-eabi/*)"
+mv "$LIBEXEC/liblto_plugin.so.real" "$LIBEXEC/liblto_plugin.so"
+```
+
+### `Segmentation fault` from cc1
+
+The binary was corrupted, almost always by `patchelf`. Re-download the toolchain and re-apply the wrappers:
+
+```sh
+rm -rf ~/.ufbt/toolchain
+ufbt -h
+```
+
+Then redo steps 5 and 6. **Never use `patchelf` on these binaries.**
+
+### `No module named 'colorlog'` / `'heatshrink2'` / `'elftools'`
+
+```sh
+pip install colorlog heatshrink2 pyelftools
+```
+
+### `convert: No such file or directory`
+
+`pillow` is missing: `pip install pillow`, or `pkg install python-pillow`.
+
+### `python3: No such file or directory`
+
+The toolchain's Python symlink is broken or was restored by an update. Re-run step 5.
+
+### `CANNOT LINK EXECUTABLE "python3": library "ld-linux-aarch64.so.1" not found`
+
+`LD_PRELOAD` is pointed at glibc's `libc.so.6`, which breaks Termux's own Bionic binaries. Clear it:
+
+```sh
+unset LD_PRELOAD
+unset -f ufbt          # in case a shell function is shadowing ufbt
+```
+
+Then check your shell startup files for leftovers:
+
+```sh
+grep -r "glibc\|LD_PRELOAD" ~/.bashrc ~/.profile ~/.bash_profile ~/.zshrc 2>/dev/null
+```
+
+### `ufbt update` says the SDK is up to date, but the toolchain is missing
+
+ufbt tracks the SDK and the toolchain separately. Force both:
+
+```sh
+rm -rf ~/.ufbt/current ~/.ufbt/toolchain
+ufbt update --index-url=https://up.unleashedflip.com/directory.json --channel=dev
+ufbt -h
+```
+
+Then redo steps 5 and 6.
+
+### The app builds but reports the wrong API version
+
+An `ufbt update` was run without `--index-url`, so ufbt switched back to the official SDK. Re-run the
+command from [step 4](#4-point-ufbt-at-the-unleashed-sdk).
+
+### The wrappers disappeared after an update
+
+Expected — `ufbt update` can replace the whole toolchain directory. Re-run steps 5 and 6.
+
+## What actually happens
+
+Each wrapper invokes its real binary through glibc's dynamic linker with an explicit `--library-path`
+pointing at glibc's libraries. When `arm-none-eabi-gcc` execs `cc1`, it hits a shell script that chains
+through the linker to the untouched `.real` binary. The cross-compiled output is unaffected — it targets
+bare-metal Cortex-M, not Linux.
+
+```
+ufbt (Python, Bionic)
+  └─ arm-none-eabi-gcc (wrapper)
+       └─ ld-linux-aarch64.so.1 → arm-none-eabi-gcc.real (glibc)
+            ├─ cc1 (wrapper)      → ld-linux-aarch64.so.1 → cc1.real
+            ├─ as (wrapper)       → ld-linux-aarch64.so.1 → as.real
+            └─ collect2 → ld (wrapper) → ld-linux-aarch64.so.1 → ld.real
+                 └─ output: some_app.fap (ARM Cortex-M4, for the Flipper Zero)
+```
+
+## Credits
+
+Worked out and written up by [@CamsShaft](https://github.com/CamsShaft) through extensive trial and error
+on a Samsung Galaxy S22 running Termux — no PC, no proot, no virtual machines. Original guide and its MIT
+license: [BUILD-FLIPPER-FAPS-IN-TERMUX](https://github.com/CamsShaft/BUILD-FLIPPER-FAPS-IN-TERMUX).

--- a/documentation/HowToBuild.md
+++ b/documentation/HowToBuild.md
@@ -58,3 +58,7 @@ Check `dist/` for build outputs.
 Use `flipper-z-{target}-update-{suffix}.tgz` to flash your device.
 
 If compilation fails, make sure all submodules are all initialized. Either clone with `--recursive` or use `git submodule update --init --recursive`.
+
+# Build apps on Android (no PC)
+
+Applications (`.fap`) can also be built on an Android phone with `ufbt` running inside Termux — see [Building FAPs on Android with Termux](BuildingFapsOnAndroid.md). This covers apps only, not the firmware.


### PR DESCRIPTION
# What's new

Closes #1028

Adds `documentation/BuildingFapsOnAndroid.md` — how to run `ufbt` inside Termux on a stock Android phone and build `.fap` applications on-device, with no PC, proot or VM.

Adapted **with permission** from [@CamsShaft](https://github.com/CamsShaft)'s [BUILD-FLIPPER-FAPS-IN-TERMUX](https://github.com/CamsShaft/BUILD-FLIPPER-FAPS-IN-TERMUX) (MIT), offered in #1028. They are credited in the doc header, in the Credits section, in the ReadMe link and in the changelog.

Linked from `documentation/HowToBuild.md` and the ReadMe's *Firmware & Development* section.

The guide covers **applications only**, not firmware — `fbt` is out of scope and the doc says so up front.

## Changes made to the original

Three substantive ones, all noted here so the author can pull them back upstream if they want:

1. **Unleashed SDK, not the official one.** The original runs a plain `ufbt update`, which pulls the *official* firmware SDK (its sample output shows API 87.1). The doc now uses
   `ufbt update --index-url=https://up.unleashedflip.com/directory.json --channel=dev`
   and warns that every later `ufbt update` needs the same flags, or you silently drop back to the official SDK and build against the wrong API. Same index the ReadMe already lists and `applications_user/dallas_tester` CI already uses.

2. **`ufbt launch` doesn't work unrooted — replaced.** The original's deploy step says to connect over USB OTG and run `ufbt launch`. Android does not expose USB CDC-ACM device nodes (`/dev/ttyACM*`) to Termux without root, so there is nothing for ufbt's serial layer to talk to. Step 8 now says this plainly, and deploys by copying the `.fap` out through `termux-setup-storage` → shared storage instead, cross-linked to `AppsOnSDCard.md`.

3. **Toolchain wrapper loop hardened.** The original is three copy-pasted loops; this is one `wrap()` helper called with three globs, plus:
   - the gcc version directory is globbed (`libexec/gcc/arm-none-eabi/*/*`) instead of hardcoded to `12.3.1`, which is only correct for the current toolchain 39;
   - `*.real` payloads are skipped and `$f.real` is checked, so the loop is idempotent. The original's `bin/arm-none-eabi-*` glob re-matches `…gcc.real` on a second run and wraps the wrapper — and the original itself tells you to re-run these steps after every `ufbt update`;
   - `bin/python3` is deliberately left out of the glob, since by then it points at Termux's Bionic Python and must not be run through glibc's linker;
   - `python3*` is symlinked with `ln -sf` over a glob instead of `rm`-ing a hardcoded `python3.11`.

Smaller edits: `pillow`/`scons` table rows rewritten from the original's venting into what the packages are actually for, a `pkg install python-pillow` fallback if the wheel won't build, a note that the two `glibc-*` installs must be separate commands (`glibc-repo` is what adds the repo `glibc-runner` comes from), and troubleshooting entries for the two new failure modes (wrong API version, wrappers gone after an update).

# Verification

No code changes — docs only.

- `pkg install` names checked against the live Termux `termux-main` index: `file`, `python-pip`, `python-pillow`, `glibc-repo` all present (`glibc-runner` comes from the repo `glibc-repo` adds).
- `gcc-arm-none-eabi-12.3-aarch64-linux-flipper-39.tar.gz` returns 200, so the aarch64 Linux toolchain the guide depends on really is published.
- `https://up.unleashedflip.com/directory.json` parsed — `development` / `release-candidate` / `release` channels present, `dev` and `release` populated.
- The step 5 and 6 shell blocks were extracted from the rendered markdown and executed against a mock toolchain tree (`bin/`, `arm-none-eabi/bin/`, `libexec/gcc/arm-none-eabi/12.3.1/` with `cc1`, `liblto_plugin.so`, an `install-tools/` dir, a non-ELF script and `python3`/`python3.11`). Result: the 4 intended binaries wrapped, `liblto_plugin.so` / `python3*` / the directory / the script untouched, a second run wrapped nothing, and the generated wrapper contains the right absolute paths and a literal `"$@"`.
- All relative links and heading anchors in the new doc resolve (`HowToBuild.md`, `AppsOnSDCard.md`, `../ReadMe.md#-links`, `#troubleshooting`, `#4-point-ufbt-at-the-unleashed-sdk`).

**Not verified on hardware:** nobody here has run the full flow end-to-end on an Android phone. The procedure is @CamsShaft's, who reports doing exactly that from scratch on a Galaxy S22. The three changes above are the parts that most warrant a second pair of eyes on a real device — particularly whether `--index-url` survives the toolchain bootstrap in step 4.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The prose and structure of the guide are @CamsShaft's work, reorganised for this repo. AI assistance was used to adapt it: rewriting the wrapper loops into the idempotent, version-agnostic `wrap()` helper, adding the Unleashed `--index-url` step, replacing the `ufbt launch` deploy step, and running the verification listed above (package-index and toolchain-URL checks, the mock-toolchain execution of the shell blocks, and the link/anchor check).

# Checklist (For Reviewer) (Don't fill this out!):

- [ ] PR has proper description of new feature/bugfix
- [ ] Description contains actions to verify feature/bugfix on the hardware
- [ ] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


