### PR TITLE
HID: stop Mouse Jiggler timers when inactive

### DIFF
--- a/applications/system/hid_app/views/hid_mouse_jiggler.c
+++ b/applications/system/hid_app/views/hid_mouse_jiggler.c
@@ -92,6 +92,8 @@ static void hid_mouse_jiggler_exit_callback(void* context) {
     furi_assert(context);
     HidMouseJiggler* hid_mouse_jiggler = context;
     furi_timer_stop(hid_mouse_jiggler->timer);
+    with_view_model(
+        hid_mouse_jiggler->view, HidMouseJigglerModel * model, { model->running = false; }, false);
 }
 
 static bool hid_mouse_jiggler_input_callback(InputEvent* event, void* context) {
@@ -99,6 +101,12 @@ static bool hid_mouse_jiggler_input_callback(InputEvent* event, void* context) {
     HidMouseJiggler* hid_mouse_jiggler = context;
 
     bool consumed = false;
+    bool timer_start = false;
+    uint32_t timer_period = 0;
+
+    if(event->type == InputTypePress && event->key == InputKeyOk) {
+        furi_timer_stop(hid_mouse_jiggler->timer);
+    }
 
     with_view_model(
         hid_mouse_jiggler->view,
@@ -107,9 +115,9 @@ static bool hid_mouse_jiggler_input_callback(InputEvent* event, void* context) {
             if(event->type == InputTypePress && event->key == InputKeyOk) {
                 model->running = !model->running;
                 if(model->running) {
-                    furi_timer_stop(hid_mouse_jiggler->timer);
-                    furi_timer_start(hid_mouse_jiggler->timer, intervals[model->interval_idx]);
-                };
+                    timer_period = furi_ms_to_ticks(intervals[model->interval_idx]);
+                    timer_start = true;
+                }
                 consumed = true;
             }
             if(event->type == InputTypePress && event->key == InputKeyRight && !model->running &&
@@ -124,6 +132,10 @@ static bool hid_mouse_jiggler_input_callback(InputEvent* event, void* context) {
             }
         },
         true);
+
+    if(timer_start) {
+        furi_timer_start(hid_mouse_jiggler->timer, timer_period);
+    }
 
     return consumed;
 }

--- a/applications/system/hid_app/views/hid_mouse_jiggler_stealth.c
+++ b/applications/system/hid_app/views/hid_mouse_jiggler_stealth.c
@@ -93,6 +93,10 @@ static void hid_mouse_jiggler_stealth_draw_callback(Canvas* canvas, void* contex
 static void hid_mouse_jiggler_stealth_timer_callback(void* context) {
     furi_assert(context);
     HidMouseJigglerStealth* hid_mouse_jiggler = context;
+    uint32_t timer_period = 0;
+    int8_t move_x = 0;
+    int8_t move_y = 0;
+
     with_view_model(
         hid_mouse_jiggler->view,
         HidMouseJigglerStealthModel * model,
@@ -103,24 +107,37 @@ static void hid_mouse_jiggler_stealth_timer_callback(void* context) {
                     model->min_interval + rand() % (model->max_interval - model->min_interval + 1);
 
                 // HID mouse reports use signed 8-bit movement deltas
-                int8_t move_x = (rand() % (2 * INT8_MAX + 1)) - INT8_MAX;
-                int8_t move_y = (rand() % (2 * INT8_MAX + 1)) - INT8_MAX;
-
-                // Perform the mouse move with the randomized values
-                hid_hal_mouse_move(hid_mouse_jiggler->hid, move_x, move_y);
-
-                // Restart timer with the new random interval
-                furi_timer_stop(hid_mouse_jiggler->timer);
-                furi_timer_start(hid_mouse_jiggler->timer, randomIntervalMinutes * 60000);
+                move_x = (rand() % (2 * INT8_MAX + 1)) - INT8_MAX;
+                move_y = (rand() % (2 * INT8_MAX + 1)) - INT8_MAX;
+                timer_period = furi_ms_to_ticks(randomIntervalMinutes * 60000U);
             }
         },
         false);
+
+    if(timer_period == 0) return;
+
+    hid_hal_mouse_move(hid_mouse_jiggler->hid, move_x, move_y);
+
+    bool running = false;
+    with_view_model(
+        hid_mouse_jiggler->view,
+        HidMouseJigglerStealthModel * model,
+        { running = model->running; },
+        false);
+    if(running) {
+        furi_timer_start(hid_mouse_jiggler->timer, timer_period);
+    }
 }
 
 static void hid_mouse_jiggler_stealth_exit_callback(void* context) {
     furi_assert(context);
     HidMouseJigglerStealth* hid_mouse_jiggler = context;
     furi_timer_stop(hid_mouse_jiggler->timer);
+    with_view_model(
+        hid_mouse_jiggler->view,
+        HidMouseJigglerStealthModel * model,
+        { model->running = false; },
+        false);
 }
 
 static bool hid_mouse_jiggler_stealth_input_callback(InputEvent* event, void* context) {
@@ -128,6 +145,12 @@ static bool hid_mouse_jiggler_stealth_input_callback(InputEvent* event, void* co
     HidMouseJigglerStealth* hid_mouse_jiggler = context;
 
     bool consumed = false;
+    bool timer_start = false;
+    uint32_t timer_period = 0;
+
+    if(event->type == InputTypePress && event->key == InputKeyOk) {
+        furi_timer_stop(hid_mouse_jiggler->timer);
+    }
 
     with_view_model(
         hid_mouse_jiggler->view,
@@ -138,11 +161,11 @@ static bool hid_mouse_jiggler_stealth_input_callback(InputEvent* event, void* co
                 case InputKeyOk:
                     model->running = !model->running;
                     if(model->running) {
-                        furi_timer_stop(hid_mouse_jiggler->timer);
                         int randomIntervalMinutes =
                             model->min_interval +
                             rand() % (model->max_interval - model->min_interval + 1);
-                        furi_timer_start(hid_mouse_jiggler->timer, randomIntervalMinutes * 60000);
+                        timer_period = furi_ms_to_ticks(randomIntervalMinutes * 60000U);
+                        timer_start = true;
                     }
                     consumed = true;
                     break;
@@ -182,6 +205,10 @@ static bool hid_mouse_jiggler_stealth_input_callback(InputEvent* event, void* co
         },
         true);
 
+    if(timer_start) {
+        furi_timer_start(hid_mouse_jiggler->timer, timer_period);
+    }
+
     return consumed;
 }
 
@@ -199,7 +226,7 @@ HidMouseJigglerStealth* hid_mouse_jiggler_stealth_alloc(Hid* hid) {
     hid_mouse_jiggler->hid = hid;
 
     hid_mouse_jiggler->timer = furi_timer_alloc(
-        hid_mouse_jiggler_stealth_timer_callback, FuriTimerTypePeriodic, hid_mouse_jiggler);
+        hid_mouse_jiggler_stealth_timer_callback, FuriTimerTypeOnce, hid_mouse_jiggler);
 
     with_view_model(
         hid_mouse_jiggler->view,


### PR DESCRIPTION
# What's new

Mouse Jiggler and Mouse Jiggler Stealth left their timers active after Stop, and leaving the view stopped the timer without clearing the running state. Reopening the view could show the wrong control state, while the regular jiggler continued waking its callback when inactive.

Stop the timer before changing the running state, clear that state on view exit, and keep timer operations outside the view-model lock. Stealth uses a one-shot timer so each random interval is scheduled only while the jiggler is running. Normal movement and interval choices are unchanged.

# Verification

- `./fbt format`
- `./fbt lint`
- `./fbt fap_hid_usb fap_hid_ble`
- `FBT_NO_SYNC=1 ./fbt COMPACT=1 DEBUG=0 build/f7-firmware-C/firmware.elf build/f7-updater-C/updater.elf`
- Hardware: not tested

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

AI assistance was used to review the HID timer lifecycle and prepare the focused patch. The contributor reviewed the final changes and their interaction with the view-model mutex and FuriTimer lifecycle.

# Checklist (For Reviewer) (Don't fill this out!):

- [ ] PR has proper description of new feature/bugfix
- [ ] Description contains actions to verify feature/bugfix on the hardware
- [ ] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
