### PR TITLE
HID: keep stealth Mouse Jiggler movement within HID range

### DIFF
--- a/applications/system/hid_app/views/hid_mouse_jiggler_stealth.c
+++ b/applications/system/hid_app/views/hid_mouse_jiggler_stealth.c
@@ -1,4 +1,5 @@
 #include "hid_mouse_jiggler_stealth.h"
+#include <stdint.h>
 #include <gui/elements.h>
 #include "../hid.h"
 
@@ -101,9 +102,9 @@ static void hid_mouse_jiggler_stealth_timer_callback(void* context) {
                 int randomIntervalMinutes =
                     model->min_interval + rand() % (model->max_interval - model->min_interval + 1);
 
-                // Randomize the mouse movement distance and direction
-                int move_x = (rand() % 2001) - 1000; // Randomly between -1000 and 1000
-                int move_y = (rand() % 2001) - 1000; // Randomly between -1000 and 1000
+                // HID mouse reports use signed 8-bit movement deltas
+                int8_t move_x = (rand() % (2 * INT8_MAX + 1)) - INT8_MAX;
+                int8_t move_y = (rand() % (2 * INT8_MAX + 1)) - INT8_MAX;
 
                 // Perform the mouse move with the randomized values
                 hid_hal_mouse_move(hid_mouse_jiggler->hid, move_x, move_y);


### PR DESCRIPTION
# What's new

Mouse Jiggler Stealth generated movement deltas from -1000 to 1000, but `hid_hal_mouse_move` accepts signed 8-bit deltas and the HID mouse report range is -127 to 127. The values were narrowed before transmission, so the transmitted movement was not the generated movement.

Generate each axis directly within the signed HID range. This removes the out-of-range narrowing while keeping the random movement and one report per interval unchanged.

# Verification

- `./fbt format`
- `./fbt lint`
- `./fbt fap_hid_usb fap_hid_ble`
- `FBT_NO_SYNC=1 ./fbt COMPACT=1 DEBUG=0 build/f7-firmware-C/firmware.elf build/f7-updater-C/updater.elf`
- Hardware: not tested

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

AI assistance was used to review the HID report limits and prepare the focused range fix. The contributor reviewed the final changes against the USB and BLE HID interfaces.

# Checklist (For Reviewer) (Don't fill this out!):

- [x] PR has proper description of new feature/bugfix
- [x] Description contains actions to verify feature/bugfix on the hardware
- [x] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
