### PR TITLE
NFC: fix Social Moscow parser rejecting most genuine cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - NFC: **Fixed the EMV plugin, which never loaded** (by @mishamyte | PR #1073)
 - NFC: **Ultralight AES - closed the remaining card-lock (AUTHLIM) paths** (by @mishamyte | PR #1082 | Fixes #1081)
 - NFC: **Ultralight - Amiibo/Xiaomi unlock no longer burns an AUTHLIM attempt when the password cannot be derived** (by @mishamyte | PR #1086 | Fixes #1083)
+- NFC: **Social Moscow - fixed the parser rejecting most genuine cards** (by @mishamyte | PR #1092 | Fixes #1091)
 - Apps: **Added categories for apps in firmware builds**, if you had apps that were moved to new subfolders in favourites, or on quick buttons, you will need to re-add them to favs/buttons
 - Apps: Build tag (**18aug2026p2**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes

--- a/applications/main/nfc/plugins/supported_cards/social_moscow.c
+++ b/applications/main/nfc/plugins/supported_cards/social_moscow.c
@@ -193,15 +193,6 @@ static uint8_t calculate_luhn(uint64_t number) {
     return (10 - (sum % 10)) % 10;
 }
 
-// BCD to decimal; must cover every nibble - the card number alone is 40 bits wide
-static uint64_t hex_num(uint64_t hex) {
-    uint64_t result = 0;
-    for(uint64_t multiplier = 1; hex > 0; hex >>= 4, multiplier *= 10) {
-        result += (hex & 0x0F) * multiplier;
-    }
-    return result;
-}
-
 static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data) {
     furi_assert(device);
 
@@ -232,15 +223,20 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
         uint8_t year = data->block[60].data[11];
         uint8_t month = data->block[60].data[12];
 
-        uint64_t number = hex_num(card_control) + hex_num(card_number) * 10 +
-                          hex_num(card_region) * 10 * 10000000000 +
-                          hex_num(card_code) * 10 * 10000000000 * 100;
+        // bytes 1..9 are the number's 18 BCD digits: code(6) + region(2) + number(10)
+        bool is_bcd;
+        const uint64_t number =
+            bit_lib_bytes_to_num_bcd(&data->block[60].data[1], 9, &is_bcd) * 10 + card_control;
 
-        uint8_t luhn = calculate_luhn(number);
+        const uint8_t luhn = calculate_luhn(number);
         if(luhn != card_control) {
-            // Reached only once the sector 15 keys already identified this as a Social card,
-            // so a mismatch here means we are discarding a card we recognised
-            FURI_LOG_D(TAG, "Luhn mismatch: computed %u, card %u", luhn, card_control);
+            // the sector 15 keys already identified this as a Social card, so we are discarding one
+            FURI_LOG_D(
+                TAG,
+                "Luhn mismatch: computed %x, card %x%s",
+                luhn,
+                card_control,
+                is_bcd ? "" : ", number is not BCD");
             break;
         }
 

--- a/applications/main/nfc/plugins/supported_cards/social_moscow.c
+++ b/applications/main/nfc/plugins/supported_cards/social_moscow.c
@@ -194,17 +194,11 @@ static uint8_t calculate_luhn(uint64_t number) {
     return (10 - (sum % 10)) % 10;
 }
 
+// BCD to decimal; must cover every nibble - the card number alone is 40 bits wide
 static uint64_t hex_num(uint64_t hex) {
     uint64_t result = 0;
-    for(uint8_t i = 0; i < 8; ++i) {
-        uint8_t half_byte = hex & 0x0F;
-        uint64_t num = 0;
-        for(uint8_t j = 0; j < 4; ++j) {
-            num += (half_byte & 0x1) * (1 << j);
-            half_byte = half_byte >> 1;
-        }
-        result += num * pow(10, i);
-        hex = hex >> 4;
+    for(uint64_t multiplier = 1; hex > 0; hex >>= 4, multiplier *= 10) {
+        result += (hex & 0x0F) * multiplier;
     }
     return result;
 }

--- a/applications/main/nfc/plugins/supported_cards/social_moscow.c
+++ b/applications/main/nfc/plugins/supported_cards/social_moscow.c
@@ -7,7 +7,6 @@
 #include <bit_lib/bit_lib.h>
 #include <nfc/protocols/mf_classic/mf_classic_poller_sync.h>
 #include "../../api/mosgortrans/mosgortrans_util.h"
-#include "furi_hal_rtc.h"
 
 #define TAG "Social_Moscow"
 

--- a/applications/main/nfc/plugins/supported_cards/social_moscow.c
+++ b/applications/main/nfc/plugins/supported_cards/social_moscow.c
@@ -238,7 +238,12 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
                           hex_num(card_code) * 10 * 10000000000 * 100;
 
         uint8_t luhn = calculate_luhn(number);
-        if(luhn != card_control) break;
+        if(luhn != card_control) {
+            // Reached only once the sector 15 keys already identified this as a Social card,
+            // so a mismatch here means we are discarding a card we recognised
+            FURI_LOG_D(TAG, "Luhn mismatch: computed %u, card %u", luhn, card_control);
+            break;
+        }
 
         FuriString* metro_result = furi_string_alloc();
         FuriString* ground_result = furi_string_alloc();
@@ -246,9 +251,10 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
             mosgortrans_parse_transport_block(&data->block[4], metro_result);
         bool is_ground_data_present =
             mosgortrans_parse_transport_block(&data->block[16], ground_result);
+        // the number is fixed-width 6+2+10+1 digits, so keep the leading zeros
         furi_string_cat_printf(
             parsed_data,
-            "\e#Social \ecard\nNumber: %lx %x %llx %x\nOMC: %llx\nValid for: %02x/%02x %02x%02x\n",
+            "\e#Social \ecard\nNumber: %06lx %02x %010llx %x\nOMC: %llx\nValid for: %02x/%02x %02x%02x\n",
             card_code,
             card_region,
             card_number,


### PR DESCRIPTION
# What's new

Fixes #1091. The Social Moscow (Соцкарта москвича) parser rejected roughly **9 out of 10** genuine cards, which fell through to a plain Mifare Classic dump with no parsed output.

`hex_num()` converted packed BCD to a decimal value, but walked only **8 nibbles**:

```c
for(uint8_t i = 0; i < 8; ++i) {   // 8 nibbles == 32 bits
```

It was fed `card_number`, which is **40 bits / 10 nibbles**:

```c
uint64_t card_number = bit_lib_get_bits_64(data->block[60].data, 40, 40);
```

So the two most significant BCD digits were dropped and replaced by `00` before the Luhn check digit was computed, the result disagreed with the digit stored on the card, and `if(luhn != card_control) break;` aborted the parse before emitting anything.

A card survived only when the dropped pair happened to contribute a multiple of 10 to the Luhn sum — `S(2·D8) + D9 ≡ 0 (mod 10)`, about one in ten.

The rendered number was never affected: the `Number:` line prints the raw BCD nibbles and does not go through `hex_num()`. Only the gate was broken.

## Where it came from

Not ours. `social_moscow.c` was rewritten in OFW commit `6ead328bb` (flipperdevices/flipperzero-firmware#3464, 2024-10-06), which introduced `calculate_luhn()` + `hex_num()` and reached us in **unlshd-079**. Before that we carried a 1187-line downstream copy whose gate was `parsed = result1 || result2` — parse succeeded if either transport block had a known layout — so 077 and 078 parsed these cards fine.

**OFW `dev` still ships the identical `hex_num()` with `i < 8`.** Worth an upstream PR too; this one is Unleashed-only for now.

## The fix

`hex_num()` was a hand-rolled copy of **`bit_lib_bytes_to_num_bcd()`** (`lib/bit_lib/bit_lib.c:466`) — already exported to plugins (`api_symbols.csv:774`), already unit-tested (`bit_lib_test.c:688`), and already called by `zolotaya_korona.c`, `zolotaya_korona_online.c` and `emv.c`. So rather than widen the broken loop, the fix deletes it:

```c
// bytes 1..9 are the number's 18 BCD digits: code(6) + region(2) + number(10)
bool is_bcd;
const uint64_t number =
    bit_lib_bytes_to_num_bcd(&data->block[60].data[1], 9, &is_bcd) * 10 + card_control;
```

Every digit above the check digit is byte-aligned in `block[60]` bytes 1..9 (code = 1-3, region = 4, number = 5-9), so the whole thing collapses to one call. That also removes the three hand-maintained positional multipliers `* 10 * 10000000000 * 100`, which had to stay in sync with four separate `bit_lib_get_bits*` offsets — the exact hazard class this PR exists to fix. Net deletion.

The mandatory `is_bcd` out-parameter comes free, so the rejection log can now tell a corrupt number from a genuine check-digit mismatch — validation the old private helper never had.

### `pow()` is gone, and it was costing 7 KB of flash and ~1 ms per parse

In the **release** build `pow` was never constant-folded — newlib's implementation was linked into the FAP statically, so `pow`/`__ieee754_pow` were *defined* symbols in the `.fal`, not undefined ones. (Its `-` in `targets/f7/api_symbols.csv:3284` therefore never applied; what `pow` left undefined were the soft-float helpers `__aeabi_dadd` / `__aeabi_dmul` / `__aeabi_ddiv` / `__aeabi_dcmp*`, all of which *are* exported `+` — which is why `APPCHK` passed all along.) Removing the file's only floating-point call takes `w_pow.o e_pow.o e_sqrt.o s_finite.o s_fabs.o math_err.o s_scalbn.o` out of every shipped build:

| `COMPACT=1 DEBUG=0` | `social_moscow_parser.fal` |
|---|---|
| dev | 25,564 B |
| this branch | **18,232 B** |
| | **−7,332 B (−28.7%)** |

The old code ran 4 calls × 8 fixed iterations × a soft-float `__ieee754_pow` — roughly 60-70k cycles, about **1 ms** per parse on a 64 MHz M4 with no double-precision FPU. The replacement is a single library call.

## Three things folded in from review

**The Luhn gate had no diagnostic.** That is why a checker rejecting nine of ten genuine cards went unnoticed for four releases — on the device, a rejected card is indistinguishable from a card no parser claims. `nfc_supported_cards_parse()` runs all 30 `NfcProtocolMfClassic` plugins against every Classic card, so logging the *discriminator* gates above (card type, sector-15 keys) would be noise; this gate sits behind them and only fires on a card already positively identified as a Social card. `csc.c:105` sets exactly this precedent with `FURI_LOG_D(TAG, "Checksum failed")`, and `TAG` is already used elsewhere in this file. The two discriminator breaks stay silent on purpose — that matches `troika.c`, `plantain.c`, `two_cities.c` and `csc.c`.

**The rendered number carried no field widths.** `Number: %lx %x %llx %x` against a number the Luhn expression treats as fixed-width 6+2+10+1 digits, so any field with a leading zero rendered short — a `card_number` of `0x0413960406` printed as 9 digits, giving an 18-digit card number. Pre-existing, but it belongs in this PR's blast radius: before the fix ~10% of cards reached that line, now 100% do, and the field whose digit count is wrong is the one this PR is about. Now `%06lx %02x %010llx %x`. Left `OMC: %llx` alone — a zero-filled block 21 renders `OMC: 0` today, and padding it to sixteen zeros would be worse, not better.

**A separate commit drops the unused `furi_hal_rtc.h` include** (nothing in the file touches RTC; `mosgortrans_util.h` pulls it in anyway). Unrelated to the bug, so it is its own commit and can be dropped on its own.

# Verification

`fbt fap_social_moscow_parser` passes `APPCHK` in both debug and `COMPACT=1 DEBUG=0`; `fbt lint` and `fbt format` both exit 0.

Checked against **four real card dumps** by transliterating `bit_lib_get_bits*`, both versions of the BCD conversion, and `calculate_luhn` to the host and running them over the real block 60 data.

Card numbers are withheld — these are real cards belonging to real people. Every Moscow social card shares the same `9643 90` issuer + `77` region prefix, so the only card-specific digits below are the two the truncation drops and the check digit:

| dump | digit pair dropped by the truncation | check digit stored on card | computed by old code | old | new |
|---|---|---|---|---|---|
| A | `54` | 4 | 7 | rejected | accepted |
| B | `20` | 3 | 5 | rejected | accepted |
| C | `78` | 8 | 2 | rejected | accepted |
| D | `76` | 6 | 6 | accepted | accepted |

1 of 4 today, **4 of 4 after the fix**. The card data was always valid; the checker was not.

Three things make this a mechanism and not a correlation:

- The 1-of-4 hit rate and *which* dump passed match the field report that prompted the issue.
- The survival formula `S(2·D8) + D9 ≡ 0 (mod 10)` predicts the exact wrong check digits (7, 5, 2) that the shipped code produces.
- Dump D is a genuine Luhn collision — `S(2·6) + 7 = 10`, weighing the same as the `00` the truncation substitutes. It is a regression control, not a redundant fourth case.

**The library call is bit-exact against the old arithmetic**, so none of that evidence is lost in the swap: identical on all four dumps and on **200,000 random inputs** including non-BCD nibbles and leading zeros, zero mismatches. Both forms compute `Σ nibbleᵢ · 10ⁱ`; `res = res*10 + nibble` carries identically to `nibble * multiplier`.

**Overflow.** Worth stating for hostile rather than well-formed input, since the fix makes the value reaching `calculate_luhn()` up to 100× larger: with every nibble `0xF`, `number` = 16,666,666,666,666,666,665 against a `UINT64_MAX` of 18,446,744,073,709,551,615. Fits, with headroom. `furi_check(len <= 9)` in the helper permits exactly the 9 bytes passed.

The sector-15 key gate (`A0A1A2A3A4A5` / `7DE02A7F6025`) passes on all four dumps, so the Luhn check was the only thing rejecting them.

**Confirmed on hardware.** Release build (`COMPACT=1 DEBUG=0`) flashed over USB to an f7; `device_info` reports the branch commit with `firmware_commit_dirty: false`. All four dumps were loaded from Saved and **all four parse correctly** — the three that this firmware rejected before now render the Social card view, and dump D still renders as it did.

Still unverified, for a reviewer with a card to hand:

- A **live card read** rather than a saved-dump load. The saved path enters at `parse()` and skips `social_moscow_verify()` / `social_moscow_read()` entirely.
- A **negative control** — a non-Social-Moscow Classic 1K must still be rejected.

# Known gaps, deliberately not fixed here

Filed separately rather than folded in, to keep this PR a targeted fix:

- **#1093** — a zero-filled or unread `block[60]` passes the Luhn gate, because `calculate_luhn(0) == 0` and `card_control` is also 0. The mirror image of this bug: a false positive that renders an all-zero card and suppresses the raw dump the user needed.
- **#1094** — `mosgortrans_util.c` drops an unknown ticket layout silently, so a new Moscow layout is indistinguishable from "no ticket". Shared with `troika.c`.
- **#1095** — no supported-card parser has any test coverage (0 of 41), which is what made this bug class undetectable.
- **#1096** — `smartrider.c` logs "not my card" at `FURI_LOG_E`, spamming the console on every Classic scan.

Also unchanged and out of scope: `calculate_luhn()` is byte-identical to `myki_calculate_luhn()`, but plugins share code by source inclusion rather than API export, so deduplicating it would add a file pair and two `application.fam` edits to save exactly zero flash.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Investigated and written with Claude Code, then reviewed by it across eight agents. The generated code is the `bit_lib_bytes_to_num_bcd()` call that replaces the private converter, the rejection log, and the format widths.

Two review findings changed the shape of the fix and are worth naming. The first draft simply widened the broken loop; the reuse pass found that the tree already had the exact function, unit-tested and exported, so the fix became a deletion instead. The review also caught a false claim in an earlier version of this description — that `pow()` had only ever been constant-folded — which turned out to be true of the debug build and wrong for the release build, where newlib's `pow` was linked in whole. Both were verified against the built objects and the four dumps before anything changed.

Fixes #1091
