### PR TITLE
Loader: show the loading animation while an app's .fap is read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Apps: **Added categories for apps in firmware builds**, if you had apps that were moved to new subfolders in favourites, or on quick buttons, you will need to re-add them to favs/buttons
 - Apps: Build tag (**18aug2026p2**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes
+- Loader: **Opening an app now shows the loading animation while its .fap is read from the SD card**, instead of the screen sitting frozen on the previous view (by @mishamyte | PR #1101 | Closes #1100)
 - NFC: **Ultralight read result now says whether authentication failed or was never attempted** (by @mishamyte | PR #1090 | Closes #1088)
 - NFC: **Ultralight - the default password is no longer tried when AUTHLIM cannot be read** (by @mishamyte | PR #1089 | Fixes #1087)
 - BadUSB: Moved demo files to examples folder

--- a/applications/services/loader/loader.c
+++ b/applications/services/loader/loader.c
@@ -652,6 +652,23 @@ static bool loader_do_is_locked(Loader* loader) {
     return loader->app.thread != NULL;
 }
 
+// A deferred launch brackets a whole chain and each .fap read nests inside it, so refcount
+static void loader_do_show_loading(Loader* loader) {
+    furi_check(loader->loading_depth < UINT8_MAX);
+    loader->loading_depth++;
+    if(loader->loading_depth > 1) return;
+    // Launched apps attach their viewport above ours, so re-front on every show
+    view_holder_send_to_front(loader->view_holder);
+    view_holder_set_view(loader->view_holder, loading_get_view(loader->loading));
+}
+
+static void loader_do_hide_loading(Loader* loader) {
+    furi_check(loader->loading_depth > 0);
+    loader->loading_depth--;
+    if(loader->loading_depth > 0) return;
+    view_holder_set_view(loader->view_holder, NULL);
+}
+
 static LoaderMessageLoaderStatusResult loader_do_start_by_name(
     Loader* loader,
     const char* name,
@@ -715,12 +732,15 @@ static LoaderMessageLoaderStatusResult loader_do_start_by_name(
         {
             Storage* storage = furi_record_open(RECORD_STORAGE);
             if(storage_file_exists(storage, name)) {
+                // Reading a .fap off the SD card takes seconds; internal apps above are instant
+                loader_do_show_loading(loader);
                 status =
                     loader_start_external_app(loader, storage, name, args, error_message, false);
                 if(status.value == LoaderStatusErrorApiMismatch) {
                     status = loader_start_external_app(
                         loader, storage, name, args, error_message, true);
                 }
+                loader_do_hide_loading(loader);
                 furi_record_close(RECORD_STORAGE);
                 break;
             }
@@ -778,8 +798,7 @@ static bool loader_do_deferred_launch(Loader* loader, LoaderDeferredLaunchRecord
 
     bool is_successful = false;
     FuriString* error_message = furi_string_alloc();
-    view_holder_set_view(loader->view_holder, loading_get_view(loader->loading));
-    view_holder_send_to_front(loader->view_holder);
+    loader_do_show_loading(loader);
 
     do {
         const char* app_name_str = record->name_or_path;
@@ -799,7 +818,7 @@ static bool loader_do_deferred_launch(Loader* loader, LoaderDeferredLaunchRecord
         loader_do_next_deferred_launch_if_available(loader);
     } while(false);
 
-    view_holder_set_view(loader->view_holder, NULL);
+    loader_do_hide_loading(loader);
     furi_string_free(error_message);
     return is_successful;
 }

--- a/applications/services/loader/loader_i.h
+++ b/applications/services/loader/loader_i.h
@@ -34,6 +34,7 @@ struct Loader {
     Gui* gui;
     ViewHolder* view_holder;
     Loading* loading;
+    uint8_t loading_depth;
 };
 
 typedef enum {


### PR DESCRIPTION
# What's new

Opening an app from the main menu drew nothing while the loader read and relocated its `.fap` off the SD card — the screen sat on the previous view, so the press looked ignored, and the app appeared a second or two later. NFC is the worst case: at 327 KB it is 2.5x the next largest main-menu app (`infrared.fap`, 131 KB). A cold or fragmented card stretches it further, which is why it feels intermittent.

The loading animation was never missing, only unused on this path. `loader_applications.c` already raises it around a launch from the Apps browser, and `loader_do_deferred_launch()` around a chained one. The gap was `loader_do_start_by_name()` — which **every** other entry point funnels through — while `loader_start_external_app()` blocked the loader thread in `flipper_application_preload()` and `flipper_application_map_to_memory()`.

So this is not an NFC fix. It covers the main menu, archive browser, desktop favourites and hold-buttons, RPC and autorun, for every `MENUEXTERNAL` and `EXTSETTINGS` app.

**Scoped to the `.fap` branch** rather than the whole function: that `storage_file_exists` test is the first point that knows the launch will touch the SD card at all. Internal apps resolve above it and start in microseconds, so covering them would only flash the hourglass for a frame. It also brackets the API-mismatch retry as one span, which bracketing inside `loader_start_external_app()` would have split in two.

**Show/hide is refcounted.** Launches nest: `loader_do_deferred_launch()` calls `loader_do_start_by_name()`, and re-enters itself once per queued app on failure, up to `LOADER_QUEUE_MAX_SIZE` deep. Without the refcount the inner hide would tear the backdrop down mid-chain, which is the gap the deferred site exists to cover. Both callers now share the pair, which also drops the stop/start the old code inflicted on the animation at every link of a retry chain. The counter follows `furi_hal_power_insomnia_enter/exit`: guarded at both ends with a bare `furi_check` so it survives release builds, where an unbalanced hide would otherwise wrap to 255 and strand a fullscreen view that swallows all input.

`view_holder_send_to_front()` runs on every show, not once at attach — launched apps and the Apps browser add their viewports above the loader's, and `gui_view_port_find_enabled()` takes the last one added.

Error dialogs raised from inside the load still render on top: dialogs allocate a fresh `ViewHolder` per message and `gui_add_view_port()` pushes to front, so the API-mismatch prompt is not covered by the view we sent to front first.

**Left uncovered on purpose.** The desktop's `DesktopGlobalBeforeAppStarted` handshake runs above the internal/external split and is budgeted at 3 s, so reaching it would mean showing the hourglass for internal apps too. And the hide fires when the app thread starts, not when it paints; closing that needs a GUI "viewport drawn" signal that does not exist, and the deferred path has always had the same shape.

**Known follow-up, deliberately not here:** `loader_applications.c` still owns a duplicate `Loading` + `ViewHolder`, so an Apps-browser launch now stacks two identical animations (visually identical, one is never drawn). Deduplicating it needs new `LoaderMessageTypeShow/HideLoading` message types so the browser thread can drive the loader's view — its own risk surface, worth a separate PR.

# Verification

Hardware: Flipper Zero, release build flashed over USB.

1. From the main menu, open **NFC** (the largest `.fap`). Before: the menu freezes for ~1-3 s with no feedback. After: the rotating hourglass appears immediately and is replaced by the app.
2. Repeat for other main-menu apps — Infrared, LF RFID, iButton, Bad USB — same behaviour, proportional to `.fap` size.
3. Open an **internal** app (e.g. Sub-GHz) and confirm **no** hourglass flash — it must stay instant.
4. Open a saved `.nfc`/`.ir`/`.sub` from the **archive browser** and confirm the hourglass appears there too.
5. Apps browser (**Apps** → any category → a `.fap`): confirm the animation still looks correct and does not flicker or double up visibly.
6. Chained launch: from the NFC app, trigger a flow that enqueues another app and returns — confirm the animation runs continuously across the chain and does not blink off between apps.
7. Confirm an app that fails to launch still shows its error dialog, with no hourglass left on screen behind it.

Builds clean (`fbt firmware_all`), `fbt format` and `scripts/lint.py check` clean.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

The diagnosis and the whole diff were produced by Claude Opus 5 under my direction, then reviewed and hardware-tested by me.

The generated code is two files. In `loader_i.h`, one field: `uint8_t loading_depth` in `struct Loader`. In `loader.c`, a pair of static helpers — `loader_do_show_loading()` increments the counter, and on the 0→1 transition sends the loader's existing `ViewHolder` to the front and sets the pre-existing `Loading` view on it; `loader_do_hide_loading()` decrements and clears the view on the 1→0 transition, with `furi_check` guards at both ends. The `.fap` branch of `loader_do_start_by_name()` is wrapped in that pair, and `loader_do_deferred_launch()`'s two inline `view_holder_set_view`/`send_to_front` calls are replaced by the same helpers so the two spans compose. No new views, assets, or allocations are introduced — it reuses the `Loading` instance the loader has always allocated in `loader_alloc()`.

Reviewed by seven independent review agents (correctness, comment accuracy, silent-failure, reuse, simplification, efficiency, altitude); no critical or high findings survived. One agent proposed deleting the refcount by removing the outer show/hide in `loader_do_deferred_launch()`; rejected, because that pair is upstream OFW code from `[FL-3953] Application chaining (#4105)` and uniquely covers chained launches to internal apps.

Closes #1100
