### PR TITLE
[NFC]: don't probe the default password when AUTHLIM cannot be read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Apps: **Added categories for apps in firmware builds**, if you had apps that were moved to new subfolders in favourites, or on quick buttons, you will need to re-add them to favs/buttons
 - Apps: Build tag (**18aug2026p2**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes
+- NFC: **Ultralight - the default password is no longer tried when AUTHLIM cannot be read** (by @mishamyte | PR #1089 | Fixes #1087)
 - BadUSB: Moved demo files to examples folder
 - NFC: Removed unreachable EMV render code that called an undefined function (by @mishamyte | PR #1085 | Fixes #1084)
 <br><br>

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
@@ -752,10 +752,23 @@ static NfcCommand mf_ultralight_poller_handler_try_default_pass(MfUltralightPoll
             break;
 
         MfUltralightConfigPages* config = NULL;
-        mf_ultralight_get_config_page(instance->data, &config);
+        if(!mf_ultralight_get_config_page(instance->data, &config)) break;
+
+        // AUTHLIM sits in the ACCESS page. Unread pages are zero-filled, so an unread ACCESS
+        // reads back as "no limit" - and probing the default password burns one of the very
+        // attempts AUTHLIM counts. Unknown has to mean protected.
+        //
+        // Write mode is exempt: the app skips the read-phase auth there, so this probe is the
+        // only thing that can unlock a password-protected target, and the user asked for it.
+        const uint16_t access_page = mf_ultralight_get_config_page_num(instance->data->type) + 1;
+        const bool authlim_known = instance->pages_read >= access_page + 1;
+        const bool writing_to_target = instance->mode == MfUltralightPollerModeWrite;
+
         if(instance->auth_context.auth_success) {
             config->password = instance->auth_context.password;
             config->pack = instance->auth_context.pack;
+        } else if(!authlim_known && !writing_to_target) {
+            FURI_LOG_W(TAG, "AUTHLIM unreadable, not probing the default password");
         } else if(config->access.authlim == 0) {
             FURI_LOG_D(TAG, "No limits in authentication. Trying default password");
             bit_lib_num_to_bytes_be(


### PR DESCRIPTION
# What's new

`mf_ultralight_poller_handler_try_default_pass()` reads `config->access.authlim` out of the in-memory card image and probes the default password when it is zero:

```c
MfUltralightConfigPages* config = NULL;
mf_ultralight_get_config_page(instance->data, &config);   // return dropped
...
} else if(config->access.authlim == 0) {
    // send PWD_AUTH with FFFFFFFF
```

`config` points **into `data->page[]`** (`mf_ultralight.c:701`). On a card whose ACCESS page was never returned, those bytes are still the zero fill from `malloc` — so `authlim == 0` means *"we don't know"* just as often as it means *"no limit"*, and the code treats it as the latter.

This runs on **every** read of any type with `PasswordAuth` — it is not gated on the card being locked.

## Is the risk real? Datasheet says yes, under three conditions

Checked against **MF0ULX1 (Ultralight EV1) rev 3.3**. It needs all three:

| Condition | Default | Probe fires wrongly? |
|---|---|---|
| `PROT = 0` (write-only protection) | **yes** | No &mdash; §10.2, reads still return data, so ACCESS is read and AUTHLIM is correct |
| `PROT = 1`, `AUTH0` above the ACCESS page (NXP's own recommendation, §8.6.1) | &mdash; | No &mdash; ACCESS still readable |
| `AUTHLIM = 000b` | **yes** | Harmless &mdash; §8.6.2, counting disabled |
| **`PROT = 1`, `AUTH0` ≤ ACCESS page, `AUTHLIM ≠ 0`** | &mdash; | **Yes** |

When all three hold, §8.6.2 is unambiguous:

> each negative authentication verification is internally counted. … As soon as this internal counter reaches the number specified in AUTHLIM, any further negative password verification leads to a **permanent locking** of the protected part of the memory … Independent, whether the provided password is correct or not, each subsequent PWD_AUTH fails.

So `AUTHLIM + 1` ordinary reads permanently lock the card. Mitigation, same section: a *successful* verification before the limit resets the counter to zero.

The card this destroys is a deliberately hardened one &mdash; read-protected from a low page with brute-force limiting enabled &mdash; and it destroys it through plain Reads. A small share of cards, and the worst possible share to be wrong about.

Affects nine types: UL11, UL21, NTAG210/212/213/215/216, NTAG I2C Plus 1K/2K. UL-C and UL-AES are not in that set, so this is a different family from #1081 / #1082.

## The fix

Gate the probe on the ACCESS page having actually been read:

```c
const uint16_t access_page = mf_ultralight_get_config_page_num(instance->data->type) + 1;
const bool authlim_known = instance->pages_read >= access_page + 1;
const bool writing_to_target = instance->mode == MfUltralightPollerModeWrite;
```

`AUTHLIM` unknown now means *assume protected* rather than *assume unlimited*. Reads are strictly sequential from page 0, so `pages_read` is a sound "did this page come off the card" test &mdash; the same convention as the neighbouring `mf_ultralight_is_pwd_pack_read()`.

**Write mode is exempt, deliberately.** The app sets `skip_auth = true` for the read phase when writing to a target (`mf_ultralight.c:437-439`), so for password-protected types this probe is the only thing that can set `auth_success`, and `request_write_data` hard-gates on it (`poller.c:893-897`). Gating it there would turn a working write into "Card locked" for any target still carrying the factory password. A write is user-initiated; a plain read is not. This mirrors #1082's reasoning, where a user-initiated action is allowed to spend an attempt.

Also takes the previously dropped return of `mf_ultralight_get_config_page()`. It fails only for types with no config page, which the feature check above already excludes &mdash; but the next line dereferences the pointer it would have left `NULL`, so this converts a latent crash into a no-op.

## What is lost

Default-password detection on `PROT = 1` cards whose `AUTH0` covers the ACCESS page. That is exactly the set where probing was unsafe. `PROT = 0` cards, factory-blank cards (`AUTH0 = 0xFF`) and every fully-readable card keep it, because their ACCESS page is readable.

# Verification

**No false negatives are structurally possible.** `config_page + 2 <= total_pages` holds for all nine PasswordAuth types (UL11 18/20, UL21 39/41, NTAG213 43/45, NTAG215 133/135, NTAG216 229/231, I2C Plus 1K 229/236, 2K 229/492, NTAG210 18/20, NTAG212 39/41), so a complete read always satisfies the gate.

- ACCESS is byte 4 of the packed `MfUltralightConfigPages`, i.e. byte 0 of page `config_page + 1`. Confirmed against the struct.
- `pages_read` is a count, not an index, and reads are sequential from page 0 (`poller.c:685`, `:706-710`), so page *p* was read iff `p < pages_read`.
- `instance->pages_read` rather than `data->pages_read` matters: `handler_idle` (`:228`) resets only the former, so after a failed attempt the latter can carry a stale higher value.
- The `pages_read -= 2` rollback runs after the check and only when `pages_read == pages_total`, which already implies `authlim_known`.
- NTAG I2C Plus linear→sector mapping is 1:1 below page 234, so page 227/228 really are those pages.
- `fbt firmware_all` and `fbt fap_nfc` build clean; `fbt format` produces no changes; `fbt lint` exits 0. **API version unchanged** &mdash; `mf_ultralight_get_config_page_num` was already exported.

**Not hardware-tested.** Confirming the original bug means watching a real card's attempt counter decrement, which risks the card. Two cases worth putting on hardware before merge:

1. A **PROT=0 NTAG21x with the factory password** &mdash; the probe must still run and still find `FFFFFFFF` (regression check on the common path).
2. A **PROT=1 / low-AUTH0 card** &mdash; `Trying default password` must be absent from the log, and `AUTHLIM unreadable, not probing the default password` present.

# Related, not fixed here

Two pre-existing spots read the same config image without a `pages_read` check. Neither can lock a card, so they are out of scope, but they are the same defect shape:

- `poller.c:365-368` &mdash; `access.nfc_cnt_pwd_prot`; costs one NAK'd `READ_CNT`, no PWD_AUTH.
- `mf_ultralight.c:761-762` &mdash; `mf_ultralight_is_counter_configured` reads `access.nfc_cnt_en` ungated; display-only, and it fails in the losing direction (a readable counter is skipped).

Also worth knowing: `config->auth0` and `access.prot` are synthesized into that same possibly-unread page a few lines below, so a partial dump saves fabricated config bytes. Pre-existing, unchanged here.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The defect was found by an AI review pass over #1086 and filed as #1087; the datasheet conditions above were then checked by hand against MF0ULX1 rev 3.3. The fix is about ten lines. Two review passes caught the write-mode regression in the first draft &mdash; the original gate applied to every mode and would have broken writing to protected targets &mdash; and that was verified against the write path before changing it.

Fixes #1087
