### PR TITLE
SubGHz: fix BinRAW upload buffer bounds

### DIFF
--- a/lib/subghz/blocks/encoder.c
+++ b/lib/subghz/blocks/encoder.c
@@ -40,7 +40,7 @@ size_t subghz_protocol_blocks_get_upload_from_bit_array(
         if(last_bit == subghz_protocol_blocks_get_bit_array(data_array, index_bit)) {
             duration += duration_bit;
         } else {
-            if(size_upload > max_size_upload) {
+            if(size_upload >= max_size_upload) {
                 furi_crash("SubGhz: Encoder buffer overflow");
             }
             upload[size_upload++] = level_duration_make(
@@ -49,6 +49,9 @@ size_t subghz_protocol_blocks_get_upload_from_bit_array(
             duration = duration_bit;
         }
         index_bit++;
+    }
+    if(size_upload >= max_size_upload) {
+        furi_crash("SubGhz: Encoder buffer overflow");
     }
     upload[size_upload++] = level_duration_make(
         subghz_protocol_blocks_get_bit_array(data_array, index_bit - 1), duration);


### PR DESCRIPTION
# What's new

BinRAW upload generation could advance the write index beyond the allocated upload buffer at the capacity boundary. Tighten the bound before appending the next LevelDuration and before the final unconditional write. Normal-size signals are unchanged.

# Verification

- `./fbt format`
- `./fbt lint`
- Firmware and updater compile/link completed with `./fbt COMPACT=1 DEBUG=0 updater_package`; the distribution wrapper then hit the existing workspace-path-with-space issue in `scripts/update.py`
- Hardware: not tested

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

- AI generated the BinRAW upload bound checks and reviewed them against the fixed-size LevelDuration upload buffer and both existing append paths.

# Checklist (For Reviewer) (Don't fill this out!):

- [x] PR has proper description of new feature/bugfix
- [x] Description contains actions to verify feature/bugfix on the hardware
- [x] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
