### PR TITLE
NFC: keep the CUID dictionary pass end marker out of the sector counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - NFC: FeliCa - a saved dump claiming more blocks than the card can hold is now rejected on load, instead of being read past the end of the block array (by @MNeroba | PR #1106)
 - HID: Mouse Jiggler (Stealth) - movement is now generated within the signed 8-bit range that HID mouse reports carry, instead of a +-1000 value that was truncated before it was sent (by @MNeroba | PR #1111)
 - Expansion: Fixed an off-by-one that accepted FuriHalSerialIdMax itself as a serial id when setting an expansion module callback (by @MNeroba | PR #1108)
+- NFC: stop the CUID dictionary pass ending one key index early
+- NFC: keep the CUID dictionary pass end marker out of the sector counter (by @mishamyte | PR #1115 | Fixes #1114)
 <br><br>
 
 ----

--- a/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic_extra_scenes.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic_extra_scenes.c
@@ -155,15 +155,16 @@ static NfcCommand nfc_dict_attack_worker_callback(NfcGenericEvent event, void* c
         keys_dict_rewind(instance->nfc_dict_context.dict);
         instance->nfc_dict_context.dict_keys_current = 0;
 
-        // In CUID mode, increment the key index and calculate sector from it
         if(is_cuid_dict) {
             instance->nfc_dict_context.current_key_idx++;
             // Calculate sector from key_idx (each sector has 2 keys: A and B)
-            instance->nfc_dict_context.current_sector =
-                instance->nfc_dict_context.current_key_idx / 2;
-            // Write back to event data so poller can read it
-            mfc_event->data->next_sector_data.current_sector =
-                instance->nfc_dict_context.current_sector;
+            uint8_t next_sector = instance->nfc_dict_context.current_key_idx / 2;
+            // The poller adopts this as its cursor and ends the pass one past the last sector,
+            // so that marker is for it, not for the view.
+            mfc_event->data->next_sector_data.current_sector = next_sector;
+            if(next_sector < instance->nfc_dict_context.sectors_total) {
+                instance->nfc_dict_context.current_sector = next_sector;
+            }
         } else {
             instance->nfc_dict_context.current_sector =
                 mfc_event->data->next_sector_data.current_sector;
@@ -349,6 +350,8 @@ static void mf_classic_scene_dict_attack_prepare_view(NfcApp* instance) {
     dict_attack_set_total_dict_keys(
         instance->dict_attack, instance->nfc_dict_context.dict_keys_total);
     instance->nfc_dict_context.dict_keys_current = 0;
+    // A phase reports no sector until it has cleared its first one, else the last one lingers.
+    instance->nfc_dict_context.current_sector = 0;
 
     dict_attack_set_callback(
         instance->dict_attack, nfc_dict_attack_dict_attack_result_callback, instance);


### PR DESCRIPTION
# What's new

Fixes #1114 - the follow-up to be559b2ee, which was correct but had one side effect on the view.

That commit moved the `NextSector` callback ahead of the end-of-pass check so the app's key index could reach the last one (previously the last sector's key B was never requested). As a result the final callback now fires with `current_key_idx == 2 * sectors_total`, and the app stored that value in two places: the event, where the poller needs it as the "pass is over" marker, and `nfc_dict_context.current_sector`, which only feeds the view. So the CUID pass ended on `Unlocking sector: 16` on a 1K (`40` on a 4K), and because nothing resets the counter between dictionary phases, that number stayed on screen through the opening of the user-dictionary phase - until its first key was found, which is its slowest stretch.

- `nfc_dict_attack_worker_callback()`: the marker goes to the event unconditionally; the display cursor is updated only while the value is a real sector.
- `mf_classic_scene_dict_attack_prepare_view()`: reset the counter next to the existing per-phase reset (`dict_keys_current`), immediately above the repaint that ends the function. All five phase entries funnel through it, and each phase's poller restarts at sector 0, so the CUID phase's last sector no longer carries over either. It has to sit ahead of that repaint - resetting when the poller starts is too late, because `prepare_view()` has already painted the stale value under the new phase's header, and nothing repaints again until the new poller's first `RequestMode`, which needs the card back on the antenna.

The poller's own cursor is untouched - it is correct as be559b2ee left it.

Also adds the two missing CHANGELOG lines: one for be559b2ee, which went in without an entry, and one for this fix. Both are under "Other changes" - happy to promote the CUID key-skip one to "Main changes" if you consider it headline material.

# Verification

Needs a per-UID dictionary at `nfc/assets/mf_classic_dict_<uid>.nfc` for a Mifare Classic card (any MFKey-recovered one works).

1. Read the card - the `MF Classic CUID Dictionary` phase runs first.
2. Watch the second line as that phase ends: before, it showed `Unlocking sector: 16` on a 1K and kept showing it after the header flipped to the user dictionary; now it stays on the last real sector and restarts from `0` with the next phase.
3. Worth checking with the card lifted at the phase boundary, which is where the stale value used to persist indefinitely.
4. The pass itself must behave exactly as before: same keys found, same sectors read, and the last sector's key B still tried (the be559b2ee fix).

Built (`fbt fap_nfc`, APPCHK clean) and `scripts/lint.py` clean. Not verified on hardware yet.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Claude Code was used to trace the CUID dictionary state machine across the poller and the app while reviewing be559b2ee, and it wrote the two hunks in `mf_classic_extra_scenes.c` and the CHANGELOG lines to my direction. Both hunks are app-side and display-only: one keeps the one-past-the-last-sector marker out of `nfc_dict_context.current_sector` (it still goes to the event, which is what ends the pass), the other zeroes that counter in `mf_classic_scene_dict_attack_prepare_view()` so each dictionary phase starts where its poller does. Reviewed and built by me.

# Checklist (For Reviewer) (Don't fill this out!):

- [ ] PR has proper description of new feature/bugfix
- [ ] Description contains actions to verify feature/bugfix on the hardware
- [ ] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
