### PR TITLE
[NFC]: drop the unreachable EMV render code that called an undefined function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Apps: Build tag (**18aug2026p2**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes
 - BadUSB: Moved demo files to examples folder
+- NFC: Removed unreachable EMV render code that called an undefined function (by @mishamyte | PR #1085 | Fixes #1084)
 <br><br>
 
 ----

--- a/applications/main/nfc/helpers/protocol_support/emv/emv_render.c
+++ b/applications/main/nfc/helpers/protocol_support/emv/emv_render.c
@@ -1,6 +1,5 @@
 #include "emv_render.h"
 
-#include "../iso14443_4a/iso14443_4a_render.h"
 #include <bit_lib.h>
 #include "nfc/nfc_app_i.h"
 

--- a/applications/main/nfc/helpers/protocol_support/emv/emv_render.c
+++ b/applications/main/nfc/helpers/protocol_support/emv/emv_render.c
@@ -30,28 +30,6 @@ void nfc_render_emv_uid(const uint8_t* uid, const uint8_t uid_len, FuriString* s
     furi_string_cat_printf(str, "\n");
 }
 
-void nfc_render_emv_data(const EmvData* data, FuriString* str) {
-    nfc_render_emv_pan(data->emv_application.pan, data->emv_application.pan_len, str);
-    nfc_render_emv_name(data->emv_application.application_name, str);
-}
-
-void nfc_render_emv_pan(const uint8_t* data, const uint8_t len, FuriString* str) {
-    if(len == 0) return;
-
-    FuriString* card_number = furi_string_alloc();
-    for(uint8_t i = 0; i < len; i++) {
-        if((i % 2 == 0) && (i != 0)) furi_string_cat_printf(card_number, " ");
-        furi_string_cat_printf(card_number, "%02X", data[i]);
-    }
-
-    // Cut padding 'F' from card number
-    furi_string_trim(card_number, "F");
-    furi_string_cat(str, card_number);
-    furi_string_free(card_number);
-
-    furi_string_cat_printf(str, "\n");
-}
-
 void nfc_render_emv_currency(uint16_t cur_code, FuriString* str) {
     if(!cur_code) return;
 

--- a/applications/main/nfc/helpers/protocol_support/emv/emv_render.h
+++ b/applications/main/nfc/helpers/protocol_support/emv/emv_render.h
@@ -7,12 +7,6 @@
 
 void nfc_render_emv_info(const EmvData* data, NfcProtocolFormatType format_type, FuriString* str);
 
-void nfc_render_emv_data(const EmvData* data, FuriString* str);
-
-void nfc_render_emv_pan(const uint8_t* data, const uint8_t len, FuriString* str);
-
-void nfc_render_emv_name(const char* data, FuriString* str);
-
 void nfc_render_emv_application(const EmvApplication* data, FuriString* str);
 
 void nfc_render_emv_application_interchange_profile(const EmvApplication* apl, FuriString* str);

--- a/applications/main/nfc/nfc_app.c
+++ b/applications/main/nfc/nfc_app.c
@@ -265,7 +265,7 @@ void nfc_blink_stop(NfcApp* nfc) {
     notification_message(nfc->notifications, &sequence_blink_stop);
 }
 
-void nfc_make_app_folders(NfcApp* instance) {
+static void nfc_make_app_folders(NfcApp* instance) {
     furi_assert(instance);
 
     if(!storage_simply_mkdir(instance->storage, NFC_APP_FOLDER)) {

--- a/applications/main/nfc/nfc_app_i.h
+++ b/applications/main/nfc/nfc_app_i.h
@@ -261,8 +261,6 @@ typedef enum {
 extern "C" {
 #endif
 
-int32_t nfc_task(void* p);
-
 void nfc_text_store_set(NfcApp* nfc, const char* text, ...);
 
 void nfc_text_store_clear(NfcApp* nfc);
@@ -297,8 +295,6 @@ bool nfc_load_from_file_select(NfcApp* instance);
 bool nfc_load_file(NfcApp* instance, FuriString* path, bool show_dialog);
 
 bool nfc_save_file(NfcApp* instance, FuriString* path);
-
-void nfc_make_app_folder(NfcApp* instance);
 
 void nfc_append_filename_string_when_present(NfcApp* instance, FuriString* string);
 

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller_i.h
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller_i.h
@@ -33,9 +33,6 @@ extern "C" {
 #define SET_PACKED_BIT(arr, bit) ((arr)[(bit) / 8] |= (1 << ((bit) % 8)))
 #define GET_PACKED_BIT(arr, bit) ((arr)[(bit) / 8] & (1 << ((bit) % 8)))
 
-extern const MfClassicKey auth1_backdoor_key;
-extern const MfClassicKey auth2_backdoor_key;
-extern const MfClassicKey auth3_backdoor_key;
 extern const uint16_t valid_sums[19];
 
 typedef enum {


### PR DESCRIPTION
# What's new

`nfc_render_emv_data()` (`emv_render.c:33`) called `nfc_render_emv_name()`, which is declared at `emv_render.h:14` and **defined nowhere in the tree**.

It only escaped being a link error because `nfc_render_emv_data()` has no callers itself, so `-ffunction-sections` + `--gc-sections` discarded the whole island before the linker had to resolve anything. The moment anyone wired it into a render path, `nfc_emv.fal` would gain an unresolved import &mdash; and the import check does not run for plugins, so the build would stay green and it would ship as a plugin that silently never loads. That is exactly how the EMV plugin was broken until #1073 fixed it.

Nothing is lost. Even when `nfc_render_emv_name` last had a definition it was a stub &mdash; `UNUSED(data); furi_string_cat_printf(str, "\n");` &mdash; so it only ever printed a newline. And `plugins/supported_cards/emv.c` renders a strict superset of what the island produced: application label or name, PAN with the same `F`-padding trim, cardholder name, plus dates, resolved country/currency names, PIN try counter and the Mobile bit.

To be precise about which screen is which, since it matters for review:

| Screen | Renderer | Showed PAN/name before? |
|---|---|---|
| Read success / Supported Card | `supported_cards/emv.c` via `nfc_supported_cards_parse` | yes, and still does |
| Info | `nfc_render_emv_info` &rarr; `nfc_render_emv_extra` | **no** &mdash; AID, interchange profile, currency and country codes only |

So the Info screen never showed PAN or name, and this deletion changes nothing on it.

## Commits

1. **The fix** &mdash; delete `nfc_render_emv_data`, `nfc_render_emv_pan` (its only caller was `nfc_render_emv_data`) and the `nfc_render_emv_name` declaration.
2. **`emv_render.c` no longer includes `../iso14443_4a/iso14443_4a_render.h`.** That header declares only `nfc_render_iso14443_4a_info/_brief/_extra`, none of which this file calls. Pre-existing, unrelated to the undefined function &mdash; folded in because it is the same file and the same kind of leftover.
3. **Four more declarations with no definition anywhere**, found by sweeping every header under `applications/main/nfc` and `lib/nfc`:
   - `nfc_make_app_folder` (`nfc_app_i.h:301`) &mdash; a singular typo of `nfc_make_app_folders`. This is the dangerous one: it sits in the `extern "C"` block of a header **every protocol plugin includes**, is one character from a real function, and is absent from the app API table, so a plugin calling it would compile clean, link clean and ship as a `.fal` that never loads. The real function has a single same-file caller and is now `static` rather than an undeclared global.
   - `nfc_task` (`nfc_app_i.h:264`) &mdash; relic; the entry point has been `nfc_app()` for a long time.
   - `auth1_backdoor_key`, `auth2_backdoor_key`, `auth3_backdoor_key` (`mf_classic_poller_i.h:36-38`) &mdash; superseded by `mf_classic_backdoor_keys[]`, referenced by nothing since. Firmware core, so a stray reference there would be a hard link error rather than a silent plugin failure; removed for completeness, not danger.

## On making plugin import checks strict

The issue asked whether the check should be strict rather than warning-only. I tested it: **it cannot be flipped as-is.**

Forcing the validator to run against `nfc_mf_classic.fal` reports 36 unresolved symbols, every one legitimate:

```
dict_attack_*, detect_reader_*, nfc_blink_*, nfc_save_shadow_file,
nfc_protocol_support_common_*, nfc_app_run_external,
I_MFKey_qr_25x25, A_Loading_24, I_NFC_manual_60x50, I_WarningDolphin_45x42
```

Those come from the NFC app's own private table (`api/nfc_app_api_table_i.h`) and resolve at runtime through the composite API resolver. `_validate_app_imports` (`scripts/fbt_tools/fbt_extapps.py:295`) diffs against the firmware SDK only, so it cannot see a host app's table. Strict mode would fail all 15 protocol plugins and all 45 parser plugins.

Two things that make this worse than the issue assumed:

- The validator target is attached to plugins but **never built**, so today a `.fal` does not even get the warning.
- **21 app-private functions are visible to plugin code** through `nfc_app_i.h` and its view headers yet are absent from the API table &mdash; `nfc_save`, `nfc_delete`, `nfc_load_file`, `dict_attack_alloc`, `loading_label_set_text` and so on. The standout is `nfc_show_loading_popup`, which differs from the *exported* `nfc_show_loading_label_popup` only by the word `label`. Any of them is a clean build and a dead plugin.

A useful check would validate against *firmware SDK &cup; the host app's exported table*. That would have caught this defect and the 47 unresolved imports found during #1073. It is a real change to `fbt` and wants its own issue rather than riding along with a deletion.

# Verification

No behaviour to test &mdash; everything deleted was unreachable, which is the point. Confirmed by inspection, by the linker, and by the build:

- Repo-wide grep for all three EMV names across `applications/`, `lib/`, `targets/`, `plugins/` and `api_symbols.csv`: zero surviving references. Same for the four declarations in commit 3.
- Both `.text` sections were already in *Discarded input sections* of `nfc_emv_d.elf.map`. A mergeable `.rodata` fragment from `nfc_render_emv_pan` did survive the link, so `nfc_emv.fal` drops 8 bytes: text+rodata 2,626 &rarr; 2,618.
- Every remaining symbol in `emv_render.c` has a live caller (`nfc_render_emv_info` from `emv.c:24,73`; `nfc_render_emv_transactions` from `emv_extra_scenes.c:12`; the rest internally).
- `fbt firmware_all` builds clean and reports **API version 88.4 unchanged**, confirming none of the removed declarations were part of the public SDK.
- `fbt fap_nfc` clean with `APPCHK` passing; `fbt format` produces no changes; `fbt lint` exits 0.

One thing deliberately **not** deleted: `nfc_scene_read_success_on_enter_emv` looks dead because `emv_parse` always returns true, but `nfc_supported_cards_parse` returns false when the plugin subsystem fails to load. It is a genuine fallback.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The change is 37 deleted lines and one `static` keyword &mdash; no new code was generated. AI review passes found the defects and swept the tree for others; each was verified by hand before acting: call graphs traced with `grep`, redundancy checked against `plugins/supported_cards/emv.c`, the discarded sections read out of the link map, and the strict-import-check question tested by forcing the validator to run on a plugin target.

Fixes #1084
