### PR TITLE
SubGHz: guard transmitter cleanup when unavailable

### DIFF
--- a/applications/main/subghz/helpers/subghz_txrx.c
+++ b/applications/main/subghz/helpers/subghz_txrx.c
@@ -24,6 +24,7 @@ static void subghz_txrx_radio_device_power_off(SubGhzTxRx* instance) {
 
 SubGhzTxRx* subghz_txrx_alloc(void) {
     SubGhzTxRx* instance = malloc(sizeof(SubGhzTxRx));
+    instance->transmitter = NULL;
     instance->setting = subghz_setting_alloc();
     subghz_setting_load(instance->setting, EXT_PATH("subghz/assets/setting_user"));
 
@@ -390,6 +391,7 @@ static void subghz_txrx_tx_stop(SubGhzTxRx* instance) {
     subghz_devices_stop_async_tx(instance->radio_device);
     subghz_transmitter_stop(instance->transmitter);
     subghz_transmitter_free(instance->transmitter);
+    instance->transmitter = NULL;
 
     //if protocol dynamic then we save the last upload
     //but only when we transmitted our own fff_data (bound to file_path)

--- a/applications/main/subghz/helpers/subghz_txrx.c
+++ b/applications/main/subghz/helpers/subghz_txrx.c
@@ -350,7 +350,10 @@ SubGhzTxRxStartTxState subghz_txrx_tx_start(SubGhzTxRx* instance, FlipperFormat*
             ret = SubGhzTxRxStartTxStateErrorParserOthers;
         }
         if(ret != SubGhzTxRxStartTxStateOk) {
-            subghz_transmitter_free(instance->transmitter);
+            if(instance->transmitter) {
+                subghz_transmitter_free(instance->transmitter);
+                instance->transmitter = NULL;
+            }
             if(instance->txrx_state != SubGhzTxRxStateIDLE) {
                 subghz_txrx_idle(instance);
             }


### PR DESCRIPTION
# What's new

An invalid or unsupported `Protocol` value can make `subghz_transmitter_alloc_init()` return `NULL` before a transmitter is allocated. The previous error path passed that value to `subghz_transmitter_free()`, which requires a non-NULL instance. The helper also left the transmitter pointer uninitialized on allocation and stale after normal TX cleanup.

Initialize the pointer, guard error cleanup, and clear it after freeing. Valid transmissions keep the same setup and teardown behavior. The PR is limited to the main SubGHz helper; the unrelated SubGHz Remote submodule change has been removed.

# Verification

- `./fbt format`
- `./fbt lint`
- `FBT_NO_SYNC=1 ./fbt FIRMWARE_APP_SET=unit_tests fap_test_subghz`
- `FBT_NO_SYNC=1 ./fbt COMPACT=1 DEBUG=0 build/f7-firmware-C/firmware.elf build/f7-updater-C/updater.elf`
- Hardware: not tested

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- AI assistance was used to review the transmitter allocation and cleanup lifecycle and to prepare the focused guard and pointer-lifecycle changes. The contributor reviewed the final scope, diff, and validation results.

# Checklist (For Reviewer) (Don't fill this out!):

- [x] PR has proper description of new feature/bugfix
- [x] Description contains actions to verify feature/bugfix on the hardware
- [x] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
