### PR TITLE
NFC: parser fixes for unread blocks, unknown ticket layouts and SmartRider log spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - NFC: **Ultralight - the default password is no longer tried when AUTHLIM cannot be read** (by @mishamyte | PR #1089 | Fixes #1087)
 - BadUSB: Moved demo files to examples folder
 - NFC: Removed unreachable EMV render code that called an undefined function (by @mishamyte | PR #1085 | Fixes #1084)
+- NFC: Social Moscow - a card is no longer parsed from blocks that were never read (by @mishamyte | PR #1097 | Fixes #1093)
+- NFC: Mosgortrans - an unrecognised ticket layout is now logged instead of silently dropping the section (by @mishamyte | PR #1097 | Fixes #1094)
+- NFC: SmartRider no longer logs not-my-card checks as errors on every Mifare Classic scan (by @mishamyte | PR #1097 | Fixes #1096)
 <br><br>
 
 ----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@
 - NFC: **Ultralight - the default password is no longer tried when AUTHLIM cannot be read** (by @mishamyte | PR #1089 | Fixes #1087)
 - BadUSB: Moved demo files to examples folder
 - NFC: Removed unreachable EMV render code that called an undefined function (by @mishamyte | PR #1085 | Fixes #1084)
-- NFC: Social Moscow - a card is no longer parsed from blocks that were never read (by @mishamyte | PR #1097 | Fixes #1093)
-- NFC: Mosgortrans - an unrecognised ticket layout is now logged instead of silently dropping the section (by @mishamyte | PR #1097 | Fixes #1094)
-- NFC: SmartRider no longer logs not-my-card checks as errors on every Mifare Classic scan (by @mishamyte | PR #1097 | Fixes #1096)
+- NFC: Social Moscow - a partially read card no longer shows an all-zero card number as if it were real (by @mishamyte | PR #1097 | Fixes #1093)
+- NFC: Mosgortrans - an unrecognised ticket layout is now named in the debug log, instead of the Metro/Ground section vanishing with no explanation (by @mishamyte | PR #1097 | Fixes #1094)
+- NFC: SmartRider, All-In-One and Banapass no longer log an error for every card that is not theirs (by @mishamyte | PR #1097 | Fixes #1096)
 <br><br>
 
 ----

--- a/applications/main/nfc/api/mosgortrans/mosgortrans_util.c
+++ b/applications/main/nfc/api/mosgortrans/mosgortrans_util.c
@@ -1314,7 +1314,7 @@ bool mosgortrans_parse_transport_block(const MfClassicBlock* block, FuriString* 
         break;
     }
     default:
-        // a new ticket layout is otherwise indistinguishable from a card with no ticket
+        // the layout value is already logged above; what is missing is that we did not know it
         FURI_LOG_D(TAG, "Unknown layout type %x", layout_type);
         return false;
     }

--- a/applications/main/nfc/api/mosgortrans/mosgortrans_util.c
+++ b/applications/main/nfc/api/mosgortrans/mosgortrans_util.c
@@ -1315,7 +1315,7 @@ bool mosgortrans_parse_transport_block(const MfClassicBlock* block, FuriString* 
     }
     default:
         // the layout value is already logged above; what is missing is that we did not know it
-        FURI_LOG_D(TAG, "Unknown layout type %x", layout_type);
+        FURI_LOG_D(TAG, "Layout %x is not supported", layout_type);
         return false;
     }
 

--- a/applications/main/nfc/api/mosgortrans/mosgortrans_util.c
+++ b/applications/main/nfc/api/mosgortrans/mosgortrans_util.c
@@ -1314,7 +1314,8 @@ bool mosgortrans_parse_transport_block(const MfClassicBlock* block, FuriString* 
         break;
     }
     default:
-        result = NULL;
+        // a new ticket layout is otherwise indistinguishable from a card with no ticket
+        FURI_LOG_D(TAG, "Unknown layout type %x", layout_type);
         return false;
     }
 

--- a/applications/main/nfc/plugins/supported_cards/all_in_one.c
+++ b/applications/main/nfc/plugins/supported_cards/all_in_one.c
@@ -47,7 +47,7 @@ static bool all_in_one_parse(const NfcDevice* device, FuriString* parsed_data) {
 
     do {
         if(data->page[4].data[0] != 0x45 || data->page[4].data[1] != 0xD9) {
-            FURI_LOG_E(TAG, "Pass not verified");
+            FURI_LOG_D(TAG, "Pass not verified");
             break;
         }
 

--- a/applications/main/nfc/plugins/supported_cards/banapass.c
+++ b/applications/main/nfc/plugins/supported_cards/banapass.c
@@ -90,7 +90,7 @@ static bool banapass_read(Nfc* nfc, NfcDevice* device) {
         MfClassicError error = mf_classic_poller_sync_detect_type(nfc, &type);
         if(error != MfClassicErrorNone) break;
         if(type != MfClassicType1k) {
-            FURI_LOG_E(TAG, "Card not MIFARE Classic 1k");
+            FURI_LOG_D(TAG, "Card not MIFARE Classic 1k");
             break;
         }
 

--- a/applications/main/nfc/plugins/supported_cards/nfc_supported_card_plugin.h
+++ b/applications/main/nfc/plugins/supported_cards/nfc_supported_card_plugin.h
@@ -16,6 +16,12 @@
  * Then, register the plugin in the `application.fam` file in the `nfc` directory. Use the existing
  * entries as an example. After being registered, the plugin will be automatically deployed with the application.
  *
+ * @note a card that is not yours is not an error: log the checks that decline a card at
+ * FURI_LOG_D, since every plugin of a protocol runs against every card of that protocol.
+ *
+ * @note for Mifare Classic, guard every block you read with mf_classic_is_block_read().
+ * Knowing a sector's keys does not mean its blocks were read - the two are tracked separately.
+ *
  * @note the APPID field MUST end with `_parser` so the applicaton would know that this particular file
  * is a supported card plugin.
  *

--- a/applications/main/nfc/plugins/supported_cards/smartrider.c
+++ b/applications/main/nfc/plugins/supported_cards/smartrider.c
@@ -214,13 +214,13 @@ static bool smartrider_parse(const NfcDevice* device, FuriString* parsed_data) {
     SmartRiderData sr_data = {0};
 
     if(data->type != MfClassicType1k) {
-        FURI_LOG_E(TAG, "Invalid card type");
+        FURI_LOG_D(TAG, "Invalid card type");
         return false;
     }
 
     const MfClassicSectorTrailer* sec_tr = mf_classic_get_sector_trailer_by_sector(data, 0);
     if(!sec_tr || memcmp(sec_tr->key_a.data, STANDARD_KEYS[0], 6) != 0) {
-        FURI_LOG_E(TAG, "Key verification failed for sector 0");
+        FURI_LOG_D(TAG, "Key verification failed for sector 0");
         return false;
     }
 
@@ -228,7 +228,7 @@ static bool smartrider_parse(const NfcDevice* device, FuriString* parsed_data) {
     for(size_t i = 0; i < COUNT_OF(required_blocks); i++) {
         if(required_blocks[i] >= MAX_BLOCKS ||
            !mf_classic_is_block_read(data, required_blocks[i])) {
-            FURI_LOG_E(TAG, "Required block %d is not read or out of range", required_blocks[i]);
+            FURI_LOG_D(TAG, "Required block %d is not read or out of range", required_blocks[i]);
             return false;
         }
     }

--- a/applications/main/nfc/plugins/supported_cards/smartrider.c
+++ b/applications/main/nfc/plugins/supported_cards/smartrider.c
@@ -7,7 +7,6 @@
 
 #define MAX_TRIPS           10
 #define TAG                 "SmartRider"
-#define MAX_BLOCKS          64
 #define MAX_DATE_ITERATIONS 366
 
 static const uint8_t STANDARD_KEYS[3][6] = {
@@ -226,9 +225,8 @@ static bool smartrider_parse(const NfcDevice* device, FuriString* parsed_data) {
 
     static const uint8_t required_blocks[] = {14, 4, 5, 1, 52, 50, 0};
     for(size_t i = 0; i < COUNT_OF(required_blocks); i++) {
-        if(required_blocks[i] >= MAX_BLOCKS ||
-           !mf_classic_is_block_read(data, required_blocks[i])) {
-            FURI_LOG_D(TAG, "Required block %d is not read or out of range", required_blocks[i]);
+        if(!mf_classic_is_block_read(data, required_blocks[i])) {
+            FURI_LOG_D(TAG, "Required block %d is not read", required_blocks[i]);
             return false;
         }
     }

--- a/applications/main/nfc/plugins/supported_cards/social_moscow.c
+++ b/applications/main/nfc/plugins/supported_cards/social_moscow.c
@@ -260,14 +260,13 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
             card_region,
             card_number,
             card_control);
-        // block 21 lives in another sector, so it can be missing while block 60 is present.
-        // say so rather than omitting the line - our output replaces the view that would have
-        // shown Sectors Read, so a dropped line is the only sign the dump is incomplete
+        // block 21 is in another sector, so it can be missing while 60 is present; say
+        // "Unknown" rather than drop the line, as our text replaces the Sectors Read view
         if(mf_classic_is_block_read(data, 21)) {
             const uint64_t omc_number = bit_lib_get_bits_64(data->block[21].data, 8, 64);
             furi_string_cat_printf(parsed_data, "OMC: %llx\n", omc_number);
         } else {
-            furi_string_cat(parsed_data, "OMC: unknown\n");
+            furi_string_cat(parsed_data, "OMC: Unknown\n");
         }
         furi_string_cat_printf(
             parsed_data,

--- a/applications/main/nfc/plugins/supported_cards/social_moscow.c
+++ b/applications/main/nfc/plugins/supported_cards/social_moscow.c
@@ -226,7 +226,6 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
         uint8_t card_region = bit_lib_get_bits(data->block[60].data, 32, 8);
         uint64_t card_number = bit_lib_get_bits_64(data->block[60].data, 40, 40);
         uint8_t card_control = bit_lib_get_bits(data->block[60].data, 80, 4);
-        uint64_t omc_number = bit_lib_get_bits_64(data->block[21].data, 8, 64);
         uint8_t year = data->block[60].data[11];
         uint8_t month = data->block[60].data[12];
 
@@ -261,9 +260,14 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
             card_region,
             card_number,
             card_control);
-        // block 21 lives in another sector, so it can be missing while block 60 is present
+        // block 21 lives in another sector, so it can be missing while block 60 is present.
+        // say so rather than omitting the line - our output replaces the view that would have
+        // shown Sectors Read, so a dropped line is the only sign the dump is incomplete
         if(mf_classic_is_block_read(data, 21)) {
+            const uint64_t omc_number = bit_lib_get_bits_64(data->block[21].data, 8, 64);
             furi_string_cat_printf(parsed_data, "OMC: %llx\n", omc_number);
+        } else {
+            furi_string_cat(parsed_data, "OMC: unknown\n");
         }
         furi_string_cat_printf(
             parsed_data,

--- a/applications/main/nfc/plugins/supported_cards/social_moscow.c
+++ b/applications/main/nfc/plugins/supported_cards/social_moscow.c
@@ -215,6 +215,13 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
             bit_lib_bytes_to_num_be(sec_tr->key_b.data, COUNT_OF(sec_tr->key_b.data));
         if((key_a != cfg.keys[cfg.data_sector].a) || (key_b != cfg.keys[cfg.data_sector].b)) break;
 
+        // knowing the sector 15 keys does not mean its blocks were read; a zero block 60 would
+        // otherwise satisfy the check digit below, since calculate_luhn(0) is 0
+        if(!mf_classic_is_block_read(data, 60)) {
+            FURI_LOG_D(TAG, "Block 60 was not read");
+            break;
+        }
+
         uint32_t card_code = bit_lib_get_bits_32(data->block[60].data, 8, 24);
         uint8_t card_region = bit_lib_get_bits(data->block[60].data, 32, 8);
         uint64_t card_number = bit_lib_get_bits_64(data->block[60].data, 40, 40);
@@ -249,12 +256,18 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
         // the number is fixed-width 6+2+10+1 digits, so keep the leading zeros
         furi_string_cat_printf(
             parsed_data,
-            "\e#Social \ecard\nNumber: %06lx %02x %010llx %x\nOMC: %llx\nValid for: %02x/%02x %02x%02x\n",
+            "\e#Social \ecard\nNumber: %06lx %02x %010llx %x\n",
             card_code,
             card_region,
             card_number,
-            card_control,
-            omc_number,
+            card_control);
+        // block 21 lives in another sector, so it can be missing while block 60 is present
+        if(mf_classic_is_block_read(data, 21)) {
+            furi_string_cat_printf(parsed_data, "OMC: %llx\n", omc_number);
+        }
+        furi_string_cat_printf(
+            parsed_data,
+            "Valid for: %02x/%02x %02x%02x\n",
             month,
             year,
             data->block[60].data[13],


### PR DESCRIPTION
# What's new

Three small parser fixes found while reviewing #1092, bundled rather than filed as separate PRs. One commit each, independently revertable. Common theme: parsers behaving sanely on data that is incomplete or unrecognised.

## `Closes #1093` — a Social Moscow card could be parsed from blocks that were never read

The mirror image of the bug #1092 fixed: that one was a false negative, this is a false positive.

Knowing a sector's keys does **not** mean its blocks were read. Keys arrive through the key-found path (`mf_classic_parse_block` loads key A and key B from a trailer independently of the data bytes), while a block saved as `??` never reaches `mf_classic_set_block_read`. `mf_classic_alloc` zero-fills, so `data->block[60]` reads back as all zeros.

And an all-zero block 60 **passed the check digit gate**: `calculate_luhn(0)` returns 0 because `while(payload > 0)` never runs, and `card_control` extracted from a zero block is also 0. So the parser claimed the card and rendered `Number: 000000 00 0000000000 0` / `OMC: 0`, suppressing the raw Mifare Classic dump the user actually needed.

Block 60 is now required. Block 21 sits in a different sector and can be missing on its own, so the `OMC:` line now reads `unknown` instead of printing a zero that looks like a real value.

Review talked me out of simply omitting the line, and the argument is worth recording: when a parser returns true, `nfc_protocol_support.c:664-670` renders the parse text **instead of** the protocol's own read-success view — and that is the view carrying `Keys Found` / `Sectors Read`. So on a partially read card the parse output is the *only* thing on screen, and a quietly dropped line would be the sole indication anything was missing. `bambu.c`, `charliecard.c`, `kazan.c`, `ndef.c`, `sonicare.c` and `clipper.c` all print an explicit `Unknown` for a field they cannot fill; this now matches.

Blocks 4 and 16 deliberately get no guard — unread they read as zeros, a zero transport department is not in `valid_departments`, so those sections are already omitted correctly.

## `Closes #1094` — Mosgortrans dropped an unknown ticket layout silently

```c
    default:
        result = NULL;
        return false;
```

A new Moscow ticket layout made the Metro/Ground section vanish in a way indistinguishable from a card carrying no ticket. The layout value is printed earlier in the function, but nothing said it had not been recognised.

The removed assignment was a no-op — it set the local parameter copy, not the caller's `FuriString`, so it never cleared anything despite reading as if it did.

Shared file: both `troika.c` and `social_moscow.c` benefit.

## `Closes #1096` — SmartRider logged not-my-card checks as errors

`FURI_LOG_E` sits above the default runtime level (`FuriLogLevelInfo`), so unlike `FURI_LOG_D` these were never filtered and reached the console on every scan.

Two of the three are pure discriminators — wrong card type, wrong sector-0 key — and fire on essentially every Classic card that is not a SmartRider. **The third is not**, and the original commit message overstated this: `"Required block %d is not read"` sits behind the sector-0 key check against `2031D1E57A3B`, a SmartRider-specific key, so it only fires on a genuinely partially-read SmartRider. It is still right at debug, but for a different reason: the fallback view already tells the user `Sectors Read: y/16`, so nothing is unrecoverably lost, and a parse-time Warn would be the only one in the entire directory (across all 41 parsers: 82 debug, 19 warn — all in read paths — 3 info).

The structurally identical parsers — `troika.c`, `plantain.c`, `two_cities.c`, `csc.c` — break silently on the same gates, and `kazan.c` logs its key gate at debug.

**Extended past SmartRider after review.** `all_in_one.c` and `banapass.c` carried the identical error-level discriminator (`"Pass not verified"`, `"Card not MIFARE Classic 1k"`), so they are included rather than left as the only two parsers still shouting on every foreign card. The remaining error logs in those files fire *after* the card is identified, so they stay.

Worth noting the runtime effect, which is the opposite of a cost. `FURI_LOG_D` is *not* compiled out in plugins — `site_scons/extapps.scons:54` adds `LOGS_DEBUG_BUILD` to every external app, so the strip guard in `furi/core/log.h` never applies. But at the default runtime level (`Info`), debug short-circuits after one comparison, while **error does not**: it takes a mutex, allocates a `FuriString`, and runs two `vsnprintf` passes for the header and body. Since every plugin of a protocol runs against every card of that protocol, each Classic tap previously paid that full path three times over for cards that were none of these three. Roughly 12 malloc/free pairs and 3 mutex round-trips saved per tap, at identical flash size.

# Verification

`fap_social_moscow_parser`, `fap_troika_parser`, `fap_smartrider_parser`, `fap_all_in_one_parser`, `fap_banapass_parser` and `fap_nfc` all build with `APPCHK` passing. `fbt format` and `fbt lint` both exit 0.

Measured release `.fal` cost of the Social Moscow change: 18,072 → 18,308 bytes (+236). Of that, +136 is the block-60 guard and its log string, +100 the block-21 guard and the render split; +25 is the single new SDK import (`mf_classic_is_block_read`). Collapsing the three `furi_string_cat_printf` calls back into one via a `char[20]` buffer measures **larger**, at 18,376, so the split as written is also the smaller form.

**The #1093 mechanism is verified rather than assumed**, by reading the load path:

- `mf_classic_parse_block` sets `block_unknown_bytes_mask` per byte; a fully-`??` block leaves it `0xffff` and takes no branch that calls `mf_classic_set_block_read`, so `mf_classic_is_block_read()` stays false.
- The same function loads key A and key B from a trailer under separate masks (`0x003f` / `0xfc00`), which is why sector-15 keys can be known while block 60 is absent.
- `calculate_luhn(0) == 0` — confirmed by transliterating it.

Reproduce by taking any Social Moscow dump and replacing block 60 with `?? ?? ...`; before this change it renders an all-zero Social card, after it falls through to the raw dump.

**On hardware.** An earlier commit of this branch was flashed as a release build and the four real Social Moscow dumps that validated #1092 still parse correctly. Two synthetic fixtures for the #1093 path (block 60 blanked to `??`, and block 21 blanked) are on the device but the visual check on them is not confirmed, and the last two commits — `OMC: Unknown`, the log rewording, the dead-bound removal — landed after that flash. None of them changes parse behaviour on a complete dump.

Not verified: a live SmartRider or Troika read. I have neither card.

# Not included

**#1095** (supported-card parsers have no test coverage) stays out — it is a design decision about test infrastructure, not a code change.

Two fleet-wide findings came out of reviewing this PR and are filed rather than swept in, because each needs a per-parser reject-vs-degrade judgement like the block-60/block-21 split above:

- **#1098** — only 3 of 30 Mifare Classic parsers guard their block reads, and the rest print zeros as real data. `mf_classic_set_key_found()` never touches `block_read_mask`, so "keys known" and "blocks read" are genuinely independent. Best demonstration: `metromoney.c:151` computes `balance = ... - 100` on an unread block, underflows, and displays `Balance: 42949671.96 GEL`.
- **#1099** — `nfc_supported_cards_parse()` never resets `parsed_data` between plugins, so a parser that writes a header and then declines (`troika.c`, `banapass.c`, `plantain.c` all do) leaves it for the next one. One-line host-side fix, but a different concern from these three.

Rejected outright, for the record: declaring required blocks in `NfcSupportedCardsPlugin`. The block set is data-dependent for most parsers, the struct is shared across seven protocols where "blocks" is meaningless, and adding a field forces an `NFC_SUPPORTED_CARD_PLUGIN_API_VERSION` bump — which silently drops every out-of-tree `.fal`, the same failure mode that hid the EMV plugin in #1073.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Written with Claude Code. The generated code is the two `mf_classic_is_block_read` guards and the split render call in `social_moscow.c`, the log line replacing the no-op assignment in `mosgortrans_util.c`, and the three log-level changes in `smartrider.c`. All three issues were found during the multi-agent review of #1092; the block-read mechanism was traced through `mf_classic_parse_block` before writing the guard, rather than inferred from the symptom.

Closes #1093
Closes #1094
Closes #1096
