### PR TITLE
F7: reject invalid serial expansion sentinel

### DIFF
--- a/targets/f7/furi_hal/furi_hal_serial_control.c
+++ b/targets/f7/furi_hal/furi_hal_serial_control.c
@@ -377,7 +377,7 @@ void furi_hal_serial_control_set_expansion_callback(
     FuriHalSerialId serial_id,
     FuriHalSerialControlExpansionCallback callback,
     void* context) {
-    furi_check(serial_id <= FuriHalSerialIdMax);
+    furi_check(serial_id < FuriHalSerialIdMax);
     furi_check(furi_hal_serial_control);
 
     FuriHalSerialControlMessageExpCallback message_input = {


### PR DESCRIPTION
# What's new

The expansion callback setter accepted FuriHalSerialIdMax even though it is the end sentinel, allowing an invalid serial ID into the callback message. Reject the sentinel with a strict upper bound; all valid serial IDs remain accepted.

# Verification

- `./fbt format`
- `./fbt lint`
- Firmware and updater compile/link completed with `./fbt COMPACT=1 DEBUG=0 updater_package`; the distribution wrapper then hit the existing workspace-path-with-space issue in `scripts/update.py`
- Hardware: not tested

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

- AI generated the strict F7 serial-ID guard and reviewed it against the HAL sentinel definition and the surrounding callback API contract.

# Checklist (For Reviewer) (Don't fill this out!):

- [x] PR has proper description of new feature/bugfix
- [x] Description contains actions to verify feature/bugfix on the hardware
- [x] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
