### PR TITLE
[NFC]: Ultralight Amiibo/Xiaomi auth left skip_auth unset on a 4-byte UID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - NFC: **Protocol scenes moved into their own plugins, roughly halving the app's resident RAM** (by @mishamyte | PR #1073)
 - NFC: **Fixed the EMV plugin, which never loaded** (by @mishamyte | PR #1073)
 - NFC: **Ultralight AES - closed the remaining card-lock (AUTHLIM) paths** (by @mishamyte | PR #1082 | Fixes #1081)
+- NFC: **Ultralight - Amiibo/Xiaomi unlock no longer burns an AUTHLIM attempt when the password cannot be derived** (by @mishamyte | PR #1086 | Fixes #1083)
 - Apps: **Added categories for apps in firmware builds**, if you had apps that were moved to new subfolders in favourites, or on quick buttons, you will need to re-add them to favs/buttons
 - Apps: Build tag (**18aug2026p2**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes

--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
@@ -152,18 +152,25 @@ static NfcCommand
                 mf_ultralight_event->data->auth_context.skip_auth = true;
             }
         } else if(instance->mf_ul_auth->type == MfUltralightAuthTypeXiaomi) {
-            if(mf_ultralight_generate_xiaomi_pass(
-                   instance->mf_ul_auth,
-                   data->iso14443_3a_data->uid,
-                   data->iso14443_3a_data->uid_len)) {
-                mf_ultralight_event->data->auth_context.skip_auth = false;
+            // Both generators refuse a UID that is not 7 bytes and leave the password alone.
+            // Left unassigned, skip_auth reads false (its union is zero-filled), so the poller
+            // would PWD_AUTH with a stale password and burn an AUTHLIM attempt every time.
+            const bool generated = mf_ultralight_generate_xiaomi_pass(
+                instance->mf_ul_auth,
+                data->iso14443_3a_data->uid,
+                data->iso14443_3a_data->uid_len);
+            mf_ultralight_event->data->auth_context.skip_auth = !generated;
+            if(!generated) {
+                FURI_LOG_W("MfUltralightApp", "Xiaomi password needs a 7-byte UID, skipping auth");
             }
         } else if(instance->mf_ul_auth->type == MfUltralightAuthTypeAmiibo) {
-            if(mf_ultralight_generate_amiibo_pass(
-                   instance->mf_ul_auth,
-                   data->iso14443_3a_data->uid,
-                   data->iso14443_3a_data->uid_len)) {
-                mf_ultralight_event->data->auth_context.skip_auth = false;
+            const bool generated = mf_ultralight_generate_amiibo_pass(
+                instance->mf_ul_auth,
+                data->iso14443_3a_data->uid,
+                data->iso14443_3a_data->uid_len);
+            mf_ultralight_event->data->auth_context.skip_auth = !generated;
+            if(!generated) {
+                FURI_LOG_W("MfUltralightApp", "Amiibo password needs a 7-byte UID, skipping auth");
             }
         } else if(
             instance->mf_ul_auth->type == MfUltralightAuthTypeManual ||


### PR DESCRIPTION
# What's new

`mf_ultralight_generate_amiibo_pass()` and `_xiaomi_pass()` (`helpers/mf_ultralight_auth.c:30`, `:47`) return `false` for a UID that is not 7 bytes, and leave `instance->password` untouched. Both call sites in `helpers/protocol_support/mf_ultralight/mf_ultralight.c` dropped that return value, so `auth_context.skip_auth` was **never assigned** on the failing path:

```c
} else if(instance->mf_ul_auth->type == MfUltralightAuthTypeAmiibo) {
    if(mf_ultralight_generate_amiibo_pass(...)) {
        mf_ultralight_event->data->auth_context.skip_auth = false;
    }          // <- no else
}
```

`skip_auth` is not a fresh local. It is read out of `MfUltralightPollerEventData`, a **union** (`mf_ultralight_poller.h:68-75`) shared with `error`, `write_data`, `poller_mode`, `key_request_data` and `write_key_skip`.

**The unassigned value was not merely stale &mdash; it was reliably `false`.** `skip_auth` sits at byte 43 of the `auth_context` arm (password@0-3, tdes_key@4-19, aes_key@20-35, aes_key_type@36-39, pack@40-41, auth_success@42, skip_auth@43), past everything any other arm writes (`key_request_data` stops at byte 32), and the poller instance comes from a zero-filling `malloc` (`memmgr_heap.c:467`). Nothing else in the union can reach that byte.

So `mf_ultralight_poller_handler_auth()` took the authenticate branch (`mf_ultralight_poller.c:449`) **every time**, copied the app's `password` field, and sent a real `PWD_AUTH` with a password nobody generated. On a card that counts failed attempts that spends an AUTHLIM attempt &mdash; the same class of problem as #1081 / #1082, and deterministic rather than occasional.

Every other branch in that function assigns `skip_auth` unconditionally; these two were the outliers.

## The fix

Let the generator's result drive the flag directly, so there is no path that leaves it unset:

```c
const bool generated = mf_ultralight_generate_amiibo_pass(
    instance->mf_ul_auth,
    data->iso14443_3a_data->uid,
    data->iso14443_3a_data->uid_len);
mf_ultralight_event->data->auth_context.skip_auth = !generated;
if(!generated) {
    FURI_LOG_W("MfUltralightApp", "Amiibo password needs a 7-byte UID, skipping auth");
}
```

Same for Xiaomi. The log tag is namespaced `...App` to match `mf_classic.c`, so it does not collide with the stack's own `MfUltralightPoller` / `MfUltralightListener` tags when grepping a log.

## Why no "UID not supported" screen

The issue suggested one, and I looked into it. The GUI **never handles `MfUltralightPollerEventTypeAuthFailed` at all** &mdash; only the CLI dump command does (`cli/commands/dump/protocols/mf_ultralight/nfc_cli_dump_mf_ultralight.c:26`). So a genuinely failed password auth already falls back silently to an unauthenticated read.

With this fix, a 4-byte-UID card now behaves exactly like that: no auth attempt, plain read. Adding a message for this one case would make it the only auth failure in the app that reports itself.

That gap is real and worth closing &mdash; a user cannot currently distinguish "auth failed, the card counted it" from "no auth was attempted", which are opposites in cost. It needs the same plumbing for every auth outcome rather than one path, so it is filed as **#1088** instead of bolted on here.

Also worth noting the stale password is reachable in practice: `mf_ultralight_auth_reset()` does clear it, but `nfc_unlock_helper_setup_from_state()` only calls that for reads that are **not** part of an unlock flow. During an unlock the password persists from a previous manual entry.

# Verification

Static, and stated plainly: **this is not hardware-tested.** Reproducing it needs an Ultralight/NTAG card with a 4-byte UID, and confirming the dangerous half means deliberately burning an AUTHLIM attempt on a card that counts them, which is not something to do casually.

What is verified:

- Both generators return `false` without touching `password` when `uid_len != 7` (`mf_ultralight_auth.c:30-45`, `:47-63`).
- The byte offsets above, computed from the type sizes in `mf_ultralight.h` (password 4, keys 16+16, enum 4, pack 2, two bools) and confirmed against the union's other arms.
- The consumer at `mf_ultralight_poller.c:449` branches on it and then transmits.
- After the fix both paths assign `skip_auth` on every branch; `grep` confirms no remaining assignment-free path in that handler.
- `fbt fap_nfc` builds clean with `APPCHK` passing, `fbt format` produces no further changes, `fbt lint` exits 0.

A card with a 7-byte UID (the normal Amiibo/Xiaomi case) is unaffected: the generator succeeds, `skip_auth` is `false`, behaviour is identical to before. That path is worth a smoke test by anyone with an Amiibo.

## Found while reviewing this

Two pre-existing faults, filed rather than folded in:

- **#1087** &mdash; a plain read of a protected Ultralight can burn an AUTHLIM attempt on its own. `try_default_pass` reads `access.authlim` from a config page that was never read off the card, so the zero fill decodes as "no auth limit" and it probes the default password. Same family as this bug, but it fires with **no user action at all**.
- **#1088** &mdash; the auth-outcome reporting gap described above.


# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The defect was found by an AI review pass over #1073 and filed as #1083; the fix is eight lines, written and verified by hand &mdash; the union declaration, both generators, the poller's consumer and the unlock-helper reset path were each read before changing anything.

Fixes #1083
