### PR TITLE
NFC Ultralight AES: close the remaining AUTHLIM card-lock paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - JS Runner, NFC: **Fix some out of memory crashes** - apps no longer bundle their own copy of the soft-float code, it is shared from the firmware now
 - OFW: NFC DESFire: **Fix crash when reading card with a zero-key application**
 - NFC: **Ultralight AES is no longer dictionary attacked automatically on read** - unlike Ultralight C it has an auth attempt limit, and wrong keys can lock the card permanently, so it is now started manually from "Unlock with Dictionary" with a warning
-- NFC: **Ultralight AES - closed the remaining card-lock (AUTHLIM) paths** - the Random ID real-UID reveal is now an explicit "Reveal Real UID" action instead of an automatic auth on every read (which silently spent attempts on personalized cards), and writing to a protected card now warns first since it brute-forces the key
+- NFC: **Ultralight AES - closed the remaining card-lock (AUTHLIM) paths** - the Random ID real-UID reveal is now an explicit "Reveal Real UID" action instead of an automatic auth on every read (which silently spent attempts on personalized cards), and writing to a protected card now warns first since it brute-forces the key (by @mishamyte | PR #1082 | Fixes #1081)
 - Apps: **Added categories for apps in firmware builds**, if you had apps that were moved to new subfolders in favourites, or on quick buttons, you will need to re-add them to favs/buttons
 - Apps: Build tag (**17aug2026**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - JS Runner, NFC: **Fix some out of memory crashes** - apps no longer bundle their own copy of the soft-float code, it is shared from the firmware now
 - OFW: NFC DESFire: **Fix crash when reading card with a zero-key application**
 - NFC: **Ultralight AES is no longer dictionary attacked automatically on read** - unlike Ultralight C it has an auth attempt limit, and wrong keys can lock the card permanently, so it is now started manually from "Unlock with Dictionary" with a warning
+- NFC: **Ultralight AES - closed the remaining card-lock (AUTHLIM) paths** - the Random ID real-UID reveal is now an explicit "Reveal Real UID" action instead of an automatic auth on every read (which silently spent attempts on personalized cards), and writing to a protected card now warns first since it brute-forces the key
 - Apps: **Added categories for apps in firmware builds**, if you had apps that were moved to new subfolders in favourites, or on quick buttons, you will need to re-add them to favs/buttons
 - Apps: Build tag (**17aug2026**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes

--- a/applications/main/nfc/helpers/mf_ultralight_auth.c
+++ b/applications/main/nfc/helpers/mf_ultralight_auth.c
@@ -5,6 +5,8 @@
 
 MfUltralightAuth* mf_ultralight_auth_alloc(void) {
     MfUltralightAuth* instance = malloc(sizeof(MfUltralightAuth));
+    mf_ultralight_auth_reset(
+        instance); // start in a known (None) state, not relying on the allocator
 
     return instance;
 }

--- a/applications/main/nfc/helpers/mf_ultralight_auth.h
+++ b/applications/main/nfc/helpers/mf_ultralight_auth.h
@@ -12,6 +12,7 @@ typedef enum {
     MfUltralightAuthTypeManual,
     MfUltralightAuthTypeXiaomi,
     MfUltralightAuthTypeAmiibo,
+    MfUltralightAuthTypeUidReveal, // UL-AES: user-requested real-UID reveal (all-zero UIDRetrKey)
 } MfUltralightAuthType;
 
 typedef struct {

--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
@@ -137,8 +137,7 @@ static NfcCommand
             //   - Manual key entry -> try their DataProtKey.
             //   - "Reveal Real UID" (Random ID cards) -> try the default all-zero UIDRetrKey to
             //     reveal the hidden static UID (kept in pages 0-1, shown as "Real UID" in config).
-            //     A non-default UIDRetrKey fails and keeps showing the random UID, at the cost of
-            //     one auth attempt - which is why it is behind an explicit, warned action.
+            //     A non-default UIDRetrKey fails and keeps showing the random UID.
             if(instance->mf_ul_auth->type == MfUltralightAuthTypeManual) {
                 mf_ultralight_event->data->auth_context.skip_auth = false;
                 mf_ultralight_event->data->auth_context.aes_key = instance->mf_ul_auth->aes_key;
@@ -258,10 +257,6 @@ bool nfc_scene_read_on_event_mf_ultralight(NfcApp* instance, SceneManagerEvent e
 static void nfc_scene_read_and_saved_menu_on_enter_mf_ultralight(NfcApp* instance) {
     Submenu* submenu = instance->submenu;
 
-    // Clear any auth intent left over from a menu action that was started then cancelled/aborted
-    // (e.g. "Reveal Real UID"), so it can never carry into a later plain read and auto-authenticate.
-    mf_ultralight_auth_reset(instance->mf_ul_auth);
-
     const MfUltralightData* data =
         nfc_device_get_data(instance->nfc_device, NfcProtocolMfUltralight);
     bool is_locked = !mf_ultralight_is_all_data_read(data);
@@ -310,9 +305,8 @@ static void nfc_scene_read_and_saved_menu_on_enter_mf_ultralight(NfcApp* instanc
         }
     }
 
-    // Random ID UL-AES (4-byte anticollision UID starting 0x08) hides its real static UID behind an
-    // AES auth. Offer an explicit, warned action to reveal it - never done automatically, as a wrong
-    // UIDRetrKey costs an AUTHLIM attempt (see the AuthRequest handler).
+    // Random ID cards (4-byte UID starting 0x08) hide the real static UID; offer an explicit reveal
+    // action here (see the AuthRequest handler for why it is not done automatically).
     if(data->type == MfUltralightTypeUltralightAES && data->iso14443_3a_data->uid_len == 4 &&
        data->iso14443_3a_data->uid[0] == 0x08) {
         submenu_add_item(
@@ -383,8 +377,7 @@ static bool nfc_scene_read_and_saved_menu_on_event_mf_ultralight(
             scene_manager_next_scene(instance->scene_manager, next_scene);
             consumed = true;
         } else if(event.event == SubmenuIndexRevealUid) {
-            // Reveal the hidden real UID: try the default all-zero UIDRetrKey. A wrong key costs an
-            // AUTHLIM attempt, so confirm first, then re-read with the reveal auth type set.
+            // Set the reveal auth type, then confirm via the warn scene before re-reading.
             instance->mf_ul_auth->type = MfUltralightAuthTypeUidReveal;
             nfc_mf_ultralight_aes_warn(instance, NfcSceneRead);
             consumed = true;

--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
@@ -17,6 +17,7 @@ enum {
     SubmenuIndexDictAttack,
     SubmenuIndexWriteKeepKey, // ULC: write data pages, keep target card's existing key
     SubmenuIndexWriteCopyKey, // ULC: write all pages including key from source card
+    SubmenuIndexRevealUid, // UL-AES Random ID: reveal the hidden real UID (all-zero UIDRetrKey)
 };
 
 enum {
@@ -130,19 +131,19 @@ static NfcCommand
         const MfUltralightData* data =
             nfc_device_get_data(instance->nfc_device, NfcProtocolMfUltralight);
         if(data->type == MfUltralightTypeUltralightAES) {
-            // UL-AES auth is AES, not password: only the manual key-entry flow supplies a key, so
-            // skip otherwise - except a Random ID card (4-byte anticollision UID starting 0x08),
-            // where we auto-authenticate with the default all-zero UIDRetrKey to reveal the real
-            // static UID it hides. That UID then stays in pages 0-1 (the config view shows it as
-            // "Real UID"); the presented random UID is deliberately left in place. A non-default
-            // UIDRetrKey just fails this auth and keeps showing the random UID.
-            const bool random_id =
-                (data->iso14443_3a_data->uid_len == 4 && data->iso14443_3a_data->uid[0] == 0x08);
+            // UL-AES auth is AES, not password, and it has an AUTHLIM - a failed auth is counted and
+            // can permanently lock the card. So NEVER authenticate automatically on a plain read;
+            // only when the user explicitly asked for it:
+            //   - Manual key entry -> try their DataProtKey.
+            //   - "Reveal Real UID" (Random ID cards) -> try the default all-zero UIDRetrKey to
+            //     reveal the hidden static UID (kept in pages 0-1, shown as "Real UID" in config).
+            //     A non-default UIDRetrKey fails and keeps showing the random UID, at the cost of
+            //     one auth attempt - which is why it is behind an explicit, warned action.
             if(instance->mf_ul_auth->type == MfUltralightAuthTypeManual) {
                 mf_ultralight_event->data->auth_context.skip_auth = false;
                 mf_ultralight_event->data->auth_context.aes_key = instance->mf_ul_auth->aes_key;
                 mf_ultralight_event->data->auth_context.aes_key_type = MfUltralightAesKeyTypeData;
-            } else if(random_id) {
+            } else if(instance->mf_ul_auth->type == MfUltralightAuthTypeUidReveal) {
                 const MfUltralightAesKey uid_key = {0};
                 mf_ultralight_event->data->auth_context.skip_auth = false;
                 mf_ultralight_event->data->auth_context.aes_key = uid_key;
@@ -211,6 +212,18 @@ static void nfc_mf_ultralight_aes_warn(NfcApp* instance, uint32_t next_scene) {
     scene_manager_next_scene(instance->scene_manager, NfcSceneMfUltralightAesDictAttackWarn);
 }
 
+// Start a write. Writing to a protected UL-AES target dictionary-attacks it for the write key, which
+// burns AUTHLIM attempts, so warn first; UL-C and the rest go straight to the write.
+static void nfc_mf_ultralight_write_confirm(NfcApp* instance) {
+    const MfUltralightData* data =
+        nfc_device_get_data(instance->nfc_device, NfcProtocolMfUltralight);
+    if(data->type == MfUltralightTypeUltralightAES) {
+        nfc_mf_ultralight_aes_warn(instance, NfcSceneWrite);
+    } else {
+        scene_manager_next_scene(instance->scene_manager, NfcSceneWrite);
+    }
+}
+
 bool nfc_scene_read_on_event_mf_ultralight(NfcApp* instance, SceneManagerEvent event) {
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == NfcCustomEventPollerSuccess) {
@@ -244,6 +257,10 @@ bool nfc_scene_read_on_event_mf_ultralight(NfcApp* instance, SceneManagerEvent e
 
 static void nfc_scene_read_and_saved_menu_on_enter_mf_ultralight(NfcApp* instance) {
     Submenu* submenu = instance->submenu;
+
+    // Clear any auth intent left over from a menu action that was started then cancelled/aborted
+    // (e.g. "Reveal Real UID"), so it can never carry into a later plain read and auto-authenticate.
+    mf_ultralight_auth_reset(instance->mf_ul_auth);
 
     const MfUltralightData* data =
         nfc_device_get_data(instance->nfc_device, NfcProtocolMfUltralight);
@@ -291,6 +308,19 @@ static void nfc_scene_read_and_saved_menu_on_enter_mf_ultralight(NfcApp* instanc
                 nfc_protocol_support_common_submenu_callback,
                 instance);
         }
+    }
+
+    // Random ID UL-AES (4-byte anticollision UID starting 0x08) hides its real static UID behind an
+    // AES auth. Offer an explicit, warned action to reveal it - never done automatically, as a wrong
+    // UIDRetrKey costs an AUTHLIM attempt (see the AuthRequest handler).
+    if(data->type == MfUltralightTypeUltralightAES && data->iso14443_3a_data->uid_len == 4 &&
+       data->iso14443_3a_data->uid[0] == 0x08) {
+        submenu_add_item(
+            submenu,
+            "Reveal Real UID",
+            SubmenuIndexRevealUid,
+            nfc_protocol_support_common_submenu_callback,
+            instance);
     }
 }
 
@@ -343,17 +373,20 @@ static bool nfc_scene_read_and_saved_menu_on_event_mf_ultralight(
                 nfc_device_get_data(instance->nfc_device, NfcProtocolMfUltralight);
 
             // UL-C (3DES) and UL-AES both enter a 16-byte key via the shared DesAuth key input;
-            // other types use the password-based unlock menu.
+            // other types use the password-based unlock menu. UL-AES's brick warning lives on the
+            // DesAuthUnlockWarn confirm that follows key entry (it shows the exact key), so no extra
+            // pre-entry warning here.
             uint32_t next_scene = (data->type == MfUltralightTypeMfulC ||
                                    data->type == MfUltralightTypeUltralightAES) ?
                                       NfcSceneDesAuthKeyInput :
                                       NfcSceneMfUltralightUnlockMenu;
-            if(data->type == MfUltralightTypeUltralightAES) {
-                // A wrong key costs an auth attempt here too, so warn before key entry
-                nfc_mf_ultralight_aes_warn(instance, next_scene);
-            } else {
-                scene_manager_next_scene(instance->scene_manager, next_scene);
-            }
+            scene_manager_next_scene(instance->scene_manager, next_scene);
+            consumed = true;
+        } else if(event.event == SubmenuIndexRevealUid) {
+            // Reveal the hidden real UID: try the default all-zero UIDRetrKey. A wrong key costs an
+            // AUTHLIM attempt, so confirm first, then re-read with the reveal auth type set.
+            instance->mf_ul_auth->type = MfUltralightAuthTypeUidReveal;
+            nfc_mf_ultralight_aes_warn(instance, NfcSceneRead);
             consumed = true;
         } else if(event.event == SubmenuIndexDictAttack) {
             const MfUltralightData* data =
@@ -371,11 +404,11 @@ static bool nfc_scene_read_and_saved_menu_on_event_mf_ultralight(
             consumed = true;
         } else if(event.event == SubmenuIndexWriteKeepKey) {
             instance->mf_ultralight_c_write_context.copy_key = false;
-            scene_manager_next_scene(instance->scene_manager, NfcSceneWrite);
+            nfc_mf_ultralight_write_confirm(instance);
             consumed = true;
         } else if(event.event == SubmenuIndexWriteCopyKey) {
             instance->mf_ultralight_c_write_context.copy_key = true;
-            scene_manager_next_scene(instance->scene_manager, NfcSceneWrite);
+            nfc_mf_ultralight_write_confirm(instance);
             consumed = true;
         }
     }

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support_unlock_helper.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support_unlock_helper.c
@@ -19,6 +19,10 @@ static void nfc_scene_read_setup_view(NfcApp* instance) {
 }
 
 void nfc_unlock_helper_setup_from_state(NfcApp* instance) {
+    // Every read enters through here, and this is the one place that knows whether the read was
+    // started from an unlock/reveal warn. Anything else is a plain read, which must carry no auth
+    // intent: a UL-AES key left over from an aborted reveal/unlock re-read would otherwise
+    // auto-authenticate the next card and silently spend an AUTHLIM attempt (bricking it eventually).
     bool unlocking =
         scene_manager_has_previous_scene(
             instance->scene_manager, NfcSceneMfUltralightUnlockWarn) ||
@@ -26,6 +30,8 @@ void nfc_unlock_helper_setup_from_state(NfcApp* instance) {
         // UL-AES "Reveal Real UID" re-reads via this warn scene, so treat it as an unlock too.
         scene_manager_has_previous_scene(
             instance->scene_manager, NfcSceneMfUltralightAesDictAttackWarn);
+
+    if(!unlocking) mf_ultralight_auth_reset(instance->mf_ul_auth);
 
     uint32_t state = unlocking ? NfcSceneReadMenuStateCardSearch : NfcSceneReadMenuStateCardFound;
 

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support_unlock_helper.c
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support_unlock_helper.c
@@ -22,7 +22,10 @@ void nfc_unlock_helper_setup_from_state(NfcApp* instance) {
     bool unlocking =
         scene_manager_has_previous_scene(
             instance->scene_manager, NfcSceneMfUltralightUnlockWarn) ||
-        scene_manager_has_previous_scene(instance->scene_manager, NfcSceneDesAuthUnlockWarn);
+        scene_manager_has_previous_scene(instance->scene_manager, NfcSceneDesAuthUnlockWarn) ||
+        // UL-AES "Reveal Real UID" re-reads via this warn scene, so treat it as an unlock too.
+        scene_manager_has_previous_scene(
+            instance->scene_manager, NfcSceneMfUltralightAesDictAttackWarn);
 
     uint32_t state = unlocking ? NfcSceneReadMenuStateCardSearch : NfcSceneReadMenuStateCardFound;
 


### PR DESCRIPTION
# What's new

Closes #1081. Follow-up to `4533be79` / `a358671` (which stopped auto-dictionary-attacking Ultralight AES on read).

MIFARE Ultralight AES has a **negative authentication limit (AUTH_LIM)** that Ultralight C does not. Per the MF0AES(H)20 datasheet **§8.6.5**: if `AUTH_LIM` is set (NXP recommends `<100` on deployed cards), each failed AES `AUTHENTICATE` is counted with anti-tearing and persists across power cycles; once the counter reaches the limit the protected memory is **permanently locked** — from then on *every* authentication fails "independent if the authentication is valid or not", i.e. even the correct key can no longer unlock it. Only a *successful* auth decrements the counter. So wrong keys can permanently brick a personalized card.

The earlier fix gated the two explicit attack menus. Auditing every UL-AES auth path turned up three more that could still spend AUTH_LIM attempts — two of them silently:

1. **Random ID real-UID reveal was automatic on every plain read.** The poller auto-authenticated with the default all-zero UIDRetrKey on every scan of a Random-ID card to reveal the hidden static UID; on a *personalized* card that fails and silently spends an attempt each read. It is now an explicit, warned **"Reveal Real UID"** menu action (new `MfUltralightAuthTypeUidReveal`), shown only for Random-ID UL-AES cards. Plain reads never authenticate.
2. **Write (Keep/Copy Key) brute-forces a protected target.** The write flow runs the full user+system AES dictionary against the target to gain write auth — the same brute force that was gated for the dictionary attack, but unwarned. It now shows the brick warning first for UL-AES.
3. **Manual key entry showed two "Risky Action!" dialogs.** Dropped the redundant pre-entry one, keeping the key-showing `DesAuthUnlockWarn` confirm (its key display lets the user catch a typo before it costs an attempt).

Invariant enforced throughout: **a UL-AES card is never authenticated automatically on a plain read** — only on an explicit, warned user action. Auth intent is cleared for plain reads at the single choke point every read funnels through (`nfc_unlock_helper_setup_from_state`, keyed on its existing `unlocking` discriminator), so an aborted reveal/unlock re-read can't carry an auth attempt into the next card.

# Verification

Requires a real MF0AES20 card personalized with `AUTH_LIM` set and (for the reveal test) Random ID enabled + a non-default UIDRetrKey; a PM3 is the easiest way to configure/inspect it.

- **No silent auto-auth:** repeatedly Read a personalized UL-AES card; confirm the auth-attempt counter (readable via PM3 / config page) does **not** increase per read.
- **Reveal:** for a Random ID card, the read menu shows **"Reveal Real UID"**; selecting it warns first, then on confirm re-reads and shows the real UID under "Real UID" in the card info. Plain reads keep showing the random UID.
- **Write:** Write (Keep Key) / Write (Copy Key) to a UL-AES target shows the brick warning before starting.
- **Manual unlock:** entering a key shows a single confirmation (the one that displays the key), not two.
- **Regression (the review-found bug):** start "Reveal Real UID", Continue, then press Back while it waits for the card; go back and Read a different UL-AES card — confirm no auth attempt is spent on it.
- **Untouched:** Ultralight C read / unlock / dict-attack / write behave exactly as before.

> Note: not yet hardware-tested by me — host build + full control-flow review only. On-device validation still needed before merge.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

Written with Claude Code under my direction; I made the design decisions (reveal as an opt-in action, warn before write, drop the duplicate warning) and reviewed the result. What the generated code does:

- `MfUltralightAuthTypeUidReveal` (new enum value) + the AuthRequest handler in `helpers/protocol_support/mf_ultralight/mf_ultralight.c`: the UL-AES read handler now authenticates only when the auth type is `Manual` (user's DataProtKey) or `UidReveal` (all-zero UIDRetrKey), and skips auth otherwise — removing the old automatic Random-ID auth.
- Read/saved menu: adds a "Reveal Real UID" item for Random-ID UL-AES cards that sets the reveal auth type and routes through the existing warn scene; `nfc_mf_ultralight_write_confirm` gates the two Write actions behind the same warn for UL-AES; the redundant pre-entry warn on manual unlock was removed.
- `nfc_unlock_helper_setup_from_state`: resets the UL-AES auth intent whenever a read is not an unlock/reveal read (`!unlocking`), which is the choke point that guarantees plain reads never carry a stale auth attempt.
- `mf_ultralight_auth_alloc`: initializes to a known (None) state.

Reviewed with the repo's pr-review-toolkit (code / comments / silent-failure / type-design) and `/simplify` passes before opening; the silent-failure pass caught the aborted-re-read carry-over, which is fixed by the choke-point reset above. Builds clean (`fbt fap_nfc`, APPCHK), `fbt format` + lint clean.

# Checklist (For Reviewer) (Don't fill this out!):

- [x] PR has proper description of new feature/bugfix
- [x] Description contains actions to verify feature/bugfix on the hardware
- [x] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
