### PR TITLE
NFC: stop parsers rendering data from blocks that were never read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Apps: **Added categories for apps in firmware builds**, if you had apps that were moved to new subfolders in favourites, or on quick buttons, you will need to re-add them to favs/buttons
 - Apps: Build tag (**18aug2026p2**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes
-- Loader: **Opening an app now shows the loading animation while its .fap is read from the SD card**, instead of the screen sitting frozen on the previous view (by @mishamyte | PR #1101 | Closes #1100)
 - NFC: **Ultralight read result now says whether authentication failed or was never attempted** (by @mishamyte | PR #1090 | Closes #1088)
 - NFC: **Ultralight - the default password is no longer tried when AUTHLIM cannot be read** (by @mishamyte | PR #1089 | Fixes #1087)
 - BadUSB: Moved demo files to examples folder
@@ -19,6 +18,10 @@
 - NFC: Social Moscow - a partially read card no longer shows an all-zero card number as if it were real (by @mishamyte | PR #1097 | Fixes #1093)
 - NFC: Mosgortrans - an unrecognised ticket layout is now named in the debug log, instead of the Metro/Ground section vanishing with no explanation (by @mishamyte | PR #1097 | Fixes #1094)
 - NFC: SmartRider, All-In-One and Banapass no longer log an error for every card that is not theirs (by @mishamyte | PR #1097 | Fixes #1096)
+- NFC: Metromoney, Plantain, Two Cities and Kazan no longer render values from blocks that were never read, such as a 42949671.96 GEL balance (by @mishamyte | PR #1102 | Fixes #1098)
+- NFC: Plantain no longer claims the PPK keys are installed on every 1K card (by @mishamyte | PR #1102 | Fixes #1098)
+- NFC: a supported-card parser that declines a card no longer leaks its output into the next parser (by @mishamyte | PR #1102 | Fixes #1099)
+- NFC: Social Moscow again parses dumps saved before the format carried a read mask, such as converted PM3 dumps (by @mishamyte | PR #1102 | Fixes #1098)
 <br><br>
 
 ----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - NFC: **Ultralight AES - closed the remaining card-lock (AUTHLIM) paths** (by @mishamyte | PR #1082 | Fixes #1081)
 - NFC: **Ultralight - Amiibo/Xiaomi unlock no longer burns an AUTHLIM attempt when the password cannot be derived** (by @mishamyte | PR #1086 | Fixes #1083)
 - NFC: **Social Moscow - fixed the parser rejecting most genuine cards** (by @mishamyte | PR #1092 | Fixes #1091)
+- Loader: **Opening an app now shows the loading animation while its .fap is read from the SD card**, instead of the screen sitting frozen on the previous view (by @mishamyte | PR #1101 | Closes #1100)
 - Apps: **Added categories for apps in firmware builds**, if you had apps that were moved to new subfolders in favourites, or on quick buttons, you will need to re-add them to favs/buttons
 - Apps: Build tag (**18aug2026p2**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes
@@ -18,8 +19,8 @@
 - NFC: Social Moscow - a partially read card no longer shows an all-zero card number as if it were real (by @mishamyte | PR #1097 | Fixes #1093)
 - NFC: Mosgortrans - an unrecognised ticket layout is now named in the debug log, instead of the Metro/Ground section vanishing with no explanation (by @mishamyte | PR #1097 | Fixes #1094)
 - NFC: SmartRider, All-In-One and Banapass no longer log an error for every card that is not theirs (by @mishamyte | PR #1097 | Fixes #1096)
-- NFC: Metromoney, Plantain, Two Cities and Kazan no longer render values from blocks that were never read, such as a 42949671.96 GEL balance (by @mishamyte | PR #1102 | Fixes #1098)
-- NFC: Plantain no longer claims the PPK keys are installed on every 1K card (by @mishamyte | PR #1102 | Fixes #1098)
+- NFC: Metromoney, Plantain, Two Cities and Kazan no longer present values from blocks that were never read - a 42949671.96 GEL balance, an empty purse dated 01.01.2010, a ticket valid from 00.00.2000 - declining the card or naming the field Unknown instead (by @mishamyte | PR #1102 | Fixes #1098)
+- NFC: Plantain no longer claims the PPK keys are installed on every 1K card; a card without the sector that carries them now reads No, and one whose key is missing reads Unknown (by @mishamyte | PR #1102 | Fixes #1098)
 - NFC: a supported-card parser that declines a card no longer leaks its output into the next parser (by @mishamyte | PR #1102 | Fixes #1099)
 - NFC: Social Moscow again parses dumps saved before the format carried a read mask, such as converted PM3 dumps (by @mishamyte | PR #1102 | Fixes #1098)
 <br><br>

--- a/applications/main/nfc/helpers/nfc_supported_cards.c
+++ b/applications/main/nfc/helpers/nfc_supported_cards.c
@@ -287,6 +287,8 @@ bool nfc_supported_cards_parse(
             if(plugin == NULL) continue;
 
             if(plugin->parse) {
+                // a plugin may write before it decides the card is not its own, so start clean
+                furi_string_reset(parsed_data);
                 if(plugin->parse(device, parsed_data)) {
                     card_parsed = true;
                     break;

--- a/applications/main/nfc/helpers/nfc_supported_cards.h
+++ b/applications/main/nfc/helpers/nfc_supported_cards.h
@@ -69,7 +69,8 @@ bool nfc_supported_cards_read(NfcSupportedCards* instance, NfcDevice* device, Nf
  *
  * @param[in, out] instance pointer to NfcSupportedCards instance.
  * @param[in] device pointer to a device instance holding the data is to be parsed.
- * @param[out] parsed_data pointer to the string to contain the formatted result.
+ * @param[out] parsed_data pointer to the string to contain the formatted result. It is reset
+ * before each plugin runs, and its contents are meaningful only when this function returns true.
  * @returns true if the card was successfully parsed, false otherwise.
  *
  * @see NfcSupportedCardPluginParse for detailed description.

--- a/applications/main/nfc/plugins/supported_cards/kazan.c
+++ b/applications/main/nfc/plugins/supported_cards/kazan.c
@@ -279,10 +279,6 @@ static bool kazan_parse(const NfcDevice* device, FuriString* parsed_data) {
 
         const uint8_t* block_start_ptr = &data->block[start_block_num].data[6];
 
-        FuriString* tariff_name = furi_string_alloc();
-        enum SubscriptionType subscription_type =
-            get_subscription_type(block_start_ptr[0], tariff_name);
-
         DateTime valid_from;
         valid_from.year = 2000 + block_start_ptr[1];
         valid_from.month = block_start_ptr[2];
@@ -292,6 +288,18 @@ static bool kazan_parse(const NfcDevice* device, FuriString* parsed_data) {
         valid_to.year = 2000 + block_start_ptr[4];
         valid_to.month = block_start_ptr[5];
         valid_to.day = block_start_ptr[6];
+
+        // an unread ticket block is all zeros, which renders as an unknown tariff valid from
+        // 00.00.2000; a genuine card always carries a start date
+        if(valid_from.month == 0 || valid_from.month > 12 || valid_from.day == 0 ||
+           valid_from.day > 31) {
+            FURI_LOG_D(TAG, "Ticket block is empty or its start date is invalid");
+            break;
+        }
+
+        FuriString* tariff_name = furi_string_alloc();
+        enum SubscriptionType subscription_type =
+            get_subscription_type(block_start_ptr[0], tariff_name);
 
         const uint8_t last_trip_block_number = 2;
         block_start_ptr = &data->block[start_block_num + last_trip_block_number].data[1];

--- a/applications/main/nfc/plugins/supported_cards/kazan.c
+++ b/applications/main/nfc/plugins/supported_cards/kazan.c
@@ -25,6 +25,8 @@
 #include <datetime.h>
 #include <locale/locale.h>
 
+#include "mf_classic_parser_util.h"
+
 #define TAG "Kazan"
 
 typedef struct {
@@ -95,6 +97,11 @@ enum SubscriptionType {
     SUBSCRIPTION_TYPE_ABONNEMENT_BY_TIME,
     SUBSCRIPTION_TYPE_ABONNEMENT_BY_TRIPS,
 };
+
+// only the fields the ticket blocks actually carry; DateTime here has no weekday or time
+static bool kazan_date_is_valid(const DateTime* date) {
+    return date->month >= 1 && date->month <= 12 && date->day >= 1 && date->day <= 31;
+}
 
 enum SubscriptionType get_subscription_type(uint8_t value, FuriString* tariff_name) {
     switch(value) {
@@ -289,11 +296,10 @@ static bool kazan_parse(const NfcDevice* device, FuriString* parsed_data) {
         valid_to.month = block_start_ptr[5];
         valid_to.day = block_start_ptr[6];
 
-        // an unread ticket block is all zeros, which renders as an unknown tariff valid from
-        // 00.00.2000; a genuine card always carries a start date
-        if(valid_from.month == 0 || valid_from.month > 12 || valid_from.day == 0 ||
-           valid_from.day > 31) {
-            FURI_LOG_D(TAG, "Ticket block is empty or its start date is invalid");
+        // the sector 8 key check does not mean its blocks were read, and an empty one would
+        // render as an unknown tariff valid from 00.00.2000
+        if(!mf_classic_parser_block_has_data(data, start_block_num)) {
+            FURI_LOG_D(TAG, "Ticket block %u was never read", start_block_num);
             break;
         }
 
@@ -310,14 +316,23 @@ static bool kazan_parse(const NfcDevice* device, FuriString* parsed_data) {
         last_trip.day = block_start_ptr[2];
         last_trip.hour = block_start_ptr[3];
         last_trip.minute = block_start_ptr[4];
-        bool is_last_trip_valid = (block_start_ptr[0] | block_start_ptr[1] | block_start_ptr[2]) &&
-                                  (last_trip.day < 32 && last_trip.month < 12 &&
-                                   last_trip.hour < 24 && last_trip.minute < 60);
+        bool is_last_trip_valid = kazan_date_is_valid(&last_trip) && last_trip.hour < 24 &&
+                                  last_trip.minute < 60;
 
         start_block_num = mf_classic_get_first_block_num_of_sector(balance_sector_number);
         block_start_ptr = &data->block[start_block_num].data[0];
 
         const uint32_t trip_counter = bit_lib_bytes_to_num_le(block_start_ptr, 4);
+
+        // sector 9 is not verified above and can be missing on its own, so do not present a
+        // zero counter as a balance or a trip count
+        char trip_counter_str[12];
+        if(mf_classic_parser_block_has_data(data, start_block_num)) {
+            snprintf(trip_counter_str, sizeof(trip_counter_str), "%lu", trip_counter);
+        } else {
+            FURI_LOG_D(TAG, "Balance block %u was never read", start_block_num);
+            snprintf(trip_counter_str, sizeof(trip_counter_str), "Unknown");
+        }
 
         size_t uid_len = 0;
         const uint8_t* uid = mf_classic_get_uid(data, &uid_len);
@@ -330,10 +345,18 @@ static bool kazan_parse(const NfcDevice* device, FuriString* parsed_data) {
         const char* separator = (date_format == LocaleDateFormatDMY) ? "." : "/";
 
         FuriString* valid_from_str = furi_string_alloc();
-        locale_format_date(valid_from_str, &valid_from, date_format, separator);
+        if(kazan_date_is_valid(&valid_from)) {
+            locale_format_date(valid_from_str, &valid_from, date_format, separator);
+        } else {
+            furi_string_set(valid_from_str, "Unknown");
+        }
 
         FuriString* valid_to_str = furi_string_alloc();
-        locale_format_date(valid_to_str, &valid_to, date_format, separator);
+        if(kazan_date_is_valid(&valid_to)) {
+            locale_format_date(valid_to_str, &valid_to, date_format, separator);
+        } else {
+            furi_string_set(valid_to_str, "Unknown");
+        }
 
         FuriString* last_trip_date_str = furi_string_alloc();
         locale_format_date(last_trip_date_str, &last_trip, date_format, separator);
@@ -344,8 +367,8 @@ static bool kazan_parse(const NfcDevice* device, FuriString* parsed_data) {
         if(subscription_type == SUBSCRIPTION_TYPE_PURSE) {
             furi_string_cat_printf(
                 parsed_data,
-                "Type: purse\nBalance: %lu RUR\nBalance valid:\nfrom: %s\nto: %s",
-                trip_counter,
+                "Type: purse\nBalance: %s RUR\nBalance valid:\nfrom: %s\nto: %s",
+                trip_counter_str,
                 furi_string_get_cstr(valid_from_str),
                 furi_string_get_cstr(valid_to_str));
         }
@@ -353,9 +376,9 @@ static bool kazan_parse(const NfcDevice* device, FuriString* parsed_data) {
         if(subscription_type == SUBSCRIPTION_TYPE_ABONNEMENT_BY_TRIPS) {
             furi_string_cat_printf(
                 parsed_data,
-                "Type: abonnement\nTariff: %s\nTrips left: %lu\nCard valid:\nfrom: %s\nto: %s",
+                "Type: abonnement\nTariff: %s\nTrips left: %s\nCard valid:\nfrom: %s\nto: %s",
                 furi_string_get_cstr(tariff_name),
-                trip_counter,
+                trip_counter_str,
                 furi_string_get_cstr(valid_from_str),
                 furi_string_get_cstr(valid_to_str));
         }
@@ -363,9 +386,9 @@ static bool kazan_parse(const NfcDevice* device, FuriString* parsed_data) {
         if(subscription_type == SUBSCRIPTION_TYPE_ABONNEMENT_BY_TIME) {
             furi_string_cat_printf(
                 parsed_data,
-                "Type: abonnement\nTariff: %s\nTotal valid time: %lu days\nCard valid:\nfrom: %s\nto: %s",
+                "Type: abonnement\nTariff: %s\nTotal valid time: %s days\nCard valid:\nfrom: %s\nto: %s",
                 furi_string_get_cstr(tariff_name),
-                trip_counter,
+                trip_counter_str,
                 furi_string_get_cstr(valid_from_str),
                 furi_string_get_cstr(valid_to_str));
         }
@@ -373,9 +396,9 @@ static bool kazan_parse(const NfcDevice* device, FuriString* parsed_data) {
         if(subscription_type == SUBSCRIPTION_TYPE_UNKNOWN) {
             furi_string_cat_printf(
                 parsed_data,
-                "Type: unknown\nTariff: %s\nCounter: %lu\nValid from: %s\nValid to: %s",
+                "Type: unknown\nTariff: %s\nCounter: %s\nValid from: %s\nValid to: %s",
                 furi_string_get_cstr(tariff_name),
-                trip_counter,
+                trip_counter_str,
                 furi_string_get_cstr(valid_from_str),
                 furi_string_get_cstr(valid_to_str));
         }

--- a/applications/main/nfc/plugins/supported_cards/metromoney.c
+++ b/applications/main/nfc/plugins/supported_cards/metromoney.c
@@ -23,6 +23,8 @@
 
 #include <bit_lib.h>
 
+#include "mf_classic_parser_util.h"
+
 #define TAG "Metromoney"
 
 typedef struct {
@@ -148,11 +150,18 @@ static bool metromoney_parse(const NfcDevice* device, FuriString* parsed_data) {
         const uint8_t* block_start_ptr =
             &data->block[start_block_num + ticket_block_number].data[0];
 
+        // knowing sector 1's key does not mean its blocks were read
+        const uint8_t ticket_block = start_block_num + ticket_block_number;
+        if(!mf_classic_parser_block_has_data(data, ticket_block)) {
+            FURI_LOG_D(TAG, "Ticket block %u was never read", ticket_block);
+            break;
+        }
+
         const uint32_t stored_value = bit_lib_bytes_to_num_le(block_start_ptr, 4);
-        // the balance is stored with 100 added to it, so a smaller value is not a balance at
-        // all; an unread block reads as zero and used to underflow into 42949671.96 GEL
+        // the stored value carries a +100 offset, so a smaller one underflowed to a card
+        // worth 42949671.96 GEL rather than encoding any balance we can render
         if(stored_value < 100) {
-            FURI_LOG_D(TAG, "Ticket block is empty");
+            FURI_LOG_D(TAG, "Ticket block holds %lu, below the +100 offset", stored_value);
             break;
         }
 

--- a/applications/main/nfc/plugins/supported_cards/metromoney.c
+++ b/applications/main/nfc/plugins/supported_cards/metromoney.c
@@ -148,7 +148,15 @@ static bool metromoney_parse(const NfcDevice* device, FuriString* parsed_data) {
         const uint8_t* block_start_ptr =
             &data->block[start_block_num + ticket_block_number].data[0];
 
-        uint32_t balance = bit_lib_bytes_to_num_le(block_start_ptr, 4) - 100;
+        const uint32_t stored_value = bit_lib_bytes_to_num_le(block_start_ptr, 4);
+        // the balance is stored with 100 added to it, so a smaller value is not a balance at
+        // all; an unread block reads as zero and used to underflow into 42949671.96 GEL
+        if(stored_value < 100) {
+            FURI_LOG_D(TAG, "Ticket block is empty");
+            break;
+        }
+
+        const uint32_t balance = stored_value - 100;
 
         uint32_t balance_lari = balance / 100;
         uint8_t balance_tetri = balance % 100;

--- a/applications/main/nfc/plugins/supported_cards/mf_classic_parser_util.h
+++ b/applications/main/nfc/plugins/supported_cards/mf_classic_parser_util.h
@@ -1,0 +1,30 @@
+/**
+ * @file mf_classic_parser_util.h
+ * @brief Shared helpers for the Mifare Classic supported card parsers.
+ */
+#pragma once
+
+#include <nfc/protocols/mf_classic/mf_classic.h>
+
+/**
+ * @brief Tell whether a block holds data worth rendering.
+ *
+ * Knowing a sector's keys does not mean its blocks were read - the two are tracked by separate
+ * masks - and a block that was never read is left zero-filled. The read mask answers this, except
+ * for dumps saved before the file format recorded one: mf_classic_load() wipes the mask for those
+ * while keeping the bytes. Non-zero content is therefore data as well, which keeps such dumps
+ * parsing. Only a block that was genuinely read may be reported as a zero.
+ *
+ * @param[in] data pointer to the card data.
+ * @param[in] block_num block to test; one the card does not have never holds data.
+ * @returns true if the block may be rendered, false if it must be treated as missing.
+ */
+static inline bool mf_classic_parser_block_has_data(const MfClassicData* data, uint8_t block_num) {
+    if(block_num >= mf_classic_get_total_block_num(data->type)) return false;
+    if(mf_classic_is_block_read(data, block_num)) return true;
+
+    for(size_t i = 0; i < MF_CLASSIC_BLOCK_SIZE; i++) {
+        if(data->block[block_num].data[i] != 0) return true;
+    }
+    return false;
+}

--- a/applications/main/nfc/plugins/supported_cards/nfc_supported_card_plugin.h
+++ b/applications/main/nfc/plugins/supported_cards/nfc_supported_card_plugin.h
@@ -19,8 +19,14 @@
  * @note a card that is not yours is not an error: log the checks that decline a card at
  * FURI_LOG_D, since every plugin of a protocol runs against every card of that protocol.
  *
- * @note for Mifare Classic, guard every block you read with mf_classic_is_block_read().
- * Knowing a sector's keys does not mean its blocks were read - the two are tracked separately.
+ * @note for Mifare Classic, knowing a sector's keys does not mean its blocks were read - the
+ * two are tracked separately, and an unread block is zero-filled. Prefer rejecting a value
+ * that the card cannot hold, which also catches a corrupt block; reach for
+ * mf_classic_parser_block_has_data() when zero is a legal value. Note that
+ * mf_classic_is_block_read() alone reads false for every block of a pre-v2 dump.
+ *
+ * @note parsed_data is empty when parse() is called, so a plugin may build its output before
+ * deciding the card is not its own. Its contents mean nothing unless parse() returns true.
  *
  * @note the APPID field MUST end with `_parser` so the applicaton would know that this particular file
  * is a supported card plugin.

--- a/applications/main/nfc/plugins/supported_cards/plantain.c
+++ b/applications/main/nfc/plugins/supported_cards/plantain.c
@@ -7,6 +7,8 @@
 #include <datetime.h>
 #include <nfc/protocols/mf_classic/mf_classic_poller_sync.h>
 #include <flipper_format/flipper_format.h>
+#include "mf_classic_parser_util.h"
+
 #define TAG "Plantain"
 
 #define PLANTAIN_EPOCH_START      1262304000 //2010-01-01
@@ -19,10 +21,7 @@
 #define SECOND_PPK_TICKET_OFFSET  102
 #define SECOND_TICKET_VALUE_BLOCK 108
 
-// every card type reads its purse balance from this block
-#define PLANTAIN_BALANCE_BLOCK 16
-
-// 4K-only sector whose key B distinguishes the two PPK keysets
+// the sector whose key B tells the two PPK keysets apart; only a 1K card lacks it
 #define PPK_KEYSET_SECTOR 26
 
 typedef struct {
@@ -181,6 +180,12 @@ typedef struct {
     uint8_t ppk_cnt;
 } PPKData;
 
+typedef enum {
+    PlantainPpkKeysUnknown = 0,
+    PlantainPpkKeysAbsent,
+    PlantainPpkKeysInstalled,
+} PlantainPpkKeys;
+
 typedef struct {
     uint64_t card_number;
     FuriString* card_number_str;
@@ -194,8 +199,7 @@ typedef struct {
     uint32_t last_payment_date_data;
     DateTime last_payment_date;
     uint16_t last_payment_amount;
-    uint8_t keyset;
-    bool keyset_known;
+    PlantainPpkKeys ppk_keys;
 
 } PlantainData;
 // Function to map UIC codes to station names
@@ -488,12 +492,10 @@ static void printf_plantain_data(FuriString* parsed_data, PlantainData* purse) {
         purse->last_payment_date.minute,
         purse->last_payment_amount);
 
-    if(!purse->keyset_known)
-        furi_string_cat_printf(parsed_data, "\nPPK keys installed:> Unknown");
-    else if(purse->keyset == 1)
-        furi_string_cat_printf(parsed_data, "\nPPK keys installed:> YES");
-    else
-        furi_string_cat_printf(parsed_data, "\nPPK keys installed:> NO");
+    const char* ppk_keys = (purse->ppk_keys == PlantainPpkKeysInstalled) ? "YES" :
+                           (purse->ppk_keys == PlantainPpkKeysAbsent)    ? "NO" :
+                                                                           "Unknown";
+    furi_string_cat_printf(parsed_data, "\nPPK keys installed:> %s", ppk_keys);
 }
 
 // Function to format and print PPK ticket data
@@ -598,7 +600,7 @@ static void printf_ppk_data(FuriString* parsed_data, PPKData* ticket, bool ticke
     furi_string_cat_printf(
         parsed_data, "SYS N:> %lld\nPPK CNT:> %03d", ticket->sys_n, ticket->ppk_cnt);
 }
-//Function to select a keyset based on card type
+//Function to select the key table based on card type
 static bool plantain_get_card_config(PlantainCardConfig* config, MfClassicType type) {
     bool success = true;
 
@@ -720,17 +722,6 @@ static bool plantain_read(Nfc* nfc, NfcDevice* device) {
     return is_read;
 }
 
-// an unread block is zero-filled, and a dump that does not record what was read leaves the
-// mask empty, so treat any non-zero content as data as well
-static bool plantain_block_has_data(const MfClassicData* data, uint8_t block_num) {
-    if(mf_classic_is_block_read(data, block_num)) return true;
-
-    for(size_t i = 0; i < MF_CLASSIC_BLOCK_SIZE; i++) {
-        if(data->block[block_num].data[i] != 0) return true;
-    }
-    return false;
-}
-
 //Main parsing function
 static bool plantain_parse(const NfcDevice* device, FuriString* parsed_data) {
     furi_assert(device);
@@ -757,21 +748,33 @@ static bool plantain_parse(const NfcDevice* device, FuriString* parsed_data) {
             bit_lib_bytes_to_num_be(sec_tr->key_a.data, COUNT_OF(sec_tr->key_a.data));
         if(key != cfg.keys[cfg.data_sector].a) break;
 
-        // the purse is in sectors 4 and 5, which the key check above does not cover; with
-        // no balance block there is nothing worth showing, and the Sectors Read view says more
-        if(!plantain_block_has_data(data, PLANTAIN_BALANCE_BLOCK)) {
-            FURI_LOG_D(TAG, "Balance block is empty");
+        // the purse spans sectors 4 and 5, which the sector 8 key check does not cover, and
+        // every field below comes from one of these blocks - a zero one renders as an empty
+        // card that was topped up on 01.01.2010, so decline and let Sectors Read explain
+        static const uint8_t purse_blocks[] = {16, 18, 20, 21};
+        bool purse_read = true;
+        for(size_t i = 0; i < COUNT_OF(purse_blocks); i++) {
+            if(mf_classic_parser_block_has_data(data, purse_blocks[i])) continue;
+            FURI_LOG_D(TAG, "Purse block %u is empty", purse_blocks[i]);
+            purse_read = false;
             break;
         }
+        if(!purse_read) break;
 
-        // the first byte of sector 26 key B tells the two keysets apart; that sector exists
-        // only on 4K cards, so anywhere else we simply do not know
-        const MfClassicSectorTrailer* ppk_sec_tr =
-            mf_classic_get_sector_trailer_by_sector(data, PPK_KEYSET_SECTOR);
-        const uint64_t ppk_key_b =
-            bit_lib_bytes_to_num_be(ppk_sec_tr->key_b.data, COUNT_OF(ppk_sec_tr->key_b.data));
-        purse.keyset_known = (data->type == MfClassicType4k) && (ppk_key_b != 0);
-        purse.keyset = (ppk_sec_tr->key_b.data[0] == 0x02) ? 0 : 1;
+        // key B of sector 26 tells the keysets apart: 0x02 leads the legacy key, so no PPK.
+        // a card without that sector cannot carry PPK tickets at all, which is an answer;
+        // having the sector but not its key is not, so that stays Unknown
+        if(mf_classic_get_total_sectors_num(data->type) <= PPK_KEYSET_SECTOR) {
+            purse.ppk_keys = PlantainPpkKeysAbsent;
+        } else {
+            const MfClassicSectorTrailer* ppk_sec_tr =
+                mf_classic_get_sector_trailer_by_sector(data, PPK_KEYSET_SECTOR);
+            if(mf_classic_parser_block_has_data(
+                   data, mf_classic_get_sector_trailer_num_by_sector(PPK_KEYSET_SECTOR))) {
+                purse.ppk_keys = (ppk_sec_tr->key_b.data[0] == 0x02) ? PlantainPpkKeysAbsent :
+                                                                       PlantainPpkKeysInstalled;
+            }
+        }
 
         // Extract plantain purse data and fill PPK tickets markers
         extract_purse_data(

--- a/applications/main/nfc/plugins/supported_cards/plantain.c
+++ b/applications/main/nfc/plugins/supported_cards/plantain.c
@@ -7,6 +7,8 @@
 #include <datetime.h>
 #include <nfc/protocols/mf_classic/mf_classic_poller_sync.h>
 #include <flipper_format/flipper_format.h>
+#define TAG "Plantain"
+
 #define PLANTAIN_EPOCH_START      1262304000 //2010-01-01
 #define PPK_WHOLE_EPOCH_START     946684800 //2000-01-01
 #define PPK_CURRENT_EPOCH_START   1388534400 //2014-01-01
@@ -16,6 +18,12 @@
 #define FIRST_TICKET_VALUE_BLOCK  104
 #define SECOND_PPK_TICKET_OFFSET  102
 #define SECOND_TICKET_VALUE_BLOCK 108
+
+// every card type reads its purse balance from this block
+#define PLANTAIN_BALANCE_BLOCK 16
+
+// 4K-only sector whose key B distinguishes the two PPK keysets
+#define PPK_KEYSET_SECTOR 26
 
 typedef struct {
     uint64_t a;
@@ -187,6 +195,7 @@ typedef struct {
     DateTime last_payment_date;
     uint16_t last_payment_amount;
     uint8_t keyset;
+    bool keyset_known;
 
 } PlantainData;
 // Function to map UIC codes to station names
@@ -479,7 +488,9 @@ static void printf_plantain_data(FuriString* parsed_data, PlantainData* purse) {
         purse->last_payment_date.minute,
         purse->last_payment_amount);
 
-    if(purse->keyset == 1)
+    if(!purse->keyset_known)
+        furi_string_cat_printf(parsed_data, "\nPPK keys installed:> Unknown");
+    else if(purse->keyset == 1)
         furi_string_cat_printf(parsed_data, "\nPPK keys installed:> YES");
     else
         furi_string_cat_printf(parsed_data, "\nPPK keys installed:> NO");
@@ -708,6 +719,18 @@ static bool plantain_read(Nfc* nfc, NfcDevice* device) {
 
     return is_read;
 }
+
+// an unread block is zero-filled, and a dump that does not record what was read leaves the
+// mask empty, so treat any non-zero content as data as well
+static bool plantain_block_has_data(const MfClassicData* data, uint8_t block_num) {
+    if(mf_classic_is_block_read(data, block_num)) return true;
+
+    for(size_t i = 0; i < MF_CLASSIC_BLOCK_SIZE; i++) {
+        if(data->block[block_num].data[i] != 0) return true;
+    }
+    return false;
+}
+
 //Main parsing function
 static bool plantain_parse(const NfcDevice* device, FuriString* parsed_data) {
     furi_assert(device);
@@ -734,10 +757,21 @@ static bool plantain_parse(const NfcDevice* device, FuriString* parsed_data) {
             bit_lib_bytes_to_num_be(sec_tr->key_a.data, COUNT_OF(sec_tr->key_a.data));
         if(key != cfg.keys[cfg.data_sector].a) break;
 
-        if(data->block[107].data[10] == 0x02)
-            purse.keyset = 0;
-        else
-            purse.keyset = 1;
+        // the purse is in sectors 4 and 5, which the key check above does not cover; with
+        // no balance block there is nothing worth showing, and the Sectors Read view says more
+        if(!plantain_block_has_data(data, PLANTAIN_BALANCE_BLOCK)) {
+            FURI_LOG_D(TAG, "Balance block is empty");
+            break;
+        }
+
+        // the first byte of sector 26 key B tells the two keysets apart; that sector exists
+        // only on 4K cards, so anywhere else we simply do not know
+        const MfClassicSectorTrailer* ppk_sec_tr =
+            mf_classic_get_sector_trailer_by_sector(data, PPK_KEYSET_SECTOR);
+        const uint64_t ppk_key_b =
+            bit_lib_bytes_to_num_be(ppk_sec_tr->key_b.data, COUNT_OF(ppk_sec_tr->key_b.data));
+        purse.keyset_known = (data->type == MfClassicType4k) && (ppk_key_b != 0);
+        purse.keyset = (ppk_sec_tr->key_b.data[0] == 0x02) ? 0 : 1;
 
         // Extract plantain purse data and fill PPK tickets markers
         extract_purse_data(

--- a/applications/main/nfc/plugins/supported_cards/social_moscow.c
+++ b/applications/main/nfc/plugins/supported_cards/social_moscow.c
@@ -227,8 +227,9 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
         const uint64_t number =
             bit_lib_bytes_to_num_bcd(&data->block[60].data[1], 9, &is_bcd) * 10 + card_control;
 
-        // an unread block 60 is all zeros, and calculate_luhn(0) is 0, so the check digit
-        // below would accept it; no genuine card carries a zero number
+        // keys alone do not mean the block was read, and calculate_luhn(0) is 0, so an empty
+        // block 60 would pass the check below. test the value rather than the read mask:
+        // mf_classic_load() wipes that mask for pre-v2 dumps which otherwise parse fine
         if(number == 0) {
             FURI_LOG_D(TAG, "Block 60 is empty");
             break;
@@ -262,7 +263,7 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
             card_control);
         // block 21 is in another sector, so it can be missing while 60 is present; say
         // "Unknown" rather than drop the line, as our text replaces the Sectors Read view.
-        // a non-zero value is data either way, which is all a dump without a read mask has
+        // non-zero content is data even where that mask was wiped
         const uint64_t omc_number = bit_lib_get_bits_64(data->block[21].data, 8, 64);
         if(mf_classic_is_block_read(data, 21) || omc_number != 0) {
             furi_string_cat_printf(parsed_data, "OMC: %llx\n", omc_number);

--- a/applications/main/nfc/plugins/supported_cards/social_moscow.c
+++ b/applications/main/nfc/plugins/supported_cards/social_moscow.c
@@ -215,13 +215,6 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
             bit_lib_bytes_to_num_be(sec_tr->key_b.data, COUNT_OF(sec_tr->key_b.data));
         if((key_a != cfg.keys[cfg.data_sector].a) || (key_b != cfg.keys[cfg.data_sector].b)) break;
 
-        // knowing the sector 15 keys does not mean its blocks were read; a zero block 60 would
-        // otherwise satisfy the check digit below, since calculate_luhn(0) is 0
-        if(!mf_classic_is_block_read(data, 60)) {
-            FURI_LOG_D(TAG, "Block 60 was not read");
-            break;
-        }
-
         uint32_t card_code = bit_lib_get_bits_32(data->block[60].data, 8, 24);
         uint8_t card_region = bit_lib_get_bits(data->block[60].data, 32, 8);
         uint64_t card_number = bit_lib_get_bits_64(data->block[60].data, 40, 40);
@@ -233,6 +226,13 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
         bool is_bcd;
         const uint64_t number =
             bit_lib_bytes_to_num_bcd(&data->block[60].data[1], 9, &is_bcd) * 10 + card_control;
+
+        // an unread block 60 is all zeros, and calculate_luhn(0) is 0, so the check digit
+        // below would accept it; no genuine card carries a zero number
+        if(number == 0) {
+            FURI_LOG_D(TAG, "Block 60 is empty");
+            break;
+        }
 
         const uint8_t luhn = calculate_luhn(number);
         if(luhn != card_control) {
@@ -261,9 +261,10 @@ static bool social_moscow_parse(const NfcDevice* device, FuriString* parsed_data
             card_number,
             card_control);
         // block 21 is in another sector, so it can be missing while 60 is present; say
-        // "Unknown" rather than drop the line, as our text replaces the Sectors Read view
-        if(mf_classic_is_block_read(data, 21)) {
-            const uint64_t omc_number = bit_lib_get_bits_64(data->block[21].data, 8, 64);
+        // "Unknown" rather than drop the line, as our text replaces the Sectors Read view.
+        // a non-zero value is data either way, which is all a dump without a read mask has
+        const uint64_t omc_number = bit_lib_get_bits_64(data->block[21].data, 8, 64);
+        if(mf_classic_is_block_read(data, 21) || omc_number != 0) {
             furi_string_cat_printf(parsed_data, "OMC: %llx\n", omc_number);
         } else {
             furi_string_cat(parsed_data, "OMC: Unknown\n");

--- a/applications/main/nfc/plugins/supported_cards/two_cities.c
+++ b/applications/main/nfc/plugins/supported_cards/two_cities.c
@@ -5,6 +5,8 @@
 
 #include <bit_lib.h>
 
+#include "mf_classic_parser_util.h"
+
 #define TAG "TwoCities"
 
 typedef struct {
@@ -121,17 +123,17 @@ static bool two_cities_parse(const NfcDevice* device, FuriString* parsed_data) {
         // PLANTAIN
         // =====
 
-        // Point to block 0 of sector 4, value 0
-        const uint8_t* temp_ptr = data->block[16].data;
-        // Read first 4 bytes of block 0 of sector 4 from last to first and convert them to uint32_t
-        // 38 18 00 00 becomes 00 00 18 38, and equals to 6200 decimal
-        uint32_t balance =
-            ((temp_ptr[3] << 24) | (temp_ptr[2] << 16) | (temp_ptr[1] << 8) | temp_ptr[0]) / 100;
-        // the card number is the UID, which is known even when block 0 was never read
+        // the Plantain balance is little-endian kopeks at the start of block 16
+        const uint32_t balance = bit_lib_bytes_to_num_le(data->block[16].data, 4) / 100;
+
+        // the card number is the UID, so it survives an unread manufacturer block. a card
+        // with a shorter UID is not one we can number, but its purses still read fine
         size_t uid_len = 0;
         const uint8_t* uid = mf_classic_get_uid(data, &uid_len);
-        if(uid_len != 7) break;
-        const uint64_t card_number = bit_lib_bytes_to_num_le(uid, uid_len);
+        const bool uid_is_card_number = (uid_len == 7);
+        const uint64_t card_number = uid_is_card_number ? bit_lib_bytes_to_num_le(uid, uid_len) :
+                                                          0;
+        if(!uid_is_card_number) FURI_LOG_D(TAG, "UID is %u bytes, expected 7", uid_len);
 
         // =====
         // --PLANTAIN--
@@ -149,15 +151,29 @@ static bool two_cities_parse(const NfcDevice* device, FuriString* parsed_data) {
         }
         troika_number >>= 4;
 
-        furi_string_printf(
-            parsed_data, "\e#Troika+Plantain\nPN: %lluX\nPB: %lu rur.\n", card_number, balance);
-        // sector 8 carries the Troika half and is not verified above, so it can be missing;
-        // no genuine Troika card is numbered zero
-        if(troika_number != 0) {
-            furi_string_cat_printf(
-                parsed_data, "TN: %lu\nTB: %u rur.\n", troika_number, troika_balance);
+        furi_string_printf(parsed_data, "\e#Troika+Plantain\n");
+        if(uid_is_card_number) {
+            furi_string_cat_printf(parsed_data, "PN: %lluX\n", card_number);
         } else {
-            furi_string_cat(parsed_data, "TN: Unknown\nTB: Unknown\n");
+            furi_string_cat(parsed_data, "PN: Unknown\n");
+        }
+        // block 16 is in the sector verified above, but a known key does not mean it was read
+        if(mf_classic_parser_block_has_data(data, 16)) {
+            furi_string_cat_printf(parsed_data, "PB: %lu rur.\n", balance);
+        } else {
+            furi_string_cat(parsed_data, "PB: Unknown\n");
+        }
+        // the Troika half is in sector 8, which is never verified here, and its number and
+        // balance sit in different blocks that can go missing on their own
+        if(mf_classic_parser_block_has_data(data, 32)) {
+            furi_string_cat_printf(parsed_data, "TN: %lu\n", troika_number);
+        } else {
+            furi_string_cat(parsed_data, "TN: Unknown\n");
+        }
+        if(mf_classic_parser_block_has_data(data, 33)) {
+            furi_string_cat_printf(parsed_data, "TB: %u rur.\n", troika_balance);
+        } else {
+            furi_string_cat(parsed_data, "TB: Unknown\n");
         }
 
         parsed = true;

--- a/applications/main/nfc/plugins/supported_cards/two_cities.c
+++ b/applications/main/nfc/plugins/supported_cards/two_cities.c
@@ -127,20 +127,11 @@ static bool two_cities_parse(const NfcDevice* device, FuriString* parsed_data) {
         // 38 18 00 00 becomes 00 00 18 38, and equals to 6200 decimal
         uint32_t balance =
             ((temp_ptr[3] << 24) | (temp_ptr[2] << 16) | (temp_ptr[1] << 8) | temp_ptr[0]) / 100;
-        // Read card number
-        // Point to block 0 of sector 0, value 0
-        temp_ptr = data->block[0].data;
-        // Read first 7 bytes of block 0 of sector 0 from last to first and convert them to uint64_t
-        // 04 31 16 8A 23 5C 80 becomes 80 5C 23 8A 16 31 04, and equals to 36130104729284868 decimal
-        uint8_t card_number_arr[7];
-        for(size_t i = 0; i < 7; i++) {
-            card_number_arr[i] = temp_ptr[6 - i];
-        }
-        // Copy card number to uint64_t
-        uint64_t card_number = 0;
-        for(size_t i = 0; i < 7; i++) {
-            card_number = (card_number << 8) | card_number_arr[i];
-        }
+        // the card number is the UID, which is known even when block 0 was never read
+        size_t uid_len = 0;
+        const uint8_t* uid = mf_classic_get_uid(data, &uid_len);
+        if(uid_len != 7) break;
+        const uint64_t card_number = bit_lib_bytes_to_num_le(uid, uid_len);
 
         // =====
         // --PLANTAIN--
@@ -159,12 +150,15 @@ static bool two_cities_parse(const NfcDevice* device, FuriString* parsed_data) {
         troika_number >>= 4;
 
         furi_string_printf(
-            parsed_data,
-            "\e#Troika+Plantain\nPN: %lluX\nPB: %lu rur.\nTN: %lu\nTB: %u rur.\n",
-            card_number,
-            balance,
-            troika_number,
-            troika_balance);
+            parsed_data, "\e#Troika+Plantain\nPN: %lluX\nPB: %lu rur.\n", card_number, balance);
+        // sector 8 carries the Troika half and is not verified above, so it can be missing;
+        // no genuine Troika card is numbered zero
+        if(troika_number != 0) {
+            furi_string_cat_printf(
+                parsed_data, "TN: %lu\nTB: %u rur.\n", troika_number, troika_balance);
+        } else {
+            furi_string_cat(parsed_data, "TN: Unknown\nTB: Unknown\n");
+        }
 
         parsed = true;
     } while(false);


### PR DESCRIPTION
# What's new

Follow-up to #1097, closing #1099 and the highest-exposure part of #1098.

## Parsers rendered data from blocks that were never read

Keys-found and blocks-read are tracked by two independent masks. `mf_classic_set_key_found()` writes the key into the sector trailer and never touches `block_read_mask`, so a sector routinely has both keys known while its data blocks are still zero-filled. Only 3 of 30 Mifare Classic parsers checked.

| Parser | Before | After |
|---|---|---|
| Metromoney | `Balance: 42949671.96 GEL` — the value carries a +100 offset and `0 - 100` underflowed | declines an unread block; declines a value that cannot be a balance |
| Plantain | 0 RUB purse, no trips, *topped up 01.01.2010*; every 1K/2K card claimed `PPK keys installed: YES` | declines unless all four purse blocks are present; `No` where the sector holding those keys does not exist, `Unknown` where its key is missing |
| Two Cities | card numbered zero from an unread block 0; `TN: 0`; `PB: 0 rur.` | number from the UID; **every** field says `Unknown` when its own block is missing |
| Kazan | unknown tariff `valid from 00.00.2000`; `Balance: 0 RUR` from an unverified sector | declines only an unread ticket block; implausible dates and an unread counter read `Unknown` |

## A declining parser leaked its output into the next one

`nfc_supported_cards_parse()` never reset the `FuriString` between plugins, and **20+ parsers open with `furi_string_cat*`** — they have always assumed an empty buffer. One line at the dispatcher, rather than adding a reset to twenty parsers. Closes #1099.

## It also fixes a regression #1097 shipped

**No parser calls `mf_classic_is_key_found()`** — all 30 byte-compare the trailer. `mf_classic_load()` wipes `block_read_mask` and both key masks for any `.nfc` lacking `Data format version: 2` while leaving the bytes, so those dumps still identify their card, but any `mf_classic_is_block_read()` guard fails closed on them. #1097 added two such guards to `social_moscow.c`, so legacy saves and PM3-converted dumps stopped parsing.

**The resulting rule, now written into `nfc_supported_card_plugin.h`** (replacing the note #1097 added, which this PR makes wrong): prefer rejecting a value the card cannot hold — it catches the unread block *and* a corrupt one the mask would wave through — and consult the read state only where zero is a legal value. `mf_classic_parser_block_has_data()` is that check, in a new shared header; it stays out of the mf_classic library on purpose, because the write, save and emulation paths must keep seeing the true mask.

# Verification

Host-side, replicating `mf_classic_load()` + `social_moscow_parse` in both revisions against one real dump and two crafted partial reads:

| dump | before | after |
|---|---|---|
| real card, version 2 | PARSED | PARSED — unchanged |
| real card, **old format** | **DECLINED** ← the #1097 regression | **PARSED** |
| block 60 unread, modern | DECLINED | DECLINED — #1093 still fixed |
| block 21 unread, old format | DECLINED | `PARSED, OMC: Unknown` |

**What that does and does not prove.** It confirms the control-flow flip, and I verified the load path in C independently. It does **not** verify the rendered text, the bit/BCD helpers (re-implemented in the harness — and a mis-handled BCD width in this very parser was the bug in #1092), or any of the other four parsers. Those rest on the table below.

**There is no automated test, and the reason is narrower than "the harness cannot reach plugins".** Every SDK symbol these parsers need is already exported, and a test plugin declared with `requires=["unit_tests"]` would deploy where `test_runner.c` scans — so a harness is buildable, just not in this PR. #1095 tracks it.

`fbt fap_nfc` plus all five parsers build with `APPCHK` clean; `fbt format` and `fbt lint` clean.

## Behaviour changes worth expecting

- **Every 1K and 2K Plantain now reads `PPK keys installed:> No`, not `YES`.** The old test read a byte of a sector those cards do not have, found zero, and answered YES for all of them. This will be reported as a regression; it is the fix.
- A card whose purse or ticket block was never read is now **declined**, falling back to the Keys Found / Sectors Read view — which is more informative than a fabricated zero, since our text replaces that view on success.
- All five rejection paths log at `FURI_LOG_D`. Default runtime level is Info, so **reaching them needs Log Level = Debug**; on a stock device the Sectors Read fallback does all the user-facing work.

## Manual QA

| # | State | Expected |
|---|---|---|
| S1 | Real Social Moscow, unmodified | Parses, number and OMC correct |
| S2 | Same, `Data format version` line deleted | **Parses** (declined before this PR) |
| S3 | Version 2, `Block 60` all `??` | Declined, Sectors Read shown |
| S4 | Version deleted **and** `Block 21` all `??` | Parses, `OMC: Unknown` |
| P1 | Genuine 1K Plantain | `PPK keys installed:> No` (was `YES`) |
| P2 | Genuine 4K Plantain, sector 26 key B known | `YES`/`No` as before |
| P3 | Plantain dump, `Block 20` or `21` all `??` | Declined — no 01.01.2010 purse |
| T1 | Genuine Two Cities | `PN` identical to before — compare digit for digit |
| T2 | Same, `Block 0` all `??` | Parses, **same PN** as T1 |
| T3 | Dump, `Block 16` all `??` | `PB: Unknown`, Troika half intact |
| T4 | Dump, blocks 32-35 all `??` | `TN: Unknown` / `TB: Unknown`, Plantain half intact |
| M1 | Genuine Metromoney | Unchanged |
| M2 | Dump, `Block 5` all `??` | Declined (was `42949671.96 GEL`) |
| M3 | Card at exactly 0.00 GEL (stored value 100) | Parses, `0.00 GEL` — gate boundary |
| K1 | Genuine Kazan with an active ticket | Unchanged |
| K2 | Genuine Kazan **with no ticket loaded** | Parses; dates `Unknown`, card number intact |
| K3 | Dump, `Block 32` all `??` | Declined |
| K4 | Kazan ticket valid **into December** | Parses — the old `month < 12` bound dropped these |
| K5 | Dump, `Block 36` all `??` | `Balance: Unknown`, not `0 RUR` |

Craft a dump by replacing a block's 16 bytes with `??` — byte for byte what the firmware writes for an unread block.

**Not hardware-tested. I have no Metromoney, Kazan, Two Cities or Plantain cards** — P1/P2, T1, M1 and K1/K2 are the rows that most need a real card.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

Written with Claude Code. It traced the two-mask split, found that no parser uses `mf_classic_is_key_found()` and that `mf_classic_load()` wipes the masks for old-format dumps — which identified the #1097 regression and set the content-check-over-mask-guard direction — then wrote every gate, the shared predicate and the header conventions.

A nine-agent review pass then caught four defects in its own first attempt, all fixed here: the changelog commit had **deleted PR #1101's merged entry** after a rebase; the keyset gate assumed sector 26 was 4K-only, which would have broken **2K** cards (a Plus 2K SL1 has 32 sectors); the Plantain and Two Cities gates covered **one block of a multi-block purse**, leaving `01.01.2010` dates and `PB: 0 rur.` in the same report that admitted it did not know a sibling field; and the Kazan and Two Cities gates **declined genuine cards** — one with no ticket loaded, one with a short UID — where degrading the field was correct. It also rejected one review finding with evidence: dropping the OMC read-mask arm was proposed as dead code, but the real sample's block 21 is read and genuinely all-zero, so that would have flipped a real card from `OMC: 0` to `OMC: Unknown`.

# Checklist (For Reviewer) (Don't fill this out!):

- [ ] PR has proper description of new feature/bugfix
- [ ] Description contains actions to verify feature/bugfix on the hardware
- [ ] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
