### PR TITLE
[NFC]: say what became of an Ultralight authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Apps: **Added categories for apps in firmware builds**, if you had apps that were moved to new subfolders in favourites, or on quick buttons, you will need to re-add them to favs/buttons
 - Apps: Build tag (**18aug2026p2**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes
+- NFC: **Ultralight read result now says whether authentication failed or was never attempted** (by @mishamyte | PR #1090 | Closes #1088)
 - NFC: **Ultralight - the default password is no longer tried when AUTHLIM cannot be read** (by @mishamyte | PR #1089 | Fixes #1087)
 - BadUSB: Moved demo files to examples folder
 - NFC: Removed unreachable EMV render code that called an undefined function (by @mishamyte | PR #1085 | Fixes #1084)

--- a/applications/main/nfc/helpers/mf_ultralight_auth.c
+++ b/applications/main/nfc/helpers/mf_ultralight_auth.c
@@ -5,6 +5,7 @@
 
 MfUltralightAuth* mf_ultralight_auth_alloc(void) {
     MfUltralightAuth* instance = malloc(sizeof(MfUltralightAuth));
+    instance->outcome = MfUltralightAuthOutcomeNone;
     mf_ultralight_auth_reset(
         instance); // start in a known (None) state, not relying on the allocator
 

--- a/applications/main/nfc/helpers/mf_ultralight_auth.h
+++ b/applications/main/nfc/helpers/mf_ultralight_auth.h
@@ -15,12 +15,27 @@ typedef enum {
     MfUltralightAuthTypeUidReveal, // UL-AES: user-requested real-UID reveal (all-zero UIDRetrKey)
 } MfUltralightAuthType;
 
+/** What became of the authentication the user asked for, so the read result can say. */
+/**
+ * Cleared by whoever starts a read, not by mf_ultralight_auth_reset() - it belongs to the
+ * read that produced it, and the credential reset runs after the result is drawn.
+ */
+typedef enum {
+    MfUltralightAuthOutcomeNone, /**< None was requested. */
+    /** Never read, but it is what clears a Failed left by an earlier attempt in the
+     * same unlock flow - the unlock helper deliberately does not reset mid-flow. */
+    MfUltralightAuthOutcomeSuccess,
+    MfUltralightAuthOutcomeFailed, /**< Attempted and rejected; costs an attempt if AUTHLIM is set. */
+    MfUltralightAuthOutcomeSkippedUid, /**< Not attempted: no password derivable from this UID. */
+} MfUltralightAuthOutcome;
+
 typedef struct {
     MfUltralightAuthType type;
     MfUltralightAuthPassword password;
     MfUltralightC3DesAuthKey tdes_key;
     MfUltralightAesKey aes_key;
     MfUltralightAuthPack pack;
+    MfUltralightAuthOutcome outcome;
 } MfUltralightAuth;
 
 MfUltralightAuth* mf_ultralight_auth_alloc(void);

--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
@@ -161,6 +161,7 @@ static NfcCommand
                 data->iso14443_3a_data->uid_len);
             mf_ultralight_event->data->auth_context.skip_auth = !generated;
             if(!generated) {
+                instance->mf_ul_auth->outcome = MfUltralightAuthOutcomeSkippedUid;
                 FURI_LOG_W("MfUltralightApp", "Xiaomi password needs a 7-byte UID, skipping auth");
             }
         } else if(instance->mf_ul_auth->type == MfUltralightAuthTypeAmiibo) {
@@ -170,6 +171,7 @@ static NfcCommand
                 data->iso14443_3a_data->uid_len);
             mf_ultralight_event->data->auth_context.skip_auth = !generated;
             if(!generated) {
+                instance->mf_ul_auth->outcome = MfUltralightAuthOutcomeSkippedUid;
                 FURI_LOG_W("MfUltralightApp", "Amiibo password needs a 7-byte UID, skipping auth");
             }
         } else if(
@@ -196,12 +198,17 @@ static NfcCommand
         }
     } else if(mf_ultralight_event->type == MfUltralightPollerEventTypeAuthSuccess) {
         instance->mf_ul_auth->pack = mf_ultralight_event->data->auth_context.pack;
+        instance->mf_ul_auth->outcome = MfUltralightAuthOutcomeSuccess;
+    } else if(mf_ultralight_event->type == MfUltralightPollerEventTypeAuthFailed) {
+        // Only user-driven auth reports here; the default-password probe authenticates silently.
+        instance->mf_ul_auth->outcome = MfUltralightAuthOutcomeFailed;
     }
 
     return NfcCommandContinue;
 }
 
 static void nfc_scene_read_on_enter_mf_ultralight(NfcApp* instance) {
+    instance->mf_ul_auth->outcome = MfUltralightAuthOutcomeNone;
     nfc_unlock_helper_setup_from_state(instance);
     nfc_poller_start(instance->poller, nfc_scene_read_poller_callback_mf_ultralight, instance);
 }
@@ -326,11 +333,27 @@ static void nfc_scene_read_and_saved_menu_on_enter_mf_ultralight(NfcApp* instanc
     }
 }
 
+// Failed and skipped look identical on the card; only failed can have spent a counted attempt.
+static void
+    nfc_mf_ultralight_render_auth_outcome(MfUltralightAuthOutcome outcome, FuriString* str) {
+    if(outcome == MfUltralightAuthOutcomeFailed) {
+        // Whether it cost anything depends on AUTHLIM, which is often 0 (unlimited), so this
+        // states the condition rather than asserting the card counted it.
+        furi_string_cat_printf(
+            str, "\e#Auth Failed\nCards with an auth limit\ncounted this attempt.\n\n");
+    } else if(outcome == MfUltralightAuthOutcomeSkippedUid) {
+        furi_string_cat_printf(
+            str,
+            "\e#Auth Skipped\nThis password needs a\n7-byte UID. Nothing was\nsent to the card.\n\n");
+    }
+}
+
 static void nfc_scene_read_success_on_enter_mf_ultralight(NfcApp* instance) {
     const NfcDevice* device = instance->nfc_device;
     const MfUltralightData* data = nfc_device_get_data(device, NfcProtocolMfUltralight);
 
     FuriString* temp_str = furi_string_alloc();
+    nfc_mf_ultralight_render_auth_outcome(instance->mf_ul_auth->outcome, temp_str);
 
     bool unlocked =
         scene_manager_has_previous_scene(instance->scene_manager, NfcSceneMfUltralightUnlockWarn);

--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_extra_scenes.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_extra_scenes.c
@@ -136,6 +136,7 @@ static void mf_ultralight_scene_c_dict_attack_prepare_view(NfcApp* instance) {
 }
 
 static void mf_ultralight_scene_c_dict_attack_on_enter(NfcApp* instance) {
+    instance->mf_ul_auth->outcome = MfUltralightAuthOutcomeNone;
     scene_manager_set_scene_state(
         instance->scene_manager,
         NfcSceneMfUltralightCDictAttack,
@@ -370,6 +371,7 @@ static void mf_ultralight_scene_aes_dict_attack_prepare_view(NfcApp* instance) {
 }
 
 static void mf_ultralight_scene_aes_dict_attack_on_enter(NfcApp* instance) {
+    instance->mf_ul_auth->outcome = MfUltralightAuthOutcomeNone;
     scene_manager_set_scene_state(
         instance->scene_manager,
         NfcSceneMfUltralightAesDictAttack,

--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.c
@@ -39,10 +39,13 @@ void nfc_render_mf_ultralight_pwd_pack(const MfUltralightData* data, FuriString*
         furi_string_cat_printf(str, "\e#Some Pages Are Locked!");
     }
 
-    if(has_config) {
+    if(!has_config) {
+        furi_string_cat_printf(str, "\nThis card does not support\npassword protection!");
+    } else if(mf_ultralight_is_pwd_pack_read(data)) {
         nfc_render_mf_ultralight_pwd_pack_lines(config, str);
     } else {
-        furi_string_cat_printf(str, "\nThis card does not support\npassword protection!");
+        // Unauthenticated reads mask these pages to zero - don't show 00 00 00 00 as a password.
+        furi_string_cat_printf(str, "\nPassword not captured.");
     }
 
     nfc_render_mf_ultralight_pages_count(data, str);

--- a/applications/main/nfc/helpers/protocol_support/nfc_protocol_support_base.h
+++ b/applications/main/nfc/helpers/protocol_support/nfc_protocol_support_base.h
@@ -181,14 +181,15 @@ typedef struct {
 /**
  * @brief Currently supported plugin API version.
  *
- * Bumped to 2 when NfcProtocolSupportBase gained extra_scenes: the struct layout changed, so a
- * plugin built against version 1 must be refused rather than read past its own end.
+ * Bumped to 2 when NfcProtocolSupportBase gained extra_scenes, and to 3 when MfUltralightAuth
+ * gained its outcome field: the struct layout changed, so a plugin built against the older
+ * layout must be refused rather than read or write past its own end.
  *
  * This constant guards the whole app-plugin ABI, not just this struct: plugins also dereference
  * NfcApp, and address extra scenes by index. Reordering either - or changing NfcApp's layout -
  * needs a bump too, since a stale .fal would otherwise dispatch the wrong scene silently.
  */
-#define NFC_PROTOCOL_SUPPORT_PLUGIN_API_VERSION 2
+#define NFC_PROTOCOL_SUPPORT_PLUGIN_API_VERSION 3
 
 /**
  * @brief Protocol support plugin interface.


### PR DESCRIPTION
# What's new

Closes #1088. The GUI never said what became of an Ultralight authentication — succeeded, failed, and never-attempted all rendered the same read-success screen.

`MfUltralightPollerEventTypeAuthFailed` is emitted by the poller at `mf_ultralight_poller.c:469` and `:664` and had exactly **one** consumer in the tree: the CLI dump command. The GUI ignored it.

The two states that matter are opposites in cost:

| Outcome | AUTHLIM cost | Before | Now |
|---|---|---|---|
| Auth succeeded | none | pages unlocked | unchanged |
| Auth **failed** | one attempt, **if AUTHLIM is set** | "Some Pages Are Locked!" | **Auth Failed** &mdash; cards with an auth limit counted this attempt |
| Auth **not attempted** (UID unusable, see #1086) | none | "Some Pages Are Locked!" | **Auth Skipped** &mdash; nothing was sent to the card |
| No auth requested | none | plain result | unchanged |

A user who cannot tell failed from skipped retries, and on an AUTHLIM card that is how it gets locked for good.

The wording stays **conditional** on purpose. A failed `PWD_AUTH` costs nothing when `AUTHLIM == 0`, which is the factory default — and per #1089 that field is frequently unreadable anyway. Asserting "the card counted this attempt" would contradict the firmware's own `Auth limit: unlimited` line further down the same screen.

## Where the outcome is cleared, and why it matters

It is cleared by **whoever starts a read**, not by `mf_ultralight_auth_reset()`.

That distinction is the whole design, and my first draft got it wrong. The credential reset runs *after* the result is drawn (`mf_ultralight.c:372`), and `scene_manager_previous_scene()` re-runs the target scene's `on_enter` (`scene_manager.c:123`) — so hanging the outcome off it meant the banner vanished on **Retry → Stay** or **More → Back**, the most likely next keypress. Worse, the two dictionary-attack scenes push `NfcSceneReadSuccess` (`mf_ultralight_extra_scenes.c:165/193/218/407`) without ever touching the unlock helper, so a failed unlock followed by a **successful** dictionary attack would have reported "auth failed" over unlocked data.

Now every site that starts an Ultralight poller clears it: the read scene and both dict-attack scenes.

## Also: stop the unlock screen printing a password it does not have

`nfc_render_mf_ultralight_pwd_pack()` rendered the PWD/PACK lines whenever the card *type* has a config page. Those pages read back masked as zero when auth did not succeed, so a failed unlock displayed `Password: 00 00 00 00` / `PACK: 00 00` as though recovered. Its sibling `_if_read()` already gated on `mf_ultralight_is_pwd_pack_read()`; this one now does too, and says "Password not captured" instead.

Without this, the new banner would have sat directly above a fabricated password.

## Plugin API version 2 &rarr; 3

`MfUltralightAuth` gained a field and protocol plugins dereference it. The dangerous direction is a new `.fal` against an old `.fap`: the app allocates the smaller struct and the plugin writes `->outcome` past it. The version gate refuses both directions.

Worth knowing: the constant is global, so the bump invalidates **all** protocol plugins, not just Ultralight. That is safe here because `.fal` files ship inside `nfc.fap` and `application_assets.c:298-309` compares an assets signature and **removes the old assets recursively** before re-extracting — a changed plugin always changes the signature, so stale plugins cannot survive an app update. The gate only guards someone hand-placing a `.fal`.

# Verification

`fbt fap_nfc` builds clean with `APPCHK` passing, `fbt format` produces no changes, `fbt lint` exits 0.

Reasoned through rather than measured, since it needs cards I don't have:

- `AuthFailed` cannot fire on a plain read — both emit sites are inside `if(!skip_auth)`, and the app sets `skip_auth = false` only for Reader/Manual/Amiibo/Xiaomi/UidReveal. The default-password probe calls `mf_ultralight_poller_auth_pwd()` directly and never invokes the callback.
- The banner cannot leak to other screens: info, emulate and saved-menu don't call this renderer, and loaded dumps never reach read-success.
- The PWD/PACK gate loses nothing legitimate: on success `try_default_pass` writes the real values into the config page while `pages_read` stays at total, and UL-C/UL-AES have `config_page == 0` so they take the unchanged branch.

**Worth putting on hardware:** an NTAG21x with a known password — enter it wrong once (expect **Auth Failed**), then right (expect the normal unlocked result, no banner). Then Retry → Stay, to confirm the banner survives re-entry.

# Known gaps, deliberately not fixed here

- **UL-C 3DES unlocks still report nothing**, either way. `mf_ultralight_poller_handler_auth_ultralight_c` raises neither `AuthSuccess` nor `AuthFailed` in read mode, so #1088's complaint remains true for UL-C. Fixing it means emitting those events from `lib/`, which is a separate change.
- **Cards claimed by a supported-card parser** never reach this renderer at all — `nfc_supported_cards_parse()` short-circuits the protocol's `read_success` handler (`nfc_protocol_support.c:664-670`), so a parsed NTAG shows the parser output with no banner.
- **`mf_ultralight_is_pwd_pack_read()` is ineffective on NTAG I2C Plus.** Its threshold is `pwd_page + 2 = 231`, but `total_pages` is 236/492, so the poller's `pages_read -= 2` rollback lands at 234 — still above the threshold. The predicate is pre-existing and shared with `_if_read()`; this PR leans on it but does not make it worse.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Written with Claude Code and reviewed by it twice. The generated code is the outcome enum on `MfUltralightAuth`, the three sites that record it, the render helper, and the PWD/PACK gate. The review caught two things worth naming: that clearing the outcome alongside the credentials made the banner one-shot per scene entry and left a stale verdict for the dict-attack path, and that "the card counted this attempt" asserts a cost that does not exist when `AUTHLIM == 0`. Both were verified against the poller and the scene manager before changing anything.

Closes #1088
