### PR TITLE
RPC: fix crash on unhandled loader start status

### DIFF
--- a/applications/services/rpc/rpc_app.c
+++ b/applications/services/rpc/rpc_app.c
@@ -92,17 +92,23 @@ static void rpc_system_app_start_process(const PB_Main* request, void* context) 
             app_args = app_args_temp;
         }
 
-        const LoaderStatus status = loader_start(loader, app_name, app_args, NULL);
-        if(status == LoaderStatusErrorAppStarted) {
-            result = PB_CommandStatus_ERROR_APP_SYSTEM_LOCKED;
-        } else if(status == LoaderStatusErrorInternal) {
-            result = PB_CommandStatus_ERROR_APP_CANT_START;
-        } else if(status == LoaderStatusErrorUnknownApp) {
-            result = PB_CommandStatus_ERROR_INVALID_PARAMETERS;
-        } else if(status == LoaderStatusOk) {
+        result = PB_CommandStatus_ERROR_APP_CANT_START;
+
+        switch(loader_start(loader, app_name, app_args, NULL)) {
+        case LoaderStatusOk:
             result = PB_CommandStatus_OK;
-        } else {
-            furi_crash();
+            break;
+        case LoaderStatusErrorAppStarted:
+            result = PB_CommandStatus_ERROR_APP_SYSTEM_LOCKED;
+            break;
+        case LoaderStatusErrorUnknownApp:
+            result = PB_CommandStatus_ERROR_INVALID_PARAMETERS;
+            break;
+        case LoaderStatusErrorInternal:
+        case LoaderStatusErrorApiMismatch:
+        case LoaderStatusErrorApiMismatchExit:
+            result = PB_CommandStatus_ERROR_APP_CANT_START;
+            break;
         }
     } else {
         result = PB_CommandStatus_ERROR_INVALID_PARAMETERS;


### PR DESCRIPTION
# What's new

Bug fix crash on unhandled loader start status

# Verification 

Open old app on rpc
Close on "App to old"
Crash "FatalError"

After update 

Open old app on rpc
Close on "App to old"
on qUnleashed notification "Fail to launch <app>"

# Author Checklist (Fill this out):

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [X] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Search code, git

# Checklist (For Reviewer) (Don't fill this out!):

- [x] PR has proper description of new feature/bugfix
- [x] Description contains actions to verify feature/bugfix on the hardware
- [x] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
