### PR TITLE
SubGHz + Storage: share more duplicated bodies (-4,892 B of flash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## Other changes
 - SubGHz: Fixed a one-past-the-end write when building a transmission (just in case) - the final level duration was stored without a bounds check (by @MNeroba | PR #1105)
 - SubGHz: The free/stop/yield/reset/hash/serialize handlers that were byte-identical across 57 protocols now share one implementation instead of 346 copies, freeing ~6 KB of flash (thanks @apfxtech !)
+- SubGHz & Storage: A further ~4.8 KB of flash freed - the alloc, deserialize and remaining serialize bodies still duplicated across SubGHz protocols, and the twelve Storage API calls that differed only in the command they send, now share one implementation each (by @mishamyte | PR #1116)
 - NFC: FeliCa - a saved dump claiming more blocks than the card can hold is now rejected on load, instead of being read past the end of the block array (by @MNeroba | PR #1106)
 - HID: Mouse Jiggler (Stealth) - movement is now generated within the signed 8-bit range that HID mouse reports carry, instead of a +-1000 value that was truncated before it was sent (by @MNeroba | PR #1111)
 - Expansion: Fixed an off-by-one that accepted FuriHalSerialIdMax itself as a serial id when setting an expansion module callback (by @MNeroba | PR #1108)

--- a/applications/services/storage/storage_external_api.c
+++ b/applications/services/storage/storage_external_api.c
@@ -50,6 +50,53 @@
 typedef enum {
     StorageEventFlagFileClose = (1 << 0),
 } StorageEventFlag;
+
+/****************** SHARED DISPATCH ******************/
+
+// These four carry the whole body of a dozen API calls that differ only in the command.
+
+static bool storage_file_command_bool(File* file, StorageCommand command) {
+    S_FILE_API_PROLOGUE;
+    S_API_PROLOGUE;
+    S_API_DATA_FILE;
+    S_API_MESSAGE(command);
+    S_API_EPILOGUE;
+    return S_RETURN_BOOL;
+}
+
+static uint64_t storage_file_command_uint64(File* file, StorageCommand command) {
+    S_FILE_API_PROLOGUE;
+    S_API_PROLOGUE;
+    S_API_DATA_FILE;
+    S_API_MESSAGE(command);
+    S_API_EPILOGUE;
+    return S_RETURN_UINT64;
+}
+
+static FS_Error storage_path_command(Storage* storage, const char* path, StorageCommand command) {
+    furi_check(storage);
+
+    S_API_PROLOGUE;
+    SAData data = {
+        .path = {
+            .path = path,
+            .thread_id = furi_thread_get_current_id(),
+        }};
+    S_API_MESSAGE(command);
+    S_API_EPILOGUE;
+    return S_RETURN_ERROR;
+}
+
+static FS_Error storage_sd_command(Storage* storage, StorageCommand command) {
+    furi_check(storage);
+
+    S_API_PROLOGUE;
+    SAData data = {};
+    S_API_MESSAGE(command);
+    S_API_EPILOGUE;
+    return S_RETURN_ERROR;
+}
+
 /****************** FILE ******************/
 
 static bool storage_file_open_internal(
@@ -236,48 +283,23 @@ bool storage_file_seek(File* file, uint32_t offset, bool from_start) {
 }
 
 uint64_t storage_file_tell(File* file) {
-    S_FILE_API_PROLOGUE;
-    S_API_PROLOGUE;
-    S_API_DATA_FILE;
-    S_API_MESSAGE(StorageCommandFileTell);
-    S_API_EPILOGUE;
-    return S_RETURN_UINT64;
+    return storage_file_command_uint64(file, StorageCommandFileTell);
 }
 
 bool storage_file_truncate(File* file) {
-    S_FILE_API_PROLOGUE;
-    S_API_PROLOGUE;
-    S_API_DATA_FILE;
-    S_API_MESSAGE(StorageCommandFileTruncate);
-    S_API_EPILOGUE;
-    return S_RETURN_BOOL;
+    return storage_file_command_bool(file, StorageCommandFileTruncate);
 }
 
 uint64_t storage_file_size(File* file) {
-    S_FILE_API_PROLOGUE;
-    S_API_PROLOGUE;
-    S_API_DATA_FILE;
-    S_API_MESSAGE(StorageCommandFileSize);
-    S_API_EPILOGUE;
-    return S_RETURN_UINT64;
+    return storage_file_command_uint64(file, StorageCommandFileSize);
 }
 
 bool storage_file_sync(File* file) {
-    S_FILE_API_PROLOGUE;
-    S_API_PROLOGUE;
-    S_API_DATA_FILE;
-    S_API_MESSAGE(StorageCommandFileSync);
-    S_API_EPILOGUE;
-    return S_RETURN_BOOL;
+    return storage_file_command_bool(file, StorageCommandFileSync);
 }
 
 bool storage_file_eof(File* file) {
-    S_FILE_API_PROLOGUE;
-    S_API_PROLOGUE;
-    S_API_DATA_FILE;
-    S_API_MESSAGE(StorageCommandFileEof);
-    S_API_EPILOGUE;
-    return S_RETURN_BOOL;
+    return storage_file_command_bool(file, StorageCommandFileEof);
 }
 
 bool storage_file_exists(Storage* storage, const char* path) {
@@ -405,12 +427,7 @@ bool storage_dir_read(File* file, FileInfo* fileinfo, char* name, uint16_t name_
 }
 
 bool storage_dir_rewind(File* file) {
-    S_FILE_API_PROLOGUE;
-    S_API_PROLOGUE;
-    S_API_DATA_FILE;
-    S_API_MESSAGE(StorageCommandDirRewind);
-    S_API_EPILOGUE;
-    return S_RETURN_BOOL;
+    return storage_file_command_bool(file, StorageCommandDirRewind);
 }
 
 bool storage_dir_exists(Storage* storage, const char* path) {
@@ -461,18 +478,7 @@ FS_Error storage_common_stat(Storage* storage, const char* path, FileInfo* filei
 }
 
 FS_Error storage_common_remove(Storage* storage, const char* path) {
-    furi_check(storage);
-
-    S_API_PROLOGUE;
-    SAData data = {
-        .path = {
-            .path = path,
-            .thread_id = furi_thread_get_current_id(),
-        }};
-
-    S_API_MESSAGE(StorageCommandCommonRemove);
-    S_API_EPILOGUE;
-    return S_RETURN_ERROR;
+    return storage_path_command(storage, path, StorageCommandCommonRemove);
 }
 
 FS_Error storage_common_rename(Storage* storage, const char* old_path, const char* new_path) {
@@ -742,18 +748,7 @@ FS_Error storage_common_merge(Storage* storage, const char* old_path, const char
 }
 
 FS_Error storage_common_mkdir(Storage* storage, const char* path) {
-    furi_check(storage);
-
-    S_API_PROLOGUE;
-    SAData data = {
-        .path = {
-            .path = path,
-            .thread_id = furi_thread_get_current_id(),
-        }};
-
-    S_API_MESSAGE(StorageCommandCommonMkDir);
-    S_API_EPILOGUE;
-    return S_RETURN_ERROR;
+    return storage_path_command(storage, path, StorageCommandCommonMkDir);
 }
 
 FS_Error storage_common_fs_info(
@@ -871,33 +866,15 @@ const char* storage_file_get_error_desc(File* file) {
 /****************** Raw SD API ******************/
 
 FS_Error storage_sd_format(Storage* storage) {
-    furi_check(storage);
-
-    S_API_PROLOGUE;
-    SAData data = {};
-    S_API_MESSAGE(StorageCommandSDFormat);
-    S_API_EPILOGUE;
-    return S_RETURN_ERROR;
+    return storage_sd_command(storage, StorageCommandSDFormat);
 }
 
 FS_Error storage_sd_unmount(Storage* storage) {
-    furi_check(storage);
-
-    S_API_PROLOGUE;
-    SAData data = {};
-    S_API_MESSAGE(StorageCommandSDUnmount);
-    S_API_EPILOGUE;
-    return S_RETURN_ERROR;
+    return storage_sd_command(storage, StorageCommandSDUnmount);
 }
 
 FS_Error storage_sd_mount(Storage* storage) {
-    furi_check(storage);
-
-    S_API_PROLOGUE;
-    SAData data = {};
-    S_API_MESSAGE(StorageCommandSDMount);
-    S_API_EPILOGUE;
-    return S_RETURN_ERROR;
+    return storage_sd_command(storage, StorageCommandSDMount);
 }
 
 FS_Error storage_sd_info(Storage* storage, SDInfo* info) {
@@ -914,13 +891,7 @@ FS_Error storage_sd_info(Storage* storage, SDInfo* info) {
 }
 
 FS_Error storage_sd_status(Storage* storage) {
-    furi_check(storage);
-
-    S_API_PROLOGUE;
-    SAData data = {};
-    S_API_MESSAGE(StorageCommandSDStatus);
-    S_API_EPILOGUE;
-    return S_RETURN_ERROR;
+    return storage_sd_command(storage, StorageCommandSDStatus);
 }
 
 File* storage_file_alloc(Storage* storage) {

--- a/lib/subghz/protocols/allstar_firefly.c
+++ b/lib/subghz/protocols/allstar_firefly.c
@@ -59,6 +59,7 @@ struct SubGhzProtocolDecoderAllstarFirefly {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderAllstarFirefly);
 
 struct SubGhzProtocolEncoderAllstarFirefly {
     SubGhzProtocolEncoderBase base;
@@ -66,6 +67,7 @@ struct SubGhzProtocolEncoderAllstarFirefly {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderAllstarFirefly);
 
 typedef enum {
     AllstarFireflyDecoderStepReset = 0,
@@ -107,17 +109,8 @@ const SubGhzProtocol subghz_protocol_allstar_firefly = {
 
 void* subghz_protocol_encoder_allstar_firefly_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderAllstarFirefly* instance =
-        malloc(sizeof(SubGhzProtocolEncoderAllstarFirefly));
-
-    instance->base.protocol = &subghz_protocol_allstar_firefly;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 5;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderAllstarFirefly), &subghz_protocol_allstar_firefly, 5, 256);
 }
 
 /**
@@ -189,11 +182,8 @@ SubGhzProtocolStatus subghz_protocol_encoder_allstar_firefly_deserialize(
 
 void* subghz_protocol_decoder_allstar_firefly_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderAllstarFirefly* instance =
-        malloc(sizeof(SubGhzProtocolDecoderAllstarFirefly));
-    instance->base.protocol = &subghz_protocol_allstar_firefly;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderAllstarFirefly), &subghz_protocol_allstar_firefly);
 }
 
 void subghz_protocol_decoder_allstar_firefly_feed(

--- a/lib/subghz/protocols/allstar_firefly.c
+++ b/lib/subghz/protocols/allstar_firefly.c
@@ -115,10 +115,12 @@ void* subghz_protocol_encoder_allstar_firefly_alloc(SubGhzEnvironment* environme
 
 /**
  * Generating an upload from data.
- * @param instance Pointer to a SubGhzProtocolEncoderAllstarFirefly instance
+ * @param context Pointer to a SubGhzProtocolEncoderAllstarFirefly instance
+ * @return true Always; this encoder has no failure path
  */
-static void subghz_protocol_encoder_allstar_firefly_get_upload(
-    SubGhzProtocolEncoderAllstarFirefly* instance) {
+static bool subghz_protocol_encoder_allstar_firefly_get_upload(void* context) {
+    SubGhzProtocolEncoderAllstarFirefly* instance = context;
+
     furi_assert(instance);
     size_t index = 0;
 
@@ -152,32 +154,17 @@ static void subghz_protocol_encoder_allstar_firefly_get_upload(
     }
 
     instance->encoder.size_upload = index;
-    return;
+    return true;
 }
 
 SubGhzProtocolStatus subghz_protocol_encoder_allstar_firefly_deserialize(
     void* context,
     FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderAllstarFirefly* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_allstar_firefly_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        subghz_protocol_encoder_allstar_firefly_get_upload(instance);
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_allstar_firefly_const.min_count_bit_for_found,
+        subghz_protocol_encoder_allstar_firefly_get_upload);
 }
 
 void* subghz_protocol_decoder_allstar_firefly_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/alutech_at_4n.c
+++ b/lib/subghz/protocols/alutech_at_4n.c
@@ -34,6 +34,7 @@ struct SubGhzProtocolDecoderAlutech_at_4n {
 
     const char* alutech_at_4n_rainbow_table_file_name;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderAlutech_at_4n);
 
 struct SubGhzProtocolEncoderAlutech_at_4n {
     SubGhzProtocolEncoderBase base;
@@ -43,6 +44,7 @@ struct SubGhzProtocolEncoderAlutech_at_4n {
     const char* alutech_at_4n_rainbow_table_file_name;
     uint32_t crc;
 };
+SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderAlutech_at_4n);
 
 typedef enum {
     Alutech_at_4nDecoderStepReset = 0,

--- a/lib/subghz/protocols/alutech_at_4n.c
+++ b/lib/subghz/protocols/alutech_at_4n.c
@@ -44,7 +44,7 @@ struct SubGhzProtocolEncoderAlutech_at_4n {
     const char* alutech_at_4n_rainbow_table_file_name;
     uint32_t crc;
 };
-SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderAlutech_at_4n);
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderAlutech_at_4n);
 
 typedef enum {
     Alutech_at_4nDecoderStepReset = 0,
@@ -93,25 +93,14 @@ static void subghz_protocol_alutech_at_4n_remote_controller(
     const char* file_name);
 
 void* subghz_protocol_encoder_alutech_at_4n_alloc(SubGhzEnvironment* environment) {
-    UNUSED(environment);
-    SubGhzProtocolEncoderAlutech_at_4n* instance =
-        malloc(sizeof(SubGhzProtocolEncoderAlutech_at_4n));
-
-    instance->base.protocol = &subghz_protocol_alutech_at_4n;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 512;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-
+    SubGhzProtocolEncoderAlutech_at_4n* instance = subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderAlutech_at_4n), &subghz_protocol_alutech_at_4n, 3, 512);
     instance->alutech_at_4n_rainbow_table_file_name =
         subghz_environment_get_alutech_at_4n_rainbow_table_file_name(environment);
     if(instance->alutech_at_4n_rainbow_table_file_name) {
         FURI_LOG_I(
             TAG, "Loading rainbow table from %s", instance->alutech_at_4n_rainbow_table_file_name);
     }
-
     return instance;
 }
 
@@ -366,7 +355,7 @@ static uint8_t subghz_protocol_alutech_at_4n_get_btn_code(void);
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderAlutech instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_alutech_at_4n_get_upload(
     SubGhzProtocolEncoderAlutech_at_4n* instance,
@@ -519,10 +508,8 @@ SubGhzProtocolStatus subghz_protocol_encoder_alutech_at_4n_deserialize(
 }
 
 void* subghz_protocol_decoder_alutech_at_4n_alloc(SubGhzEnvironment* environment) {
-    SubGhzProtocolDecoderAlutech_at_4n* instance =
-        malloc(sizeof(SubGhzProtocolDecoderAlutech_at_4n));
-    instance->base.protocol = &subghz_protocol_alutech_at_4n;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolDecoderAlutech_at_4n* instance = subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderAlutech_at_4n), &subghz_protocol_alutech_at_4n);
     instance->alutech_at_4n_rainbow_table_file_name =
         subghz_environment_get_alutech_at_4n_rainbow_table_file_name(environment);
     if(instance->alutech_at_4n_rainbow_table_file_name) {

--- a/lib/subghz/protocols/ansonic.c
+++ b/lib/subghz/protocols/ansonic.c
@@ -87,7 +87,7 @@ void* subghz_protocol_encoder_ansonic_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderAnsonic instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_ansonic_get_upload(SubGhzProtocolEncoderAnsonic* instance) {
     furi_assert(instance);

--- a/lib/subghz/protocols/ansonic.c
+++ b/lib/subghz/protocols/ansonic.c
@@ -28,6 +28,7 @@ struct SubGhzProtocolDecoderAnsonic {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderAnsonic);
 
 struct SubGhzProtocolEncoderAnsonic {
     SubGhzProtocolEncoderBase base;
@@ -35,6 +36,7 @@ struct SubGhzProtocolEncoderAnsonic {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderAnsonic);
 
 typedef enum {
     AnsonicDecoderStepReset = 0,
@@ -78,16 +80,8 @@ const SubGhzProtocol subghz_protocol_ansonic = {
 
 void* subghz_protocol_encoder_ansonic_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderAnsonic* instance = malloc(sizeof(SubGhzProtocolEncoderAnsonic));
-
-    instance->base.protocol = &subghz_protocol_ansonic;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 52;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderAnsonic), &subghz_protocol_ansonic, 3, 52);
 }
 
 /**
@@ -160,10 +154,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_ansonic_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderAnsonic* instance = malloc(sizeof(SubGhzProtocolDecoderAnsonic));
-    instance->base.protocol = &subghz_protocol_ansonic;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderAnsonic), &subghz_protocol_ansonic);
 }
 
 void subghz_protocol_decoder_ansonic_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/beninca_arc.c
+++ b/lib/subghz/protocols/beninca_arc.c
@@ -37,6 +37,7 @@ struct SubGhzProtocolDecoderBenincaARC {
 
     SubGhzKeystore* keystore;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderBenincaARC);
 
 struct SubGhzProtocolEncoderBenincaARC {
     SubGhzProtocolEncoderBase base;
@@ -46,6 +47,7 @@ struct SubGhzProtocolEncoderBenincaARC {
 
     SubGhzKeystore* keystore;
 };
+SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderBenincaARC);
 
 const SubGhzProtocolDecoder subghz_protocol_beninca_arc_decoder = {
     .alloc = subghz_protocol_decoder_beninca_arc_alloc,
@@ -55,7 +57,7 @@ const SubGhzProtocolDecoder subghz_protocol_beninca_arc_decoder = {
     .reset = subghz_protocol_decoder_common_reset,
 
     .get_hash_data = subghz_protocol_decoder_common_get_hash_data,
-    .serialize = subghz_protocol_decoder_beninca_arc_serialize,
+    .serialize = subghz_protocol_decoder_common_serialize_data_2,
     .deserialize = subghz_protocol_decoder_beninca_arc_deserialize,
     .get_string = subghz_protocol_decoder_beninca_arc_get_string,
 };
@@ -65,8 +67,8 @@ const SubGhzProtocolEncoder subghz_protocol_beninca_arc_encoder = {
     .free = subghz_protocol_encoder_common_free,
 
     .deserialize = subghz_protocol_encoder_beninca_arc_deserialize,
-    .stop = subghz_protocol_encoder_beninca_arc_stop,
-    .yield = subghz_protocol_encoder_beninca_arc_yield,
+    .stop = subghz_protocol_encoder_common_stop,
+    .yield = subghz_protocol_encoder_common_yield,
 };
 
 const SubGhzProtocol subghz_protocol_beninca_arc = {
@@ -265,12 +267,6 @@ void* subghz_protocol_encoder_beninca_arc_alloc(SubGhzEnvironment* environment) 
     return instance;
 }
 
-void subghz_protocol_encoder_beninca_arc_stop(void* context) {
-    furi_assert(context);
-    SubGhzProtocolEncoderBenincaARC* instance = context;
-    instance->encoder.is_running = false;
-}
-
 static void subghz_protocol_beninca_arc_encoder_get_upload(
     SubGhzProtocolEncoderBenincaARC* instance,
     size_t* index) {
@@ -380,21 +376,7 @@ bool subghz_protocol_beninca_arc_create_data(
     SubGhzProtocolStatus res =
         subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
 
-    uint8_t key_data[sizeof(uint64_t)] = {0};
-    for(size_t i = 0; i < sizeof(uint64_t); i++) {
-        key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data_2 >> (i * 8)) & 0xFF;
-    }
-
-    if(!flipper_format_rewind(flipper_format)) {
-        FURI_LOG_E(TAG, "Rewind error");
-        res = SubGhzProtocolStatusErrorParserOthers;
-    }
-
-    if((res == SubGhzProtocolStatusOk) &&
-       !flipper_format_insert_or_update_hex(flipper_format, "Data", key_data, sizeof(uint64_t))) {
-        FURI_LOG_E(TAG, "Unable to add Data2");
-        res = SubGhzProtocolStatusErrorParserOthers;
-    }
+    res = subghz_protocol_common_append_data_2(res, &instance->generic, flipper_format);
 
     return res == SubGhzProtocolStatusOk;
 }
@@ -462,25 +444,6 @@ SubGhzProtocolStatus
     } while(false);
 
     return res;
-}
-
-LevelDuration subghz_protocol_encoder_beninca_arc_yield(void* context) {
-    furi_assert(context);
-    SubGhzProtocolEncoderBenincaARC* instance = context;
-
-    if(instance->encoder.repeat == 0 || !instance->encoder.is_running) {
-        instance->encoder.is_running = false;
-        return level_duration_reset();
-    }
-
-    LevelDuration ret = instance->encoder.upload[instance->encoder.front];
-
-    if(++instance->encoder.front == instance->encoder.size_upload) {
-        if(!subghz_block_generic_global.endless_tx) instance->encoder.repeat--;
-        instance->encoder.front = 0;
-    }
-
-    return ret;
 }
 
 void* subghz_protocol_decoder_beninca_arc_alloc(SubGhzEnvironment* environment) {
@@ -565,33 +528,6 @@ void subghz_protocol_decoder_beninca_arc_feed(void* context, bool level, uint32_
             break;
         }
     }
-}
-
-SubGhzProtocolStatus subghz_protocol_decoder_beninca_arc_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset) {
-    furi_assert(context);
-    SubGhzProtocolDecoderBenincaARC* instance = context;
-    SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
-
-    uint8_t key_data[sizeof(uint64_t)] = {0};
-    for(size_t i = 0; i < sizeof(uint64_t); i++) {
-        key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data_2 >> (i * 8)) & 0xFF;
-    }
-
-    if(!flipper_format_rewind(flipper_format)) {
-        FURI_LOG_E(TAG, "Rewind error");
-        ret = SubGhzProtocolStatusErrorParserOthers;
-    }
-
-    if((ret == SubGhzProtocolStatusOk) &&
-       !flipper_format_insert_or_update_hex(flipper_format, "Data", key_data, sizeof(uint64_t))) {
-        FURI_LOG_E(TAG, "Unable to add Data");
-        ret = SubGhzProtocolStatusErrorParserOthers;
-    }
-    return ret;
 }
 
 SubGhzProtocolStatus

--- a/lib/subghz/protocols/beninca_arc.c
+++ b/lib/subghz/protocols/beninca_arc.c
@@ -47,7 +47,7 @@ struct SubGhzProtocolEncoderBenincaARC {
 
     SubGhzKeystore* keystore;
 };
-SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderBenincaARC);
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderBenincaARC);
 
 const SubGhzProtocolDecoder subghz_protocol_beninca_arc_decoder = {
     .alloc = subghz_protocol_decoder_beninca_arc_alloc,
@@ -253,17 +253,9 @@ static void subghz_protocol_beninca_arc_encrypt(
 }
 
 void* subghz_protocol_encoder_beninca_arc_alloc(SubGhzEnvironment* environment) {
-    SubGhzProtocolEncoderBenincaARC* instance = malloc(sizeof(SubGhzProtocolEncoderBenincaARC));
-
-    instance->base.protocol = &subghz_protocol_beninca_arc;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolEncoderBenincaARC* instance = subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderBenincaARC), &subghz_protocol_beninca_arc, 1, 800);
     instance->keystore = subghz_environment_get_keystore(environment);
-
-    instance->encoder.repeat = 1;
-    instance->encoder.size_upload = 800;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-
     return instance;
 }
 
@@ -447,9 +439,8 @@ SubGhzProtocolStatus
 }
 
 void* subghz_protocol_decoder_beninca_arc_alloc(SubGhzEnvironment* environment) {
-    SubGhzProtocolDecoderBenincaARC* instance = malloc(sizeof(SubGhzProtocolDecoderBenincaARC));
-    instance->base.protocol = &subghz_protocol_beninca_arc;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolDecoderBenincaARC* instance = subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderBenincaARC), &subghz_protocol_beninca_arc);
     instance->keystore = subghz_environment_get_keystore(environment);
     instance->decoder.parser_step = BenincaARCDecoderStart;
     return instance;

--- a/lib/subghz/protocols/beninca_arc.h
+++ b/lib/subghz/protocols/beninca_arc.h
@@ -27,19 +27,6 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_beninca_arc_deserialize(void* context, FlipperFormat* flipper_format);
 
 /**
- * Forced transmission stop.
- * @param context Pointer to a SubGhzProtocolEncoderBenincaARC instance
- */
-void subghz_protocol_encoder_beninca_arc_stop(void* context);
-
-/**
- * Getting the level and duration of the upload to be loaded into DMA.
- * @param context Pointer to a SubGhzProtocolEncoderBenincaARC instance
- * @return LevelDuration 
- */
-LevelDuration subghz_protocol_encoder_beninca_arc_yield(void* context);
-
-/**
  * Allocate SubGhzProtocolDecoderBenincaARC.
  * @param environment Pointer to a SubGhzEnvironment instance
  * @return SubGhzProtocolDecoderBenincaARC* pointer to a SubGhzProtocolDecoderBenincaARC instance
@@ -53,18 +40,6 @@ void* subghz_protocol_decoder_beninca_arc_alloc(SubGhzEnvironment* environment);
  * @param duration Duration of this level in, us
  */
 void subghz_protocol_decoder_beninca_arc_feed(void* context, bool level, uint32_t duration);
-
-/**
- * Serialize data SubGhzProtocolDecoderBenincaARC.
- * @param context Pointer to a SubGhzProtocolDecoderBenincaARC instance
- * @param flipper_format Pointer to a FlipperFormat instance
- * @param preset The modulation on which the signal was received, SubGhzRadioPreset
- * @return status
- */
-SubGhzProtocolStatus subghz_protocol_decoder_beninca_arc_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset);
 
 /**
  * Deserialize data SubGhzProtocolDecoderBenincaARC.

--- a/lib/subghz/protocols/bett.c
+++ b/lib/subghz/protocols/bett.c
@@ -39,6 +39,7 @@ struct SubGhzProtocolDecoderBETT {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderBETT);
 
 struct SubGhzProtocolEncoderBETT {
     SubGhzProtocolEncoderBase base;
@@ -46,6 +47,7 @@ struct SubGhzProtocolEncoderBETT {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderBETT);
 
 typedef enum {
     BETTDecoderStepReset = 0,
@@ -87,16 +89,8 @@ const SubGhzProtocol subghz_protocol_bett = {
 
 void* subghz_protocol_encoder_bett_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderBETT* instance = malloc(sizeof(SubGhzProtocolEncoderBETT));
-
-    instance->base.protocol = &subghz_protocol_bett;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 52;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderBETT), &subghz_protocol_bett, 3, 52);
 }
 
 /**
@@ -179,10 +173,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_bett_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderBETT* instance = malloc(sizeof(SubGhzProtocolDecoderBETT));
-    instance->base.protocol = &subghz_protocol_bett;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderBETT), &subghz_protocol_bett);
 }
 
 void subghz_protocol_decoder_bett_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/bett.c
+++ b/lib/subghz/protocols/bett.c
@@ -96,7 +96,7 @@ void* subghz_protocol_encoder_bett_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderBETT instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_bett_get_upload(SubGhzProtocolEncoderBETT* instance) {
     furi_assert(instance);

--- a/lib/subghz/protocols/bin_raw.c
+++ b/lib/subghz/protocols/bin_raw.c
@@ -78,6 +78,7 @@ struct SubGhzProtocolDecoderBinRAW {
     uint32_t te;
     float adaptive_threshold_rssi;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderBinRAW);
 
 struct SubGhzProtocolEncoderBinRAW {
     SubGhzProtocolEncoderBase base;
@@ -164,7 +165,7 @@ void subghz_protocol_encoder_bin_raw_free(void* context) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderBinRAW instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_bin_raw_get_upload(SubGhzProtocolEncoderBinRAW* instance) {
     furi_assert(instance);
@@ -330,9 +331,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_bin_raw_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderBinRAW* instance = malloc(sizeof(SubGhzProtocolDecoderBinRAW));
-    instance->base.protocol = &subghz_protocol_bin_raw;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolDecoderBinRAW* instance = subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderBinRAW), &subghz_protocol_bin_raw);
     instance->data_raw_ind = 0;
     instance->data_raw = malloc(BIN_RAW_BUF_RAW_SIZE * sizeof(int32_t));
     instance->data = malloc(BIN_RAW_BUF_RAW_SIZE * sizeof(uint8_t));

--- a/lib/subghz/protocols/bin_raw.c
+++ b/lib/subghz/protocols/bin_raw.c
@@ -89,6 +89,7 @@ struct SubGhzProtocolEncoderBinRAW {
     BinRAW_Markup data_markup[BIN_RAW_MAX_MARKUP_COUNT];
     uint32_t te;
 };
+SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderBinRAW);
 
 const SubGhzProtocolDecoder subghz_protocol_bin_raw_decoder = {
     .alloc = subghz_protocol_decoder_bin_raw_alloc,

--- a/lib/subghz/protocols/came.c
+++ b/lib/subghz/protocols/came.c
@@ -95,7 +95,7 @@ void* subghz_protocol_encoder_came_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderCame instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_came_get_upload(SubGhzProtocolEncoderCame* instance) {
     furi_assert(instance);

--- a/lib/subghz/protocols/came.c
+++ b/lib/subghz/protocols/came.c
@@ -36,6 +36,7 @@ struct SubGhzProtocolDecoderCame {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderCame);
 
 struct SubGhzProtocolEncoderCame {
     SubGhzProtocolEncoderBase base;
@@ -43,6 +44,7 @@ struct SubGhzProtocolEncoderCame {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderCame);
 
 typedef enum {
     CameDecoderStepReset = 0,
@@ -86,16 +88,8 @@ const SubGhzProtocol subghz_protocol_came = {
 
 void* subghz_protocol_encoder_came_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderCame* instance = malloc(sizeof(SubGhzProtocolEncoderCame));
-
-    instance->base.protocol = &subghz_protocol_came;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderCame), &subghz_protocol_came, 3, 128);
 }
 
 /**
@@ -191,10 +185,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_came_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderCame* instance = malloc(sizeof(SubGhzProtocolDecoderCame));
-    instance->base.protocol = &subghz_protocol_came;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderCame), &subghz_protocol_came);
 }
 
 void subghz_protocol_decoder_came_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/came_atomo.c
+++ b/lib/subghz/protocols/came_atomo.c
@@ -30,6 +30,7 @@ struct SubGhzProtocolDecoderCameAtomo {
 
     ManchesterState manchester_saved_state;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderCameAtomo);
 
 struct SubGhzProtocolEncoderCameAtomo {
     SubGhzProtocolEncoderBase base;
@@ -37,6 +38,7 @@ struct SubGhzProtocolEncoderCameAtomo {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderCameAtomo);
 
 typedef enum {
     CameAtomoDecoderStepReset = 0,
@@ -88,16 +90,11 @@ static uint8_t subghz_protocol_came_atomo_get_btn_code(void);
 
 void* subghz_protocol_encoder_came_atomo_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderCameAtomo* instance = malloc(sizeof(SubGhzProtocolEncoderCameAtomo));
-
-    instance->base.protocol = &subghz_protocol_came_atomo;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 1;
-    instance->encoder.size_upload = 900; //actual size 766+
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderCameAtomo),
+        &subghz_protocol_came_atomo,
+        1,
+        900); //actual size 766+
 }
 
 static LevelDuration
@@ -428,10 +425,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_came_atomo_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderCameAtomo* instance = malloc(sizeof(SubGhzProtocolDecoderCameAtomo));
-    instance->base.protocol = &subghz_protocol_came_atomo;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderCameAtomo), &subghz_protocol_came_atomo);
 }
 
 void subghz_protocol_decoder_came_atomo_reset(void* context) {

--- a/lib/subghz/protocols/came_twee.c
+++ b/lib/subghz/protocols/came_twee.c
@@ -58,6 +58,7 @@ struct SubGhzProtocolDecoderCameTwee {
     SubGhzBlockGeneric generic;
     ManchesterState manchester_saved_state;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderCameTwee);
 
 struct SubGhzProtocolEncoderCameTwee {
     SubGhzProtocolEncoderBase base;
@@ -65,6 +66,7 @@ struct SubGhzProtocolEncoderCameTwee {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderCameTwee);
 
 typedef enum {
     CameTweeDecoderStepReset = 0,
@@ -105,16 +107,8 @@ const SubGhzProtocol subghz_protocol_came_twee = {
 
 void* subghz_protocol_encoder_came_twee_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderCameTwee* instance = malloc(sizeof(SubGhzProtocolEncoderCameTwee));
-
-    instance->base.protocol = &subghz_protocol_came_twee;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 1;
-    instance->encoder.size_upload = 1536; // 1308
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderCameTwee), &subghz_protocol_came_twee, 1, 1536); // 1308
 }
 
 static LevelDuration
@@ -269,10 +263,8 @@ void subghz_protocol_encoder_came_twee_stop(void* context) {
 
 void* subghz_protocol_decoder_came_twee_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderCameTwee* instance = malloc(sizeof(SubGhzProtocolDecoderCameTwee));
-    instance->base.protocol = &subghz_protocol_came_twee;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderCameTwee), &subghz_protocol_came_twee);
 }
 
 void subghz_protocol_decoder_came_twee_reset(void* context) {

--- a/lib/subghz/protocols/chamberlain_code.c
+++ b/lib/subghz/protocols/chamberlain_code.c
@@ -52,6 +52,7 @@ struct SubGhzProtocolDecoderChamb_Code {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderChamb_Code);
 
 struct SubGhzProtocolEncoderChamb_Code {
     SubGhzProtocolEncoderBase base;
@@ -59,6 +60,7 @@ struct SubGhzProtocolEncoderChamb_Code {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderChamb_Code);
 
 typedef enum {
     Chamb_CodeDecoderStepReset = 0,
@@ -101,16 +103,8 @@ const SubGhzProtocol subghz_protocol_chamb_code = {
 
 void* subghz_protocol_encoder_chamb_code_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderChamb_Code* instance = malloc(sizeof(SubGhzProtocolEncoderChamb_Code));
-
-    instance->base.protocol = &subghz_protocol_chamb_code;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 24;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderChamb_Code), &subghz_protocol_chamb_code, 3, 24);
 }
 
 static uint64_t subghz_protocol_chamb_bit_to_code(uint64_t data, uint8_t size) {
@@ -234,10 +228,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_chamb_code_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderChamb_Code* instance = malloc(sizeof(SubGhzProtocolDecoderChamb_Code));
-    instance->base.protocol = &subghz_protocol_chamb_code;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderChamb_Code), &subghz_protocol_chamb_code);
 }
 
 static bool subghz_protocol_chamb_code_to_bit(uint64_t* data, uint8_t size) {

--- a/lib/subghz/protocols/clemsa.c
+++ b/lib/subghz/protocols/clemsa.c
@@ -95,7 +95,7 @@ void* subghz_protocol_encoder_clemsa_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderClemsa instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_clemsa_get_upload(void* context) {
     SubGhzProtocolEncoderClemsa* instance = context;

--- a/lib/subghz/protocols/clemsa.c
+++ b/lib/subghz/protocols/clemsa.c
@@ -38,6 +38,7 @@ struct SubGhzProtocolDecoderClemsa {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderClemsa);
 
 struct SubGhzProtocolEncoderClemsa {
     SubGhzProtocolEncoderBase base;
@@ -45,6 +46,7 @@ struct SubGhzProtocolEncoderClemsa {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderClemsa);
 
 typedef enum {
     ClemsaDecoderStepReset = 0,
@@ -86,16 +88,8 @@ const SubGhzProtocol subghz_protocol_clemsa = {
 
 void* subghz_protocol_encoder_clemsa_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderClemsa* instance = malloc(sizeof(SubGhzProtocolEncoderClemsa));
-
-    instance->base.protocol = &subghz_protocol_clemsa;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 52;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderClemsa), &subghz_protocol_clemsa, 3, 52);
 }
 
 /**
@@ -179,10 +173,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_clemsa_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderClemsa* instance = malloc(sizeof(SubGhzProtocolDecoderClemsa));
-    instance->base.protocol = &subghz_protocol_clemsa;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderClemsa), &subghz_protocol_clemsa);
 }
 
 void subghz_protocol_decoder_clemsa_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/clemsa.c
+++ b/lib/subghz/protocols/clemsa.c
@@ -97,7 +97,8 @@ void* subghz_protocol_encoder_clemsa_alloc(SubGhzEnvironment* environment) {
  * @param instance Pointer to a SubGhzProtocolEncoderClemsa instance
  * @return true On success
  */
-static bool subghz_protocol_encoder_clemsa_get_upload(SubGhzProtocolEncoderClemsa* instance) {
+static bool subghz_protocol_encoder_clemsa_get_upload(void* context) {
+    SubGhzProtocolEncoderClemsa* instance = context;
     furi_assert(instance);
     size_t index = 0;
     size_t size_upload = (instance->generic.data_count_bit * 2);
@@ -145,30 +146,11 @@ static bool subghz_protocol_encoder_clemsa_get_upload(SubGhzProtocolEncoderClems
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_clemsa_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderClemsa* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_clemsa_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        if(!subghz_protocol_encoder_clemsa_get_upload(instance)) {
-            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
-            break;
-        }
-        instance->encoder.is_running = true;
-
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_clemsa_const.min_count_bit_for_found,
+        subghz_protocol_encoder_clemsa_get_upload);
 }
 
 void* subghz_protocol_decoder_clemsa_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/common.c
+++ b/lib/subghz/protocols/common.c
@@ -132,7 +132,7 @@ void* subghz_protocol_encoder_common_alloc(
 SubGhzProtocolStatus subghz_protocol_encoder_common_deserialize(
     void* context,
     FlipperFormat* flipper_format,
-    uint8_t min_count_bit,
+    uint16_t min_count_bit,
     SubGhzProtocolEncoderGetUpload get_upload) {
     furi_assert(context);
     SubGhzProtocolEncoderCommonGeneric* instance = context;
@@ -155,7 +155,7 @@ SubGhzProtocolStatus subghz_protocol_encoder_common_deserialize(
 SubGhzProtocolStatus subghz_protocol_decoder_common_deserialize_te(
     void* context,
     FlipperFormat* flipper_format,
-    uint8_t min_count_bit) {
+    uint16_t min_count_bit) {
     furi_assert(context);
     SubGhzProtocolDecoderCommonTe* instance = context;
     SubGhzProtocolStatus ret = subghz_block_generic_deserialize_check_count_bit(

--- a/lib/subghz/protocols/common.c
+++ b/lib/subghz/protocols/common.c
@@ -128,3 +128,48 @@ void* subghz_protocol_encoder_common_alloc(
     instance->common.encoder.is_running = false;
     return instance;
 }
+
+SubGhzProtocolStatus subghz_protocol_encoder_common_deserialize(
+    void* context,
+    FlipperFormat* flipper_format,
+    uint8_t min_count_bit,
+    SubGhzProtocolEncoderGetUpload get_upload) {
+    furi_assert(context);
+    SubGhzProtocolEncoderCommonGeneric* instance = context;
+    SubGhzProtocolStatus ret = subghz_block_generic_deserialize_check_count_bit(
+        &instance->generic, flipper_format, min_count_bit);
+    if(ret != SubGhzProtocolStatusOk) {
+        return ret;
+    }
+    // Optional value
+    flipper_format_read_uint32(
+        flipper_format, "Repeat", (uint32_t*)&instance->common.encoder.repeat, 1);
+
+    if(!get_upload(instance)) {
+        return SubGhzProtocolStatusErrorEncoderGetUpload;
+    }
+    instance->common.encoder.is_running = true;
+    return ret;
+}
+
+SubGhzProtocolStatus subghz_protocol_decoder_common_deserialize_te(
+    void* context,
+    FlipperFormat* flipper_format,
+    uint8_t min_count_bit) {
+    furi_assert(context);
+    SubGhzProtocolDecoderCommonTe* instance = context;
+    SubGhzProtocolStatus ret = subghz_block_generic_deserialize_check_count_bit(
+        &instance->common.generic, flipper_format, min_count_bit);
+    if(ret != SubGhzProtocolStatusOk) {
+        return ret;
+    }
+    if(!flipper_format_rewind(flipper_format)) {
+        FURI_LOG_E(instance->common.generic.protocol_name, "Rewind error");
+        return SubGhzProtocolStatusErrorParserOthers;
+    }
+    if(!flipper_format_read_uint32(flipper_format, "TE", (uint32_t*)&instance->te, 1)) {
+        FURI_LOG_E(instance->common.generic.protocol_name, "Missing TE");
+        return SubGhzProtocolStatusErrorParserTe;
+    }
+    return ret;
+}

--- a/lib/subghz/protocols/common.c
+++ b/lib/subghz/protocols/common.c
@@ -57,3 +57,52 @@ SubGhzProtocolStatus subghz_protocol_decoder_common_serialize(
     SubGhzProtocolDecoderCommon* instance = context;
     return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
 }
+
+SubGhzProtocolStatus subghz_protocol_common_append_data_2(
+    SubGhzProtocolStatus status,
+    SubGhzBlockGeneric* generic,
+    FlipperFormat* flipper_format) {
+    uint8_t key_data[sizeof(uint64_t)] = {0};
+    for(size_t i = 0; i < sizeof(uint64_t); i++) {
+        key_data[sizeof(uint64_t) - i - 1] = (generic->data_2 >> (i * 8)) & 0xFF;
+    }
+
+    if(!flipper_format_rewind(flipper_format)) {
+        FURI_LOG_E(generic->protocol_name, "Rewind error");
+        status = SubGhzProtocolStatusErrorParserOthers;
+    }
+
+    if((status == SubGhzProtocolStatusOk) &&
+       !flipper_format_insert_or_update_hex(flipper_format, "Data", key_data, sizeof(uint64_t))) {
+        FURI_LOG_E(generic->protocol_name, "Unable to add Data");
+        status = SubGhzProtocolStatusErrorParserOthers;
+    }
+    return status;
+}
+
+SubGhzProtocolStatus subghz_protocol_decoder_common_serialize_data_2(
+    void* context,
+    FlipperFormat* flipper_format,
+    SubGhzRadioPreset* preset) {
+    furi_assert(context);
+    SubGhzProtocolDecoderCommon* instance = context;
+    SubGhzProtocolStatus ret =
+        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
+    return subghz_protocol_common_append_data_2(ret, &instance->generic, flipper_format);
+}
+
+SubGhzProtocolStatus subghz_protocol_decoder_common_serialize_te(
+    void* context,
+    FlipperFormat* flipper_format,
+    SubGhzRadioPreset* preset) {
+    furi_assert(context);
+    SubGhzProtocolDecoderCommonTe* instance = context;
+    SubGhzProtocolStatus ret =
+        subghz_block_generic_serialize(&instance->common.generic, flipper_format, preset);
+    if((ret == SubGhzProtocolStatusOk) &&
+       !flipper_format_write_uint32(flipper_format, "TE", &instance->te, 1)) {
+        FURI_LOG_E(instance->common.generic.protocol_name, "Unable to add TE");
+        ret = SubGhzProtocolStatusErrorParserTe;
+    }
+    return ret;
+}

--- a/lib/subghz/protocols/common.c
+++ b/lib/subghz/protocols/common.c
@@ -106,3 +106,25 @@ SubGhzProtocolStatus subghz_protocol_decoder_common_serialize_te(
     }
     return ret;
 }
+
+void* subghz_protocol_decoder_common_alloc(size_t instance_size, const SubGhzProtocol* protocol) {
+    SubGhzProtocolDecoderCommon* instance = malloc(instance_size);
+    instance->base.protocol = protocol;
+    instance->generic.protocol_name = protocol->name;
+    return instance;
+}
+
+void* subghz_protocol_encoder_common_alloc(
+    size_t instance_size,
+    const SubGhzProtocol* protocol,
+    size_t repeat,
+    size_t size_upload) {
+    SubGhzProtocolEncoderCommonGeneric* instance = malloc(instance_size);
+    instance->common.base.protocol = protocol;
+    instance->generic.protocol_name = protocol->name;
+    instance->common.encoder.repeat = repeat;
+    instance->common.encoder.size_upload = size_upload;
+    instance->common.encoder.upload = malloc(size_upload * sizeof(LevelDuration));
+    instance->common.encoder.is_running = false;
+    return instance;
+}

--- a/lib/subghz/protocols/common.h
+++ b/lib/subghz/protocols/common.h
@@ -31,6 +31,11 @@ typedef struct {
 } SubGhzProtocolEncoderCommon;
 
 typedef struct {
+    SubGhzProtocolEncoderCommon common;
+    SubGhzBlockGeneric generic;
+} SubGhzProtocolEncoderCommonGeneric;
+
+typedef struct {
     SubGhzProtocolDecoderBase base;
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
@@ -59,11 +64,39 @@ typedef struct {
             offsetof(type, encoder) == offsetof(SubGhzProtocolEncoderCommon, encoder), \
         #type " must start with the SubGhzProtocolEncoderCommon member sequence")
 
+#define SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(type)                                        \
+    SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(type);                                            \
+    _Static_assert(                                                                       \
+        offsetof(type, generic) == offsetof(SubGhzProtocolEncoderCommonGeneric, generic), \
+        #type " must keep generic directly after encoder")
+
 #define SUBGHZ_ASSERT_DECODER_TE_LAYOUT(type)                              \
     SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(type);                             \
     _Static_assert(                                                        \
         offsetof(type, te) == offsetof(SubGhzProtocolDecoderCommonTe, te), \
         #type " must keep te directly after generic")
+
+/**
+ * Allocate a decoder instance and bind it to its protocol.
+ * @param instance_size sizeof the protocol's decoder struct
+ * @param protocol Pointer to the SubGhzProtocol the instance decodes
+ * @return Pointer to the new instance
+ */
+void* subghz_protocol_decoder_common_alloc(size_t instance_size, const SubGhzProtocol* protocol);
+
+/**
+ * Allocate an encoder instance, bind it to its protocol and size its upload buffer.
+ * @param instance_size sizeof the protocol's encoder struct
+ * @param protocol Pointer to the SubGhzProtocol the instance encodes
+ * @param repeat Number of times the upload is repeated
+ * @param size_upload Upload buffer length, in LevelDuration entries
+ * @return Pointer to the new instance
+ */
+void* subghz_protocol_encoder_common_alloc(
+    size_t instance_size,
+    const SubGhzProtocol* protocol,
+    size_t repeat,
+    size_t size_upload);
 
 /**
  * Free an encoder instance along with its upload buffer.

--- a/lib/subghz/protocols/common.h
+++ b/lib/subghz/protocols/common.h
@@ -116,7 +116,7 @@ typedef bool (*SubGhzProtocolEncoderGetUpload)(void* instance);
 SubGhzProtocolStatus subghz_protocol_encoder_common_deserialize(
     void* context,
     FlipperFormat* flipper_format,
-    uint8_t min_count_bit,
+    uint16_t min_count_bit,
     SubGhzProtocolEncoderGetUpload get_upload);
 
 /**
@@ -129,7 +129,7 @@ SubGhzProtocolStatus subghz_protocol_encoder_common_deserialize(
 SubGhzProtocolStatus subghz_protocol_decoder_common_deserialize_te(
     void* context,
     FlipperFormat* flipper_format,
-    uint8_t min_count_bit);
+    uint16_t min_count_bit);
 
 /**
  * Free an encoder instance along with its upload buffer.

--- a/lib/subghz/protocols/common.h
+++ b/lib/subghz/protocols/common.h
@@ -21,8 +21,8 @@ extern "C" {
  * Protocols needing extra work in a slot either keep their own copy, or call the shared helper
  * and then write their own fields the way princeton does.
  *
- * subghz_protocol_common_append_data_2 is the exception: a plain helper rather than a slot,
- * shared by the serialize slots and the encoder create_data paths.
+ * Helpers that need a per-protocol constant or callback cannot be slots themselves, so the
+ * protocol keeps a thunk that supplies it; the rest are pointed at directly.
  */
 
 typedef struct {
@@ -97,6 +97,39 @@ void* subghz_protocol_encoder_common_alloc(
     const SubGhzProtocol* protocol,
     size_t repeat,
     size_t size_upload);
+
+/**
+ * Turns the deserialized generic block into an upload.
+ * @param instance Pointer to an encoder instance
+ * @return true On success
+ */
+typedef bool (*SubGhzProtocolEncoderGetUpload)(void* instance);
+
+/**
+ * Deserialize an encoder that needs the generic block, an optional Repeat, and an upload.
+ * @param context Pointer to a SubGhzProtocolEncoderCommonGeneric instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @param min_count_bit Minimum number of bits the protocol needs
+ * @param get_upload Per-protocol upload generator
+ * @return status
+ */
+SubGhzProtocolStatus subghz_protocol_encoder_common_deserialize(
+    void* context,
+    FlipperFormat* flipper_format,
+    uint8_t min_count_bit,
+    SubGhzProtocolEncoderGetUpload get_upload);
+
+/**
+ * Deserialize decoder data and read the TE value back.
+ * @param context Pointer to a SubGhzProtocolDecoderCommonTe instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @param min_count_bit Minimum number of bits the protocol needs
+ * @return status
+ */
+SubGhzProtocolStatus subghz_protocol_decoder_common_deserialize_te(
+    void* context,
+    FlipperFormat* flipper_format,
+    uint8_t min_count_bit);
 
 /**
  * Free an encoder instance along with its upload buffer.

--- a/lib/subghz/protocols/common.h
+++ b/lib/subghz/protocols/common.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stddef.h>
+
 #include "base.h"
 
 #include "../blocks/decoder.h"
@@ -11,11 +13,16 @@ extern "C" {
 #endif
 
 /**
- * Shared implementations of the protocol vtable entries that are byte-for-byte identical across
- * protocols. They reach the instance through a void* the same way the per-protocol copies did,
- * and only ever touch members of the leading common sequence below, so any protocol whose struct
- * starts with those members can point its vtable straight at them. Protocols that need extra work
- * in one of these slots (extra state to reset, a different teardown) keep their own copy.
+ * Shared implementations of the protocol vtable entries that are identical across protocols.
+ * They reach the instance through a void* the same way the per-protocol copies did, and only
+ * touch members of one of the leading sequences below, so any protocol whose struct starts with
+ * those members can point its vtable straight at them; the SUBGHZ_ASSERT_*_LAYOUT macros hold
+ * that down. They log through generic.protocol_name, which every alloc must therefore set.
+ * Protocols needing extra work in a slot either keep their own copy, or call the shared helper
+ * and then write their own fields the way princeton does.
+ *
+ * subghz_protocol_common_append_data_2 is the exception: a plain helper rather than a slot,
+ * shared by the serialize slots and the encoder create_data paths.
  */
 
 typedef struct {
@@ -28,6 +35,35 @@ typedef struct {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 } SubGhzProtocolDecoderCommon;
+
+typedef struct {
+    SubGhzProtocolDecoderCommon common;
+    uint32_t te;
+} SubGhzProtocolDecoderCommonTe;
+
+/**
+ * The shared handlers reach members by offset, so a protocol that reorders its prefix would
+ * silently alias the wrong one. Pinning te alone is not enough: decoder and generic are both
+ * multiples of 8, so swapping them leaves te at the same offset.
+ */
+#define SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(type)                                        \
+    _Static_assert(                                                                      \
+        offsetof(type, base) == offsetof(SubGhzProtocolDecoderCommon, base) &&           \
+            offsetof(type, decoder) == offsetof(SubGhzProtocolDecoderCommon, decoder) && \
+            offsetof(type, generic) == offsetof(SubGhzProtocolDecoderCommon, generic),   \
+        #type " must start with the SubGhzProtocolDecoderCommon member sequence")
+
+#define SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(type)                                      \
+    _Static_assert(                                                                    \
+        offsetof(type, base) == offsetof(SubGhzProtocolEncoderCommon, base) &&         \
+            offsetof(type, encoder) == offsetof(SubGhzProtocolEncoderCommon, encoder), \
+        #type " must start with the SubGhzProtocolEncoderCommon member sequence")
+
+#define SUBGHZ_ASSERT_DECODER_TE_LAYOUT(type)                              \
+    SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(type);                             \
+    _Static_assert(                                                        \
+        offsetof(type, te) == offsetof(SubGhzProtocolDecoderCommonTe, te), \
+        #type " must keep te directly after generic")
 
 /**
  * Free an encoder instance along with its upload buffer.
@@ -75,6 +111,44 @@ uint8_t subghz_protocol_decoder_common_get_hash_data(void* context);
  * @return status
  */
 SubGhzProtocolStatus subghz_protocol_decoder_common_serialize(
+    void* context,
+    FlipperFormat* flipper_format,
+    SubGhzRadioPreset* preset);
+
+/**
+ * Write generic.data_2 as a big-endian "Data" field, carrying a running status.
+ * Rewinds flipper_format. Shared by the decoder serialize slots and the encoder
+ * create_data paths.
+ * @param status Status so far, returned unchanged unless this call itself fails
+ * @param generic Pointer to a SubGhzBlockGeneric instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @return status
+ */
+SubGhzProtocolStatus subghz_protocol_common_append_data_2(
+    SubGhzProtocolStatus status,
+    SubGhzBlockGeneric* generic,
+    FlipperFormat* flipper_format);
+
+/**
+ * Serialize decoder data and append generic.data_2 as a "Data" field.
+ * @param context Pointer to a SubGhzProtocolDecoderCommon instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @param preset The modulation on which the signal was received, SubGhzRadioPreset
+ * @return status
+ */
+SubGhzProtocolStatus subghz_protocol_decoder_common_serialize_data_2(
+    void* context,
+    FlipperFormat* flipper_format,
+    SubGhzRadioPreset* preset);
+
+/**
+ * Serialize decoder data and append the TE value.
+ * @param context Pointer to a SubGhzProtocolDecoderCommonTe instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @param preset The modulation on which the signal was received, SubGhzRadioPreset
+ * @return status
+ */
+SubGhzProtocolStatus subghz_protocol_decoder_common_serialize_te(
     void* context,
     FlipperFormat* flipper_format,
     SubGhzRadioPreset* preset);

--- a/lib/subghz/protocols/dickert_mahs.c
+++ b/lib/subghz/protocols/dickert_mahs.c
@@ -29,6 +29,7 @@ struct SubGhzProtocolDecoderDickertMAHS {
     uint32_t tmp[2];
     uint8_t tmp_cnt;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderDickertMAHS);
 
 struct SubGhzProtocolEncoderDickertMAHS {
     SubGhzProtocolEncoderBase base;
@@ -36,6 +37,7 @@ struct SubGhzProtocolEncoderDickertMAHS {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderDickertMAHS);
 
 typedef enum {
     DickertMAHSDecoderStepReset = 0,
@@ -128,16 +130,8 @@ static void subghz_protocol_encoder_dickert_mahs_parse_buffer(
 
 void* subghz_protocol_encoder_dickert_mahs_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderDickertMAHS* instance = malloc(sizeof(SubGhzProtocolEncoderDickertMAHS));
-
-    instance->base.protocol = &subghz_protocol_dickert_mahs;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderDickertMAHS), &subghz_protocol_dickert_mahs, 3, 128);
 }
 
 /**

--- a/lib/subghz/protocols/dickert_mahs.c
+++ b/lib/subghz/protocols/dickert_mahs.c
@@ -211,11 +211,9 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_dickert_mahs_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderDickertMAHS* instance = malloc(sizeof(SubGhzProtocolDecoderDickertMAHS));
-    instance->base.protocol = &subghz_protocol_dickert_mahs;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolDecoderDickertMAHS* instance = subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderDickertMAHS), &subghz_protocol_dickert_mahs);
     instance->tmp_cnt = 0;
-
     return instance;
 }
 

--- a/lib/subghz/protocols/ditec_gol4.c
+++ b/lib/subghz/protocols/ditec_gol4.c
@@ -25,6 +25,7 @@ struct SubGhzProtocolDecoderDitecGOL4 {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderDitecGOL4);
 
 struct SubGhzProtocolEncoderDitecGOL4 {
     SubGhzProtocolEncoderBase base;
@@ -32,6 +33,7 @@ struct SubGhzProtocolEncoderDitecGOL4 {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderDitecGOL4);
 
 typedef enum {
     DitecGOL4DecoderStepReset = 0,
@@ -241,16 +243,8 @@ static uint32_t serial_to_display(const uint8_t* s) {
 
 void* subghz_protocol_encoder_ditec_gol4_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderDitecGOL4* instance = malloc(sizeof(SubGhzProtocolEncoderDitecGOL4));
-
-    instance->base.protocol = &subghz_protocol_ditec_gol4;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 4;
-    instance->encoder.size_upload = 128; // 110 actual
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderDitecGOL4), &subghz_protocol_ditec_gol4, 4, 128); // 110 actual
 }
 
 /**
@@ -439,10 +433,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_ditec_gol4_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderDitecGOL4* instance = malloc(sizeof(SubGhzProtocolDecoderDitecGOL4));
-    instance->base.protocol = &subghz_protocol_ditec_gol4;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderDitecGOL4), &subghz_protocol_ditec_gol4);
 }
 
 void subghz_protocol_decoder_ditec_gol4_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/doitrand.c
+++ b/lib/subghz/protocols/doitrand.c
@@ -89,7 +89,8 @@ void* subghz_protocol_encoder_doitrand_alloc(SubGhzEnvironment* environment) {
  * @param instance Pointer to a SubGhzProtocolEncoderDoitrand instance
  * @return true On success
  */
-static bool subghz_protocol_encoder_doitrand_get_upload(SubGhzProtocolEncoderDoitrand* instance) {
+static bool subghz_protocol_encoder_doitrand_get_upload(void* context) {
+    SubGhzProtocolEncoderDoitrand* instance = context;
     furi_assert(instance);
     size_t index = 0;
     size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
@@ -126,29 +127,11 @@ static bool subghz_protocol_encoder_doitrand_get_upload(SubGhzProtocolEncoderDoi
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_doitrand_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderDoitrand* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_doitrand_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        if(!subghz_protocol_encoder_doitrand_get_upload(instance)) {
-            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
-            break;
-        }
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_doitrand_const.min_count_bit_for_found,
+        subghz_protocol_encoder_doitrand_get_upload);
 }
 
 void* subghz_protocol_decoder_doitrand_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/doitrand.c
+++ b/lib/subghz/protocols/doitrand.c
@@ -29,6 +29,7 @@ struct SubGhzProtocolDecoderDoitrand {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderDoitrand);
 
 struct SubGhzProtocolEncoderDoitrand {
     SubGhzProtocolEncoderBase base;
@@ -36,6 +37,7 @@ struct SubGhzProtocolEncoderDoitrand {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderDoitrand);
 
 typedef enum {
     DoitrandDecoderStepReset = 0,
@@ -78,16 +80,8 @@ const SubGhzProtocol subghz_protocol_doitrand = {
 
 void* subghz_protocol_encoder_doitrand_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderDoitrand* instance = malloc(sizeof(SubGhzProtocolEncoderDoitrand));
-
-    instance->base.protocol = &subghz_protocol_doitrand;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderDoitrand), &subghz_protocol_doitrand, 3, 128);
 }
 
 /**
@@ -159,10 +153,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_doitrand_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderDoitrand* instance = malloc(sizeof(SubGhzProtocolDecoderDoitrand));
-    instance->base.protocol = &subghz_protocol_doitrand;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderDoitrand), &subghz_protocol_doitrand);
 }
 
 void subghz_protocol_decoder_doitrand_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/doitrand.c
+++ b/lib/subghz/protocols/doitrand.c
@@ -87,7 +87,7 @@ void* subghz_protocol_encoder_doitrand_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderDoitrand instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_doitrand_get_upload(void* context) {
     SubGhzProtocolEncoderDoitrand* instance = context;

--- a/lib/subghz/protocols/dooya.c
+++ b/lib/subghz/protocols/dooya.c
@@ -23,6 +23,7 @@ struct SubGhzProtocolDecoderDooya {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderDooya);
 
 struct SubGhzProtocolEncoderDooya {
     SubGhzProtocolEncoderBase base;
@@ -30,6 +31,7 @@ struct SubGhzProtocolEncoderDooya {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderDooya);
 
 typedef enum {
     DooyaDecoderStepReset = 0,
@@ -73,16 +75,8 @@ const SubGhzProtocol subghz_protocol_dooya = {
 
 void* subghz_protocol_encoder_dooya_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderDooya* instance = malloc(sizeof(SubGhzProtocolEncoderDooya));
-
-    instance->base.protocol = &subghz_protocol_dooya;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderDooya), &subghz_protocol_dooya, 3, 128);
 }
 
 /**
@@ -169,10 +163,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_dooya_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderDooya* instance = malloc(sizeof(SubGhzProtocolDecoderDooya));
-    instance->base.protocol = &subghz_protocol_dooya;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderDooya), &subghz_protocol_dooya);
 }
 
 void subghz_protocol_decoder_dooya_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/dooya.c
+++ b/lib/subghz/protocols/dooya.c
@@ -84,7 +84,8 @@ void* subghz_protocol_encoder_dooya_alloc(SubGhzEnvironment* environment) {
  * @param instance Pointer to a SubGhzProtocolEncoderDooya instance
  * @return true On success
  */
-static bool subghz_protocol_encoder_dooya_get_upload(SubGhzProtocolEncoderDooya* instance) {
+static bool subghz_protocol_encoder_dooya_get_upload(void* context) {
+    SubGhzProtocolEncoderDooya* instance = context;
     furi_assert(instance);
 
     size_t index = 0;
@@ -136,29 +137,11 @@ static bool subghz_protocol_encoder_dooya_get_upload(SubGhzProtocolEncoderDooya*
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_dooya_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderDooya* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_dooya_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        if(!subghz_protocol_encoder_dooya_get_upload(instance)) {
-            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
-            break;
-        }
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_dooya_const.min_count_bit_for_found,
+        subghz_protocol_encoder_dooya_get_upload);
 }
 
 void* subghz_protocol_decoder_dooya_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/dooya.c
+++ b/lib/subghz/protocols/dooya.c
@@ -82,7 +82,7 @@ void* subghz_protocol_encoder_dooya_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderDooya instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_dooya_get_upload(void* context) {
     SubGhzProtocolEncoderDooya* instance = context;

--- a/lib/subghz/protocols/elplast.c
+++ b/lib/subghz/protocols/elplast.c
@@ -77,9 +77,12 @@ void* subghz_protocol_encoder_elplast_alloc(SubGhzEnvironment* environment) {
 
 /**
  * Generating an upload from data.
- * @param instance Pointer to a SubGhzProtocolEncoderElplast instance
+ * @param context Pointer to a SubGhzProtocolEncoderElplast instance
+ * @return true Always; this encoder has no failure path
  */
-static void subghz_protocol_encoder_elplast_get_upload(SubGhzProtocolEncoderElplast* instance) {
+static bool subghz_protocol_encoder_elplast_get_upload(void* context) {
+    SubGhzProtocolEncoderElplast* instance = context;
+
     furi_assert(instance);
     size_t index = 0;
 
@@ -113,31 +116,16 @@ static void subghz_protocol_encoder_elplast_get_upload(SubGhzProtocolEncoderElpl
     }
 
     instance->encoder.size_upload = index;
-    return;
+    return true;
 }
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_elplast_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderElplast* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_elplast_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        subghz_protocol_encoder_elplast_get_upload(instance);
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_elplast_const.min_count_bit_for_found,
+        subghz_protocol_encoder_elplast_get_upload);
 }
 
 void* subghz_protocol_decoder_elplast_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/elplast.c
+++ b/lib/subghz/protocols/elplast.c
@@ -21,6 +21,7 @@ struct SubGhzProtocolDecoderElplast {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderElplast);
 
 struct SubGhzProtocolEncoderElplast {
     SubGhzProtocolEncoderBase base;
@@ -28,6 +29,7 @@ struct SubGhzProtocolEncoderElplast {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderElplast);
 
 typedef enum {
     ElplastDecoderStepReset = 0,
@@ -69,16 +71,8 @@ const SubGhzProtocol subghz_protocol_elplast = {
 
 void* subghz_protocol_encoder_elplast_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderElplast* instance = malloc(sizeof(SubGhzProtocolEncoderElplast));
-
-    instance->base.protocol = &subghz_protocol_elplast;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 64;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderElplast), &subghz_protocol_elplast, 3, 64);
 }
 
 /**
@@ -148,10 +142,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_elplast_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderElplast* instance = malloc(sizeof(SubGhzProtocolDecoderElplast));
-    instance->base.protocol = &subghz_protocol_elplast;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderElplast), &subghz_protocol_elplast);
 }
 
 void subghz_protocol_decoder_elplast_feed(void* context, bool level, volatile uint32_t duration) {

--- a/lib/subghz/protocols/faac_slh.c
+++ b/lib/subghz/protocols/faac_slh.c
@@ -52,7 +52,7 @@ struct SubGhzProtocolEncoderFaacSLH {
     SubGhzKeystore* keystore;
     const char* manufacture_name;
 };
-SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderFaacSLH);
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderFaacSLH);
 
 typedef enum {
     FaacSLHDecoderStepReset = 0,
@@ -106,16 +106,9 @@ static void subghz_protocol_faac_slh_check_remote_controller(
     const char** manufacture_name);
 
 void* subghz_protocol_encoder_faac_slh_alloc(SubGhzEnvironment* environment) {
-    SubGhzProtocolEncoderFaacSLH* instance = malloc(sizeof(SubGhzProtocolEncoderFaacSLH));
-
-    instance->base.protocol = &subghz_protocol_faac_slh;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolEncoderFaacSLH* instance = subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderFaacSLH), &subghz_protocol_faac_slh, 3, 256);
     instance->keystore = subghz_environment_get_keystore(environment);
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
     return instance;
 }
 
@@ -329,7 +322,7 @@ bool subghz_protocol_faac_slh_create_data(
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderFaacSLH instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_faac_slh_get_upload(SubGhzProtocolEncoderFaacSLH* instance) {
     furi_assert(instance);
@@ -430,9 +423,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_faac_slh_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderFaacSLH* instance = malloc(sizeof(SubGhzProtocolDecoderFaacSLH));
-    instance->base.protocol = &subghz_protocol_faac_slh;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolDecoderFaacSLH* instance = subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderFaacSLH), &subghz_protocol_faac_slh);
     instance->keystore = subghz_environment_get_keystore(environment);
     return instance;
 }

--- a/lib/subghz/protocols/faac_slh.c
+++ b/lib/subghz/protocols/faac_slh.c
@@ -41,6 +41,7 @@ struct SubGhzProtocolDecoderFaacSLH {
     SubGhzKeystore* keystore;
     const char* manufacture_name;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderFaacSLH);
 
 struct SubGhzProtocolEncoderFaacSLH {
     SubGhzProtocolEncoderBase base;
@@ -51,6 +52,7 @@ struct SubGhzProtocolEncoderFaacSLH {
     SubGhzKeystore* keystore;
     const char* manufacture_name;
 };
+SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderFaacSLH);
 
 typedef enum {
     FaacSLHDecoderStepReset = 0,

--- a/lib/subghz/protocols/feron.c
+++ b/lib/subghz/protocols/feron.c
@@ -21,6 +21,7 @@ struct SubGhzProtocolDecoderFeron {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderFeron);
 
 struct SubGhzProtocolEncoderFeron {
     SubGhzProtocolEncoderBase base;
@@ -28,6 +29,7 @@ struct SubGhzProtocolEncoderFeron {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderFeron);
 
 typedef enum {
     FeronDecoderStepReset = 0,
@@ -70,16 +72,8 @@ const SubGhzProtocol subghz_protocol_feron = {
 
 void* subghz_protocol_encoder_feron_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderFeron* instance = malloc(sizeof(SubGhzProtocolEncoderFeron));
-
-    instance->base.protocol = &subghz_protocol_feron;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderFeron), &subghz_protocol_feron, 3, 256);
 }
 
 /**
@@ -168,10 +162,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_feron_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderFeron* instance = malloc(sizeof(SubGhzProtocolDecoderFeron));
-    instance->base.protocol = &subghz_protocol_feron;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderFeron), &subghz_protocol_feron);
 }
 
 void subghz_protocol_decoder_feron_feed(void* context, bool level, volatile uint32_t duration) {

--- a/lib/subghz/protocols/feron.c
+++ b/lib/subghz/protocols/feron.c
@@ -76,12 +76,18 @@ void* subghz_protocol_encoder_feron_alloc(SubGhzEnvironment* environment) {
         sizeof(SubGhzProtocolEncoderFeron), &subghz_protocol_feron, 3, 256);
 }
 
+static void subghz_protocol_feron_check_remote_controller(SubGhzBlockGeneric* instance);
+
 /**
  * Generating an upload from data.
- * @param instance Pointer to a SubGhzProtocolEncoderFeron instance
+ * @param context Pointer to a SubGhzProtocolEncoderFeron instance
+ * @return true Always; this encoder has no failure path
  */
-static void subghz_protocol_encoder_feron_get_upload(SubGhzProtocolEncoderFeron* instance) {
+static bool subghz_protocol_encoder_feron_get_upload(void* context) {
+    SubGhzProtocolEncoderFeron* instance = context;
     furi_assert(instance);
+
+    subghz_protocol_feron_check_remote_controller(&instance->generic);
     size_t index = 0;
 
     // Send key and GAP
@@ -124,7 +130,7 @@ static void subghz_protocol_encoder_feron_get_upload(SubGhzProtocolEncoderFeron*
     }
 
     instance->encoder.size_upload = index;
-    return;
+    return true;
 }
 
 /** 
@@ -137,27 +143,11 @@ static void subghz_protocol_feron_check_remote_controller(SubGhzBlockGeneric* in
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_feron_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderFeron* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_feron_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        subghz_protocol_feron_check_remote_controller(&instance->generic);
-        subghz_protocol_encoder_feron_get_upload(instance);
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_feron_const.min_count_bit_for_found,
+        subghz_protocol_encoder_feron_get_upload);
 }
 
 void* subghz_protocol_decoder_feron_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/gangqi.c
+++ b/lib/subghz/protocols/gangqi.c
@@ -23,6 +23,7 @@ struct SubGhzProtocolDecoderGangQi {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderGangQi);
 
 struct SubGhzProtocolEncoderGangQi {
     SubGhzProtocolEncoderBase base;
@@ -30,6 +31,7 @@ struct SubGhzProtocolEncoderGangQi {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderGangQi);
 
 typedef enum {
     GangQiDecoderStepReset = 0,
@@ -72,16 +74,8 @@ const SubGhzProtocol subghz_protocol_gangqi = {
 
 void* subghz_protocol_encoder_gangqi_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderGangQi* instance = malloc(sizeof(SubGhzProtocolEncoderGangQi));
-
-    instance->base.protocol = &subghz_protocol_gangqi;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderGangQi), &subghz_protocol_gangqi, 3, 256);
 }
 
 // Get custom button code
@@ -280,10 +274,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_gangqi_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderGangQi* instance = malloc(sizeof(SubGhzProtocolDecoderGangQi));
-    instance->base.protocol = &subghz_protocol_gangqi;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderGangQi), &subghz_protocol_gangqi);
 }
 
 void subghz_protocol_decoder_gangqi_feed(void* context, bool level, volatile uint32_t duration) {

--- a/lib/subghz/protocols/gate_tx.c
+++ b/lib/subghz/protocols/gate_tx.c
@@ -85,7 +85,8 @@ void* subghz_protocol_encoder_gate_tx_alloc(SubGhzEnvironment* environment) {
  * @param instance Pointer to a SubGhzProtocolEncoderGateTx instance
  * @return true On success
  */
-static bool subghz_protocol_encoder_gate_tx_get_upload(SubGhzProtocolEncoderGateTx* instance) {
+static bool subghz_protocol_encoder_gate_tx_get_upload(void* context) {
+    SubGhzProtocolEncoderGateTx* instance = context;
     furi_assert(instance);
     size_t index = 0;
     size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
@@ -122,29 +123,11 @@ static bool subghz_protocol_encoder_gate_tx_get_upload(SubGhzProtocolEncoderGate
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_gate_tx_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderGateTx* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_gate_tx_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        if(!subghz_protocol_encoder_gate_tx_get_upload(instance)) {
-            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
-            break;
-        }
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_gate_tx_const.min_count_bit_for_found,
+        subghz_protocol_encoder_gate_tx_get_upload);
 }
 
 void* subghz_protocol_decoder_gate_tx_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/gate_tx.c
+++ b/lib/subghz/protocols/gate_tx.c
@@ -83,7 +83,7 @@ void* subghz_protocol_encoder_gate_tx_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderGateTx instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_gate_tx_get_upload(void* context) {
     SubGhzProtocolEncoderGateTx* instance = context;

--- a/lib/subghz/protocols/gate_tx.c
+++ b/lib/subghz/protocols/gate_tx.c
@@ -22,6 +22,7 @@ struct SubGhzProtocolDecoderGateTx {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderGateTx);
 
 struct SubGhzProtocolEncoderGateTx {
     SubGhzProtocolEncoderBase base;
@@ -29,6 +30,7 @@ struct SubGhzProtocolEncoderGateTx {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderGateTx);
 
 typedef enum {
     GateTXDecoderStepReset = 0,
@@ -71,16 +73,11 @@ const SubGhzProtocol subghz_protocol_gate_tx = {
 
 void* subghz_protocol_encoder_gate_tx_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderGateTx* instance = malloc(sizeof(SubGhzProtocolEncoderGateTx));
-
-    instance->base.protocol = &subghz_protocol_gate_tx;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 52; //max 24bit*2 + 2 (start, stop)
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderGateTx),
+        &subghz_protocol_gate_tx,
+        3,
+        52); //max 24bit*2 + 2 (start, stop)
 }
 
 /**
@@ -152,10 +149,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_gate_tx_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderGateTx* instance = malloc(sizeof(SubGhzProtocolDecoderGateTx));
-    instance->base.protocol = &subghz_protocol_gate_tx;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderGateTx), &subghz_protocol_gate_tx);
 }
 
 void subghz_protocol_decoder_gate_tx_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/hay21.c
+++ b/lib/subghz/protocols/hay21.c
@@ -23,6 +23,7 @@ struct SubGhzProtocolDecoderHay21 {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderHay21);
 
 struct SubGhzProtocolEncoderHay21 {
     SubGhzProtocolEncoderBase base;
@@ -30,6 +31,7 @@ struct SubGhzProtocolEncoderHay21 {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderHay21);
 
 typedef enum {
     Hay21DecoderStepReset = 0,
@@ -71,16 +73,8 @@ const SubGhzProtocol subghz_protocol_hay21 = {
 
 void* subghz_protocol_encoder_hay21_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderHay21* instance = malloc(sizeof(SubGhzProtocolEncoderHay21));
-
-    instance->base.protocol = &subghz_protocol_hay21;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 64;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderHay21), &subghz_protocol_hay21, 3, 64);
 }
 
 // Get custom button code
@@ -294,10 +288,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_hay21_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderHay21* instance = malloc(sizeof(SubGhzProtocolDecoderHay21));
-    instance->base.protocol = &subghz_protocol_hay21;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderHay21), &subghz_protocol_hay21);
 }
 
 void subghz_protocol_decoder_hay21_feed(void* context, bool level, volatile uint32_t duration) {

--- a/lib/subghz/protocols/hollarm.c
+++ b/lib/subghz/protocols/hollarm.c
@@ -23,6 +23,7 @@ struct SubGhzProtocolDecoderHollarm {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderHollarm);
 
 struct SubGhzProtocolEncoderHollarm {
     SubGhzProtocolEncoderBase base;
@@ -30,6 +31,7 @@ struct SubGhzProtocolEncoderHollarm {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderHollarm);
 
 typedef enum {
     HollarmDecoderStepReset = 0,
@@ -72,16 +74,8 @@ const SubGhzProtocol subghz_protocol_hollarm = {
 
 void* subghz_protocol_encoder_hollarm_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderHollarm* instance = malloc(sizeof(SubGhzProtocolEncoderHollarm));
-
-    instance->base.protocol = &subghz_protocol_hollarm;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderHollarm), &subghz_protocol_hollarm, 3, 128);
 }
 
 // Get custom button code
@@ -281,10 +275,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_hollarm_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderHollarm* instance = malloc(sizeof(SubGhzProtocolDecoderHollarm));
-    instance->base.protocol = &subghz_protocol_hollarm;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderHollarm), &subghz_protocol_hollarm);
 }
 
 void subghz_protocol_decoder_hollarm_feed(void* context, bool level, volatile uint32_t duration) {

--- a/lib/subghz/protocols/holtek.c
+++ b/lib/subghz/protocols/holtek.c
@@ -93,7 +93,8 @@ void* subghz_protocol_encoder_holtek_alloc(SubGhzEnvironment* environment) {
  * @param instance Pointer to a SubGhzProtocolEncoderHoltek instance
  * @return true On success
  */
-static bool subghz_protocol_encoder_holtek_get_upload(SubGhzProtocolEncoderHoltek* instance) {
+static bool subghz_protocol_encoder_holtek_get_upload(void* context) {
+    SubGhzProtocolEncoderHoltek* instance = context;
     furi_assert(instance);
 
     size_t index = 0;
@@ -132,29 +133,11 @@ static bool subghz_protocol_encoder_holtek_get_upload(SubGhzProtocolEncoderHolte
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_holtek_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderHoltek* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_holtek_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        if(!subghz_protocol_encoder_holtek_get_upload(instance)) {
-            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
-            break;
-        }
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_holtek_const.min_count_bit_for_found,
+        subghz_protocol_encoder_holtek_get_upload);
 }
 
 void* subghz_protocol_decoder_holtek_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/holtek.c
+++ b/lib/subghz/protocols/holtek.c
@@ -32,6 +32,7 @@ struct SubGhzProtocolDecoderHoltek {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderHoltek);
 
 struct SubGhzProtocolEncoderHoltek {
     SubGhzProtocolEncoderBase base;
@@ -39,6 +40,7 @@ struct SubGhzProtocolEncoderHoltek {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderHoltek);
 
 typedef enum {
     HoltekDecoderStepReset = 0,
@@ -82,16 +84,8 @@ const SubGhzProtocol subghz_protocol_holtek = {
 
 void* subghz_protocol_encoder_holtek_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderHoltek* instance = malloc(sizeof(SubGhzProtocolEncoderHoltek));
-
-    instance->base.protocol = &subghz_protocol_holtek;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderHoltek), &subghz_protocol_holtek, 3, 128);
 }
 
 /**
@@ -165,10 +159,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_holtek_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderHoltek* instance = malloc(sizeof(SubGhzProtocolDecoderHoltek));
-    instance->base.protocol = &subghz_protocol_holtek;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderHoltek), &subghz_protocol_holtek);
 }
 
 void subghz_protocol_decoder_holtek_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/holtek.c
+++ b/lib/subghz/protocols/holtek.c
@@ -91,7 +91,7 @@ void* subghz_protocol_encoder_holtek_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderHoltek instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_holtek_get_upload(void* context) {
     SubGhzProtocolEncoderHoltek* instance = context;

--- a/lib/subghz/protocols/holtek_ht12x.c
+++ b/lib/subghz/protocols/holtek_ht12x.c
@@ -37,6 +37,7 @@ struct SubGhzProtocolDecoderHoltek_HT12X {
     uint32_t te;
     uint32_t last_data;
 };
+SUBGHZ_ASSERT_DECODER_TE_LAYOUT(SubGhzProtocolDecoderHoltek_HT12X);
 
 struct SubGhzProtocolEncoderHoltek_HT12X {
     SubGhzProtocolEncoderBase base;
@@ -62,7 +63,7 @@ const SubGhzProtocolDecoder subghz_protocol_holtek_th12x_decoder = {
     .reset = subghz_protocol_decoder_common_reset,
 
     .get_hash_data = subghz_protocol_decoder_common_get_hash_data,
-    .serialize = subghz_protocol_decoder_holtek_th12x_serialize,
+    .serialize = subghz_protocol_decoder_common_serialize_te,
     .deserialize = subghz_protocol_decoder_holtek_th12x_deserialize,
     .get_string = subghz_protocol_decoder_holtek_th12x_get_string,
 };
@@ -281,22 +282,6 @@ void subghz_protocol_decoder_holtek_th12x_feed(void* context, bool level, uint32
 static void subghz_protocol_holtek_th12x_check_remote_controller(SubGhzBlockGeneric* instance) {
     instance->btn = instance->data & 0x0F;
     instance->cnt = (instance->data >> 4) & 0xFF;
-}
-
-SubGhzProtocolStatus subghz_protocol_decoder_holtek_th12x_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset) {
-    furi_assert(context);
-    SubGhzProtocolDecoderHoltek_HT12X* instance = context;
-    SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
-    if((ret == SubGhzProtocolStatusOk) &&
-       !flipper_format_write_uint32(flipper_format, "TE", &instance->te, 1)) {
-        FURI_LOG_E(TAG, "Unable to add TE");
-        ret = SubGhzProtocolStatusErrorParserTe;
-    }
-    return ret;
 }
 
 SubGhzProtocolStatus

--- a/lib/subghz/protocols/holtek_ht12x.c
+++ b/lib/subghz/protocols/holtek_ht12x.c
@@ -47,6 +47,7 @@ struct SubGhzProtocolEncoderHoltek_HT12X {
 
     uint32_t te;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderHoltek_HT12X);
 
 typedef enum {
     Holtek_HT12XDecoderStepReset = 0,
@@ -90,17 +91,8 @@ const SubGhzProtocol subghz_protocol_holtek_th12x = {
 
 void* subghz_protocol_encoder_holtek_th12x_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderHoltek_HT12X* instance =
-        malloc(sizeof(SubGhzProtocolEncoderHoltek_HT12X));
-
-    instance->base.protocol = &subghz_protocol_holtek_th12x;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderHoltek_HT12X), &subghz_protocol_holtek_th12x, 3, 128);
 }
 
 /**
@@ -181,11 +173,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_holtek_th12x_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderHoltek_HT12X* instance =
-        malloc(sizeof(SubGhzProtocolDecoderHoltek_HT12X));
-    instance->base.protocol = &subghz_protocol_holtek_th12x;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderHoltek_HT12X), &subghz_protocol_holtek_th12x);
 }
 
 void subghz_protocol_decoder_holtek_th12x_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/holtek_ht12x.c
+++ b/lib/subghz/protocols/holtek_ht12x.c
@@ -275,29 +275,8 @@ static void subghz_protocol_holtek_th12x_check_remote_controller(SubGhzBlockGene
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_holtek_th12x_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolDecoderHoltek_HT12X* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_holtek_th12x_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        if(!flipper_format_rewind(flipper_format)) {
-            FURI_LOG_E(TAG, "Rewind error");
-            ret = SubGhzProtocolStatusErrorParserOthers;
-            break;
-        }
-        if(!flipper_format_read_uint32(flipper_format, "TE", (uint32_t*)&instance->te, 1)) {
-            FURI_LOG_E(TAG, "Missing TE");
-            ret = SubGhzProtocolStatusErrorParserTe;
-            break;
-        }
-    } while(false);
-    return ret;
+    return subghz_protocol_decoder_common_deserialize_te(
+        context, flipper_format, subghz_protocol_holtek_th12x_const.min_count_bit_for_found);
 }
 
 static void subghz_protocol_holtek_th12x_event_serialize(uint8_t event, FuriString* output) {

--- a/lib/subghz/protocols/holtek_ht12x.h
+++ b/lib/subghz/protocols/holtek_ht12x.h
@@ -43,18 +43,6 @@ void* subghz_protocol_decoder_holtek_th12x_alloc(SubGhzEnvironment* environment)
 void subghz_protocol_decoder_holtek_th12x_feed(void* context, bool level, uint32_t duration);
 
 /**
- * Serialize data SubGhzProtocolDecoderHoltek_HT12X.
- * @param context Pointer to a SubGhzProtocolDecoderHoltek_HT12X instance
- * @param flipper_format Pointer to a FlipperFormat instance
- * @param preset The modulation on which the signal was received, SubGhzRadioPreset
- * @return status
- */
-SubGhzProtocolStatus subghz_protocol_decoder_holtek_th12x_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset);
-
-/**
  * Deserialize data SubGhzProtocolDecoderHoltek_HT12X.
  * @param context Pointer to a SubGhzProtocolDecoderHoltek_HT12X instance
  * @param flipper_format Pointer to a FlipperFormat instance

--- a/lib/subghz/protocols/honeywell.c
+++ b/lib/subghz/protocols/honeywell.c
@@ -7,6 +7,7 @@
 #include "../blocks/encoder.h"
 #include "../blocks/generic.h"
 #include "../blocks/math.h"
+#include "common.h"
 
 // Created by HTotoo 2023-10-30
 // Got a lot of help from LiQuiDz.
@@ -40,34 +41,36 @@ static const SubGhzBlockConst subghz_protocol_honeywell_const = {
 
 struct SubGhzProtocolDecoderHoneywell {
     SubGhzProtocolDecoderBase base;
-    SubGhzBlockGeneric generic;
     SubGhzBlockDecoder decoder;
+    SubGhzBlockGeneric generic;
     ManchesterState manchester_saved_state;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderHoneywell);
 
 struct SubGhzProtocolEncoderHoneywell {
     SubGhzProtocolEncoderBase base;
-    SubGhzBlockGeneric generic;
     SubGhzProtocolBlockEncoder encoder;
+    SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderHoneywell);
 
 const SubGhzProtocolDecoder subghz_protocol_honeywell_decoder = {
     .alloc = subghz_protocol_decoder_honeywell_alloc,
-    .free = subghz_protocol_decoder_honeywell_free,
+    .free = subghz_protocol_decoder_common_free,
     .feed = subghz_protocol_decoder_honeywell_feed,
     .reset = subghz_protocol_decoder_honeywell_reset,
-    .get_hash_data = subghz_protocol_decoder_honeywell_get_hash_data,
-    .serialize = subghz_protocol_decoder_honeywell_serialize,
+    .get_hash_data = subghz_protocol_decoder_common_get_hash_data,
+    .serialize = subghz_protocol_decoder_common_serialize,
     .deserialize = subghz_protocol_decoder_honeywell_deserialize,
     .get_string = subghz_protocol_decoder_honeywell_get_string,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_honeywell_encoder = {
     .alloc = subghz_protocol_encoder_honeywell_alloc,
-    .free = subghz_protocol_encoder_honeywell_free,
+    .free = subghz_protocol_encoder_common_free,
     .deserialize = subghz_protocol_encoder_honeywell_deserialize,
-    .stop = subghz_protocol_encoder_honeywell_stop,
-    .yield = subghz_protocol_encoder_honeywell_yield,
+    .stop = subghz_protocol_encoder_common_stop,
+    .yield = subghz_protocol_encoder_common_yield,
 };
 
 const SubGhzProtocol subghz_protocol_honeywell = {
@@ -103,19 +106,6 @@ void* subghz_protocol_encoder_honeywell_alloc(SubGhzEnvironment* environment) {
     instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
     instance->encoder.is_running = false;
     return instance;
-}
-
-void subghz_protocol_encoder_honeywell_free(void* context) {
-    furi_assert(context);
-    SubGhzProtocolEncoderHoneywell* instance = context;
-    free(instance->encoder.upload);
-    free(instance);
-}
-
-void subghz_protocol_decoder_honeywell_free(void* context) {
-    furi_assert(context);
-    SubGhzProtocolDecoderHoneywell* instance = context;
-    free(instance);
 }
 
 uint16_t subghz_protocol_honeywell_crc16(
@@ -230,26 +220,6 @@ SubGhzProtocolStatus
     return res;
 }
 
-void subghz_protocol_encoder_honeywell_stop(void* context) {
-    SubGhzProtocolEncoderHoneywell* instance = context;
-    instance->encoder.is_running = false;
-}
-
-LevelDuration subghz_protocol_encoder_honeywell_yield(void* context) {
-    SubGhzProtocolEncoderHoneywell* instance = context;
-
-    if(instance->encoder.repeat == 0 || !instance->encoder.is_running) {
-        instance->encoder.is_running = false;
-        return level_duration_reset();
-    }
-    LevelDuration ret = instance->encoder.upload[instance->encoder.front];
-    if(++instance->encoder.front == instance->encoder.size_upload) {
-        if(!subghz_block_generic_global.endless_tx) instance->encoder.repeat--;
-        instance->encoder.front = 0;
-    }
-    return ret;
-}
-
 void subghz_protocol_decoder_honeywell_reset(void* context) {
     furi_assert(context);
     SubGhzProtocolDecoderHoneywell* instance = context;
@@ -349,22 +319,6 @@ static void subghz_protocol_decoder_honeywell_addbit(void* context, bool data) {
         instance->decoder.decode_count_bit = 0;
         return;
     }
-}
-
-uint8_t subghz_protocol_decoder_honeywell_get_hash_data(void* context) {
-    furi_assert(context);
-    SubGhzProtocolDecoderHoneywell* instance = context;
-    return subghz_protocol_blocks_get_hash_data(
-        &instance->decoder, (instance->decoder.decode_count_bit / 8) + 1);
-}
-
-SubGhzProtocolStatus subghz_protocol_decoder_honeywell_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset) {
-    furi_assert(context);
-    SubGhzProtocolDecoderHoneywell* instance = context;
-    return subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
 }
 
 SubGhzProtocolStatus

--- a/lib/subghz/protocols/honeywell.c
+++ b/lib/subghz/protocols/honeywell.c
@@ -52,7 +52,7 @@ struct SubGhzProtocolEncoderHoneywell {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
-SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderHoneywell);
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderHoneywell);
 
 const SubGhzProtocolDecoder subghz_protocol_honeywell_decoder = {
     .alloc = subghz_protocol_decoder_honeywell_alloc,
@@ -88,24 +88,14 @@ static void subghz_protocol_decoder_honeywell_addbit(void* context, bool data);
 
 void* subghz_protocol_decoder_honeywell_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderHoneywell* instance = malloc(sizeof(SubGhzProtocolDecoderHoneywell));
-    instance->base.protocol = &subghz_protocol_honeywell;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderHoneywell), &subghz_protocol_honeywell);
 }
 
 void* subghz_protocol_encoder_honeywell_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderHoneywell* instance = malloc(sizeof(SubGhzProtocolEncoderHoneywell));
-
-    instance->base.protocol = &subghz_protocol_honeywell;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 4;
-    instance->encoder.size_upload = 64 * 2 + 10;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderHoneywell), &subghz_protocol_honeywell, 4, 64 * 2 + 10);
 }
 
 uint16_t subghz_protocol_honeywell_crc16(

--- a/lib/subghz/protocols/honeywell.h
+++ b/lib/subghz/protocols/honeywell.h
@@ -19,12 +19,6 @@ extern const SubGhzProtocol subghz_protocol_honeywell;
 void* subghz_protocol_encoder_honeywell_alloc(SubGhzEnvironment* environment);
 
 /**
- * Free SubGhzProtocolEncoderHoneywell.
- * @param context Pointer to a SubGhzProtocolEncoderHoneywell instance
- */
-void subghz_protocol_encoder_honeywell_free(void* context);
-
-/**
  * Deserialize and generating an upload to send.
  * @param context Pointer to a SubGhzProtocolEncoderHoneywell instance
  * @param flipper_format Pointer to a FlipperFormat instance
@@ -34,30 +28,11 @@ SubGhzProtocolStatus
     subghz_protocol_encoder_honeywell_deserialize(void* context, FlipperFormat* flipper_format);
 
 /**
- * Forced transmission stop.
- * @param context Pointer to a SubGhzProtocolEncoderHoneywell instance
- */
-void subghz_protocol_encoder_honeywell_stop(void* context);
-
-/**
- * Getting the level and duration of the upload to be loaded into DMA.
- * @param context Pointer to a SubGhzProtocolEncoderHoneywell instance
- * @return LevelDuration 
- */
-LevelDuration subghz_protocol_encoder_honeywell_yield(void* context);
-
-/**
  * Allocate SubGhzProtocolDecoderHoneywell.
  * @param environment Pointer to a SubGhzEnvironment instance
  * @return SubGhzProtocolDecoderHoneywell* pointer to a SubGhzProtocolDecoderHoneywell instance
  */
 void* subghz_protocol_decoder_honeywell_alloc(SubGhzEnvironment* environment);
-
-/**
- * Free SubGhzProtocolDecoderHoneywell.
- * @param context Pointer to a SubGhzProtocolDecoderHoneywell instance
- */
-void subghz_protocol_decoder_honeywell_free(void* context);
 
 /**
  * Reset decoder SubGhzProtocolDecoderHoneywell.
@@ -72,25 +47,6 @@ void subghz_protocol_decoder_honeywell_reset(void* context);
  * @param duration Duration of this level in, us
  */
 void subghz_protocol_decoder_honeywell_feed(void* context, bool level, uint32_t duration);
-
-/**
- * Getting the hash sum of the last randomly received parcel.
- * @param context Pointer to a SubGhzProtocolDecoderHoneywell instance
- * @return hash Hash sum
- */
-uint8_t subghz_protocol_decoder_honeywell_get_hash_data(void* context);
-
-/**
- * Serialize data SubGhzProtocolDecoderHoneywell.
- * @param context Pointer to a SubGhzProtocolDecoderHoneywell instance
- * @param flipper_format Pointer to a FlipperFormat instance
- * @param preset The modulation on which the signal was received, SubGhzRadioPreset
- * @return status
- */
-SubGhzProtocolStatus subghz_protocol_decoder_honeywell_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset);
 
 /**
  * Deserialize data SubGhzProtocolDecoderHoneywell.

--- a/lib/subghz/protocols/honeywell_wdb.c
+++ b/lib/subghz/protocols/honeywell_wdb.c
@@ -94,8 +94,8 @@ void* subghz_protocol_encoder_honeywell_wdb_alloc(SubGhzEnvironment* environment
  * @param instance Pointer to a SubGhzProtocolEncoderHoneywell_WDB instance
  * @return true On success
  */
-static bool subghz_protocol_encoder_honeywell_wdb_get_upload(
-    SubGhzProtocolEncoderHoneywell_WDB* instance) {
+static bool subghz_protocol_encoder_honeywell_wdb_get_upload(void* context) {
+    SubGhzProtocolEncoderHoneywell_WDB* instance = context;
     furi_assert(instance);
     size_t index = 0;
     size_t size_upload = (instance->generic.data_count_bit * 2) + 2;
@@ -132,29 +132,11 @@ static bool subghz_protocol_encoder_honeywell_wdb_get_upload(
 SubGhzProtocolStatus subghz_protocol_encoder_honeywell_wdb_deserialize(
     void* context,
     FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderHoneywell_WDB* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_honeywell_wdb_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        if(!subghz_protocol_encoder_honeywell_wdb_get_upload(instance)) {
-            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
-            break;
-        }
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_honeywell_wdb_const.min_count_bit_for_found,
+        subghz_protocol_encoder_honeywell_wdb_get_upload);
 }
 
 void* subghz_protocol_decoder_honeywell_wdb_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/honeywell_wdb.c
+++ b/lib/subghz/protocols/honeywell_wdb.c
@@ -33,6 +33,7 @@ struct SubGhzProtocolDecoderHoneywell_WDB {
     uint8_t relay;
     uint8_t lowbat;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderHoneywell_WDB);
 
 struct SubGhzProtocolEncoderHoneywell_WDB {
     SubGhzProtocolEncoderBase base;
@@ -40,6 +41,7 @@ struct SubGhzProtocolEncoderHoneywell_WDB {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderHoneywell_WDB);
 
 typedef enum {
     Honeywell_WDBDecoderStepReset = 0,
@@ -83,17 +85,8 @@ const SubGhzProtocol subghz_protocol_honeywell_wdb = {
 
 void* subghz_protocol_encoder_honeywell_wdb_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderHoneywell_WDB* instance =
-        malloc(sizeof(SubGhzProtocolEncoderHoneywell_WDB));
-
-    instance->base.protocol = &subghz_protocol_honeywell_wdb;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderHoneywell_WDB), &subghz_protocol_honeywell_wdb, 3, 128);
 }
 
 /**
@@ -166,11 +159,8 @@ SubGhzProtocolStatus subghz_protocol_encoder_honeywell_wdb_deserialize(
 
 void* subghz_protocol_decoder_honeywell_wdb_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderHoneywell_WDB* instance =
-        malloc(sizeof(SubGhzProtocolDecoderHoneywell_WDB));
-    instance->base.protocol = &subghz_protocol_honeywell_wdb;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderHoneywell_WDB), &subghz_protocol_honeywell_wdb);
 }
 
 void subghz_protocol_decoder_honeywell_wdb_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/honeywell_wdb.c
+++ b/lib/subghz/protocols/honeywell_wdb.c
@@ -92,7 +92,7 @@ void* subghz_protocol_encoder_honeywell_wdb_alloc(SubGhzEnvironment* environment
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderHoneywell_WDB instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_honeywell_wdb_get_upload(void* context) {
     SubGhzProtocolEncoderHoneywell_WDB* instance = context;

--- a/lib/subghz/protocols/hormann.c
+++ b/lib/subghz/protocols/hormann.c
@@ -24,6 +24,7 @@ struct SubGhzProtocolDecoderHormann {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderHormann);
 
 struct SubGhzProtocolEncoderHormann {
     SubGhzProtocolEncoderBase base;
@@ -31,6 +32,7 @@ struct SubGhzProtocolEncoderHormann {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderHormann);
 
 typedef enum {
     HormannDecoderStepReset = 0,
@@ -76,16 +78,8 @@ const SubGhzProtocol subghz_protocol_hormann = {
 
 void* subghz_protocol_encoder_hormann_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderHormann* instance = malloc(sizeof(SubGhzProtocolEncoderHormann));
-
-    instance->base.protocol = &subghz_protocol_hormann;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 1;
-    instance->encoder.size_upload = 1850; // 1801
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderHormann), &subghz_protocol_hormann, 1, 1850); // 1801
 }
 
 /**
@@ -170,10 +164,8 @@ void subghz_protocol_encoder_hormann_stop(void* context) {
 
 void* subghz_protocol_decoder_hormann_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderHormann* instance = malloc(sizeof(SubGhzProtocolDecoderHormann));
-    instance->base.protocol = &subghz_protocol_hormann;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderHormann), &subghz_protocol_hormann);
 }
 
 static bool subghz_protocol_decoder_hormann_check_pattern(SubGhzProtocolDecoderHormann* instance) {

--- a/lib/subghz/protocols/hormann.c
+++ b/lib/subghz/protocols/hormann.c
@@ -85,7 +85,7 @@ void* subghz_protocol_encoder_hormann_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderHormann instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_hormann_get_upload(SubGhzProtocolEncoderHormann* instance) {
     furi_assert(instance);

--- a/lib/subghz/protocols/ido.c
+++ b/lib/subghz/protocols/ido.c
@@ -22,6 +22,7 @@ struct SubGhzProtocolDecoderIDo {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderIDo);
 
 struct SubGhzProtocolEncoderIDo {
     SubGhzProtocolEncoderBase base;
@@ -71,11 +72,8 @@ const SubGhzProtocol subghz_protocol_ido = {
 
 void* subghz_protocol_decoder_ido_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderIDo* instance = malloc(sizeof(SubGhzProtocolDecoderIDo));
-    instance->base.protocol = &subghz_protocol_ido;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderIDo), &subghz_protocol_ido);
 }
 
 void subghz_protocol_decoder_ido_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/intertechno_v3.c
+++ b/lib/subghz/protocols/intertechno_v3.c
@@ -90,7 +90,7 @@ void* subghz_protocol_encoder_intertechno_v3_alloc(SubGhzEnvironment* environmen
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderIntertechno_V3 instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_intertechno_v3_get_upload(
     SubGhzProtocolEncoderIntertechno_V3* instance) {

--- a/lib/subghz/protocols/intertechno_v3.c
+++ b/lib/subghz/protocols/intertechno_v3.c
@@ -28,6 +28,7 @@ struct SubGhzProtocolDecoderIntertechno_V3 {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderIntertechno_V3);
 
 struct SubGhzProtocolEncoderIntertechno_V3 {
     SubGhzProtocolEncoderBase base;
@@ -35,6 +36,7 @@ struct SubGhzProtocolEncoderIntertechno_V3 {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderIntertechno_V3);
 
 typedef enum {
     IntertechnoV3DecoderStepReset = 0,
@@ -81,17 +83,8 @@ const SubGhzProtocol subghz_protocol_intertechno_v3 = {
 
 void* subghz_protocol_encoder_intertechno_v3_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderIntertechno_V3* instance =
-        malloc(sizeof(SubGhzProtocolEncoderIntertechno_V3));
-
-    instance->base.protocol = &subghz_protocol_intertechno_v3;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderIntertechno_V3), &subghz_protocol_intertechno_v3, 3, 256);
 }
 
 /**
@@ -192,11 +185,8 @@ void subghz_protocol_encoder_intertechno_v3_stop(void* context) {
 
 void* subghz_protocol_decoder_intertechno_v3_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderIntertechno_V3* instance =
-        malloc(sizeof(SubGhzProtocolDecoderIntertechno_V3));
-    instance->base.protocol = &subghz_protocol_intertechno_v3;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderIntertechno_V3), &subghz_protocol_intertechno_v3);
 }
 
 void subghz_protocol_decoder_intertechno_v3_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/jarolift.c
+++ b/lib/subghz/protocols/jarolift.c
@@ -30,6 +30,7 @@ struct SubGhzProtocolDecoderJarolift {
     uint16_t header_count;
     SubGhzKeystore* keystore;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderJarolift);
 
 struct SubGhzProtocolEncoderJarolift {
     SubGhzProtocolEncoderBase base;
@@ -54,7 +55,7 @@ const SubGhzProtocolDecoder subghz_protocol_jarolift_decoder = {
     .reset = subghz_protocol_decoder_common_reset,
 
     .get_hash_data = subghz_protocol_decoder_jarolift_get_hash_data,
-    .serialize = subghz_protocol_decoder_jarolift_serialize,
+    .serialize = subghz_protocol_decoder_common_serialize_data_2,
     .deserialize = subghz_protocol_decoder_jarolift_deserialize,
     .get_string = subghz_protocol_decoder_jarolift_get_string,
 };
@@ -227,21 +228,7 @@ bool subghz_protocol_jarolift_create_data(
     SubGhzProtocolStatus res =
         subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
 
-    uint8_t key_data[sizeof(uint64_t)] = {0};
-    for(size_t i = 0; i < sizeof(uint64_t); i++) {
-        key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data_2 >> (i * 8)) & 0xFF;
-    }
-
-    if(!flipper_format_rewind(flipper_format)) {
-        FURI_LOG_E(TAG, "Rewind error");
-        res = SubGhzProtocolStatusErrorParserOthers;
-    }
-
-    if((res == SubGhzProtocolStatusOk) &&
-       !flipper_format_insert_or_update_hex(flipper_format, "Data", key_data, sizeof(uint64_t))) {
-        FURI_LOG_E(TAG, "Unable to add Data2");
-        res = SubGhzProtocolStatusErrorParserOthers;
-    }
+    res = subghz_protocol_common_append_data_2(res, &instance->generic, flipper_format);
 
     return res == SubGhzProtocolStatusOk;
 }
@@ -585,33 +572,6 @@ uint8_t subghz_protocol_decoder_jarolift_get_hash_data(void* context) {
         hash ^= p[i];
     }
     return hash;
-}
-
-SubGhzProtocolStatus subghz_protocol_decoder_jarolift_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset) {
-    furi_assert(context);
-    SubGhzProtocolDecoderJarolift* instance = context;
-    SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
-
-    uint8_t key_data[sizeof(uint64_t)] = {0};
-    for(size_t i = 0; i < sizeof(uint64_t); i++) {
-        key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data_2 >> (i * 8)) & 0xFF;
-    }
-
-    if(!flipper_format_rewind(flipper_format)) {
-        FURI_LOG_E(TAG, "Rewind error");
-        ret = SubGhzProtocolStatusErrorParserOthers;
-    }
-
-    if((ret == SubGhzProtocolStatusOk) &&
-       !flipper_format_insert_or_update_hex(flipper_format, "Data", key_data, sizeof(uint64_t))) {
-        FURI_LOG_E(TAG, "Unable to add Data");
-        ret = SubGhzProtocolStatusErrorParserOthers;
-    }
-    return ret;
 }
 
 SubGhzProtocolStatus

--- a/lib/subghz/protocols/jarolift.c
+++ b/lib/subghz/protocols/jarolift.c
@@ -39,7 +39,7 @@ struct SubGhzProtocolEncoderJarolift {
     SubGhzBlockGeneric generic;
     SubGhzKeystore* keystore;
 };
-SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderJarolift);
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderJarolift);
 
 typedef enum {
     JaroliftDecoderStepReset = 0,
@@ -97,17 +97,9 @@ static void subghz_protocol_jarolift_remote_controller(
 static uint8_t subghz_protocol_jarolift_get_btn_code(void);
 
 void* subghz_protocol_encoder_jarolift_alloc(SubGhzEnvironment* environment) {
-    SubGhzProtocolEncoderJarolift* instance = malloc(sizeof(SubGhzProtocolEncoderJarolift));
-
-    instance->base.protocol = &subghz_protocol_jarolift;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolEncoderJarolift* instance = subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderJarolift), &subghz_protocol_jarolift, 3, 256);
     instance->keystore = subghz_environment_get_keystore(environment);
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-
     return instance;
 }
 
@@ -237,7 +229,7 @@ bool subghz_protocol_jarolift_create_data(
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderJarolift instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_jarolift_get_upload(
     SubGhzProtocolEncoderJarolift* instance,
@@ -375,13 +367,9 @@ SubGhzProtocolStatus
     return res;
 }
 
-//
-// Decoder
-//
 void* subghz_protocol_decoder_jarolift_alloc(SubGhzEnvironment* environment) {
-    SubGhzProtocolDecoderJarolift* instance = malloc(sizeof(SubGhzProtocolDecoderJarolift));
-    instance->base.protocol = &subghz_protocol_jarolift;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolDecoderJarolift* instance = subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderJarolift), &subghz_protocol_jarolift);
     instance->keystore = subghz_environment_get_keystore(environment);
     return instance;
 }

--- a/lib/subghz/protocols/jarolift.c
+++ b/lib/subghz/protocols/jarolift.c
@@ -39,6 +39,7 @@ struct SubGhzProtocolEncoderJarolift {
     SubGhzBlockGeneric generic;
     SubGhzKeystore* keystore;
 };
+SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderJarolift);
 
 typedef enum {
     JaroliftDecoderStepReset = 0,

--- a/lib/subghz/protocols/jarolift.h
+++ b/lib/subghz/protocols/jarolift.h
@@ -49,18 +49,6 @@ void subghz_protocol_decoder_jarolift_feed(void* context, bool level, uint32_t d
 uint8_t subghz_protocol_decoder_jarolift_get_hash_data(void* context);
 
 /**
- * Serialize data SubGhzProtocolDecoderJarolift.
- * @param context Pointer to a SubGhzProtocolDecoderJarolift instance
- * @param flipper_format Pointer to a FlipperFormat instance
- * @param preset The modulation on which the signal was received, SubGhzRadioPreset
- * @return status
- */
-SubGhzProtocolStatus subghz_protocol_decoder_jarolift_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset);
-
-/**
  * Deserialize data SubGhzProtocolDecoderJarolift.
  * @param context Pointer to a SubGhzProtocolDecoderJarolift instance
  * @param flipper_format Pointer to a FlipperFormat instance

--- a/lib/subghz/protocols/keeloq.c
+++ b/lib/subghz/protocols/keeloq.c
@@ -38,6 +38,7 @@ struct SubGhzProtocolDecoderKeeloq {
 
     FuriString* manufacture_from_file;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderKeeloq);
 
 struct SubGhzProtocolEncoderKeeloq {
     SubGhzProtocolEncoderBase base;
@@ -50,6 +51,7 @@ struct SubGhzProtocolEncoderKeeloq {
 
     FuriString* manufacture_from_file;
 };
+SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderKeeloq);
 
 typedef enum {
     KeeloqDecoderStepReset = 0,

--- a/lib/subghz/protocols/keeloq.c
+++ b/lib/subghz/protocols/keeloq.c
@@ -51,7 +51,7 @@ struct SubGhzProtocolEncoderKeeloq {
 
     FuriString* manufacture_from_file;
 };
-SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderKeeloq);
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderKeeloq);
 
 typedef enum {
     KeeloqDecoderStepReset = 0,
@@ -115,19 +115,10 @@ static uint32_t subghz_protocol_keeloq_check_remote_controller(
 static uint8_t subghz_protocol_keeloq_get_btn_code(uint8_t last_btn_code);
 
 void* subghz_protocol_encoder_keeloq_alloc(SubGhzEnvironment* environment) {
-    SubGhzProtocolEncoderKeeloq* instance = malloc(sizeof(SubGhzProtocolEncoderKeeloq));
-
-    instance->base.protocol = &subghz_protocol_keeloq;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolEncoderKeeloq* instance = subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderKeeloq), &subghz_protocol_keeloq, 3, 1100);
     instance->keystore = subghz_environment_get_keystore(environment);
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 1100;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-
     instance->manufacture_from_file = furi_string_alloc();
-
     return instance;
 }
 
@@ -840,14 +831,12 @@ void subghz_protocol_encoder_keeloq_stop(void* context) {
 }
 
 void* subghz_protocol_decoder_keeloq_alloc(SubGhzEnvironment* environment) {
-    SubGhzProtocolDecoderKeeloq* instance = malloc(sizeof(SubGhzProtocolDecoderKeeloq));
-    instance->base.protocol = &subghz_protocol_keeloq;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolDecoderKeeloq* instance = subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderKeeloq), &subghz_protocol_keeloq);
     instance->keystore = subghz_environment_get_keystore(environment);
     instance->manufacture_from_file = furi_string_alloc();
 
     subghz_custom_btn_set_prog_mode(PROG_MODE_OFF);
-
     return instance;
 }
 

--- a/lib/subghz/protocols/keyfinder.c
+++ b/lib/subghz/protocols/keyfinder.c
@@ -77,13 +77,18 @@ void* subghz_protocol_encoder_keyfinder_alloc(SubGhzEnvironment* environment) {
         sizeof(SubGhzProtocolEncoderKeyFinder), &subghz_protocol_keyfinder, 5, 60);
 }
 
+static void subghz_protocol_keyfinder_check_remote_controller(SubGhzBlockGeneric* instance);
+
 /**
  * Generating an upload from data.
- * @param instance Pointer to a SubGhzProtocolEncoderKeyFinder instance
+ * @param context Pointer to a SubGhzProtocolEncoderKeyFinder instance
+ * @return true Always; this encoder has no failure path
  */
-static void
-    subghz_protocol_encoder_keyfinder_get_upload(SubGhzProtocolEncoderKeyFinder* instance) {
+static bool subghz_protocol_encoder_keyfinder_get_upload(void* context) {
+    SubGhzProtocolEncoderKeyFinder* instance = context;
     furi_assert(instance);
+
+    subghz_protocol_keyfinder_check_remote_controller(&instance->generic);
     size_t index = 0;
 
     // Send key data 24 bit first
@@ -116,7 +121,7 @@ static void
         level_duration_make(false, (uint32_t)subghz_protocol_keyfinder_const.te_short * 10);
 
     instance->encoder.size_upload = index;
-    return;
+    return true;
 }
 
 /** 
@@ -130,27 +135,11 @@ static void subghz_protocol_keyfinder_check_remote_controller(SubGhzBlockGeneric
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_keyfinder_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderKeyFinder* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_keyfinder_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        subghz_protocol_keyfinder_check_remote_controller(&instance->generic);
-        subghz_protocol_encoder_keyfinder_get_upload(instance);
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_keyfinder_const.min_count_bit_for_found,
+        subghz_protocol_encoder_keyfinder_get_upload);
 }
 
 void* subghz_protocol_decoder_keyfinder_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/keyfinder.c
+++ b/lib/subghz/protocols/keyfinder.c
@@ -22,6 +22,7 @@ struct SubGhzProtocolDecoderKeyFinder {
     SubGhzBlockGeneric generic;
     uint8_t end_count;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderKeyFinder);
 
 struct SubGhzProtocolEncoderKeyFinder {
     SubGhzProtocolEncoderBase base;
@@ -29,6 +30,7 @@ struct SubGhzProtocolEncoderKeyFinder {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderKeyFinder);
 
 typedef enum {
     KeyFinderDecoderStepReset = 0,
@@ -71,16 +73,8 @@ const SubGhzProtocol subghz_protocol_keyfinder = {
 
 void* subghz_protocol_encoder_keyfinder_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderKeyFinder* instance = malloc(sizeof(SubGhzProtocolEncoderKeyFinder));
-
-    instance->base.protocol = &subghz_protocol_keyfinder;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 5;
-    instance->encoder.size_upload = 60;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderKeyFinder), &subghz_protocol_keyfinder, 5, 60);
 }
 
 /**
@@ -161,10 +155,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_keyfinder_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderKeyFinder* instance = malloc(sizeof(SubGhzProtocolDecoderKeyFinder));
-    instance->base.protocol = &subghz_protocol_keyfinder;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderKeyFinder), &subghz_protocol_keyfinder);
 }
 
 void subghz_protocol_decoder_keyfinder_feed(void* context, bool level, volatile uint32_t duration) {

--- a/lib/subghz/protocols/kinggates_stylo_4k.c
+++ b/lib/subghz/protocols/kinggates_stylo_4k.c
@@ -29,6 +29,7 @@ struct SubGhzProtocolDecoderKingGates_stylo_4k {
     uint16_t header_count;
     SubGhzKeystore* keystore;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderKingGates_stylo_4k);
 
 struct SubGhzProtocolEncoderKingGates_stylo_4k {
     SubGhzProtocolEncoderBase base;
@@ -54,7 +55,7 @@ const SubGhzProtocolDecoder subghz_protocol_kinggates_stylo_4k_decoder = {
     .reset = subghz_protocol_decoder_common_reset,
 
     .get_hash_data = subghz_protocol_decoder_common_get_hash_data,
-    .serialize = subghz_protocol_decoder_kinggates_stylo_4k_serialize,
+    .serialize = subghz_protocol_decoder_common_serialize_data_2,
     .deserialize = subghz_protocol_decoder_kinggates_stylo_4k_deserialize,
     .get_string = subghz_protocol_decoder_kinggates_stylo_4k_get_string,
 };
@@ -213,21 +214,7 @@ bool subghz_protocol_kinggates_stylo_4k_create_data(
     SubGhzProtocolStatus res =
         subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
 
-    uint8_t key_data[sizeof(uint64_t)] = {0};
-    for(size_t i = 0; i < sizeof(uint64_t); i++) {
-        key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data_2 >> (i * 8)) & 0xFF;
-    }
-
-    if(!flipper_format_rewind(flipper_format)) {
-        FURI_LOG_E(TAG, "Rewind error");
-        res = SubGhzProtocolStatusErrorParserOthers;
-    }
-
-    if((res == SubGhzProtocolStatusOk) &&
-       !flipper_format_insert_or_update_hex(flipper_format, "Data", key_data, sizeof(uint64_t))) {
-        FURI_LOG_E(TAG, "Unable to add Data2");
-        res = SubGhzProtocolStatusErrorParserOthers;
-    }
+    res = subghz_protocol_common_append_data_2(res, &instance->generic, flipper_format);
 
     return res == SubGhzProtocolStatusOk;
 }
@@ -544,33 +531,6 @@ static void subghz_protocol_kinggates_stylo_4k_remote_controller(
         instance->serial = 0;
         instance->cnt = 0;
     }
-}
-
-SubGhzProtocolStatus subghz_protocol_decoder_kinggates_stylo_4k_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset) {
-    furi_assert(context);
-    SubGhzProtocolDecoderKingGates_stylo_4k* instance = context;
-    SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
-
-    uint8_t key_data[sizeof(uint64_t)] = {0};
-    for(size_t i = 0; i < sizeof(uint64_t); i++) {
-        key_data[sizeof(uint64_t) - i - 1] = (instance->generic.data_2 >> (i * 8)) & 0xFF;
-    }
-
-    if(!flipper_format_rewind(flipper_format)) {
-        FURI_LOG_E(TAG, "Rewind error");
-        ret = SubGhzProtocolStatusErrorParserOthers;
-    }
-
-    if((ret == SubGhzProtocolStatusOk) &&
-       !flipper_format_insert_or_update_hex(flipper_format, "Data", key_data, sizeof(uint64_t))) {
-        FURI_LOG_E(TAG, "Unable to add Data");
-        ret = SubGhzProtocolStatusErrorParserOthers;
-    }
-    return ret;
 }
 
 SubGhzProtocolStatus subghz_protocol_decoder_kinggates_stylo_4k_deserialize(

--- a/lib/subghz/protocols/kinggates_stylo_4k.c
+++ b/lib/subghz/protocols/kinggates_stylo_4k.c
@@ -223,7 +223,7 @@ bool subghz_protocol_kinggates_stylo_4k_create_data(
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderKingGates_stylo_4k instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_kinggates_stylo_4k_get_upload(
     SubGhzProtocolEncoderKingGates_stylo_4k* instance,
@@ -361,14 +361,9 @@ SubGhzProtocolStatus subghz_protocol_encoder_kinggates_stylo_4k_deserialize(
     return res;
 }
 
-//
-// Decoder
-//
 void* subghz_protocol_decoder_kinggates_stylo_4k_alloc(SubGhzEnvironment* environment) {
-    SubGhzProtocolDecoderKingGates_stylo_4k* instance =
-        malloc(sizeof(SubGhzProtocolDecoderKingGates_stylo_4k));
-    instance->base.protocol = &subghz_protocol_kinggates_stylo_4k;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolDecoderKingGates_stylo_4k* instance = subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderKingGates_stylo_4k), &subghz_protocol_kinggates_stylo_4k);
     instance->keystore = subghz_environment_get_keystore(environment);
     return instance;
 }

--- a/lib/subghz/protocols/kinggates_stylo_4k.c
+++ b/lib/subghz/protocols/kinggates_stylo_4k.c
@@ -38,6 +38,7 @@ struct SubGhzProtocolEncoderKingGates_stylo_4k {
     SubGhzBlockGeneric generic;
     SubGhzKeystore* keystore;
 };
+SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderKingGates_stylo_4k);
 
 typedef enum {
     KingGates_stylo_4kDecoderStepReset = 0,

--- a/lib/subghz/protocols/kinggates_stylo_4k.h
+++ b/lib/subghz/protocols/kinggates_stylo_4k.h
@@ -43,18 +43,6 @@ void* subghz_protocol_decoder_kinggates_stylo_4k_alloc(SubGhzEnvironment* enviro
 void subghz_protocol_decoder_kinggates_stylo_4k_feed(void* context, bool level, uint32_t duration);
 
 /**
- * Serialize data SubGhzProtocolDecoderKingGates_stylo_4k.
- * @param context Pointer to a SubGhzProtocolDecoderKingGates_stylo_4k instance
- * @param flipper_format Pointer to a FlipperFormat instance
- * @param preset The modulation on which the signal was received, SubGhzRadioPreset
- * @return status
- */
-SubGhzProtocolStatus subghz_protocol_decoder_kinggates_stylo_4k_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset);
-
-/**
  * Deserialize data SubGhzProtocolDecoderKingGates_stylo_4k.
  * @param context Pointer to a SubGhzProtocolDecoderKingGates_stylo_4k instance
  * @param flipper_format Pointer to a FlipperFormat instance

--- a/lib/subghz/protocols/legrand.c
+++ b/lib/subghz/protocols/legrand.c
@@ -25,6 +25,7 @@ struct SubGhzProtocolDecoderLegrand {
     uint32_t te;
     uint32_t last_data;
 };
+SUBGHZ_ASSERT_DECODER_TE_LAYOUT(SubGhzProtocolDecoderLegrand);
 
 struct SubGhzProtocolEncoderLegrand {
     SubGhzProtocolEncoderBase base;
@@ -50,7 +51,7 @@ const SubGhzProtocolDecoder subghz_protocol_legrand_decoder = {
     .reset = subghz_protocol_decoder_legrand_reset,
 
     .get_hash_data = subghz_protocol_decoder_common_get_hash_data,
-    .serialize = subghz_protocol_decoder_legrand_serialize,
+    .serialize = subghz_protocol_decoder_common_serialize_te,
     .deserialize = subghz_protocol_decoder_legrand_deserialize,
     .get_string = subghz_protocol_decoder_legrand_get_string,
 };
@@ -275,22 +276,6 @@ void subghz_protocol_decoder_legrand_feed(void* context, bool level, uint32_t du
         instance->decoder.parser_step = LegrandDecoderStepReset;
         break;
     }
-}
-
-SubGhzProtocolStatus subghz_protocol_decoder_legrand_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset) {
-    furi_assert(context);
-    SubGhzProtocolDecoderLegrand* instance = context;
-    SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
-    if((ret == SubGhzProtocolStatusOk) &&
-       !flipper_format_write_uint32(flipper_format, "TE", &instance->te, 1)) {
-        FURI_LOG_E(TAG, "Unable to add TE");
-        ret = SubGhzProtocolStatusErrorParserTe;
-    }
-    return ret;
 }
 
 SubGhzProtocolStatus

--- a/lib/subghz/protocols/legrand.c
+++ b/lib/subghz/protocols/legrand.c
@@ -89,7 +89,7 @@ void* subghz_protocol_encoder_legrand_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderLegrand instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_legrand_get_upload(SubGhzProtocolEncoderLegrand* instance) {
     furi_assert(instance);

--- a/lib/subghz/protocols/legrand.c
+++ b/lib/subghz/protocols/legrand.c
@@ -35,6 +35,7 @@ struct SubGhzProtocolEncoderLegrand {
 
     uint32_t te;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderLegrand);
 
 typedef enum {
     LegrandDecoderStepReset = 0,
@@ -78,16 +79,11 @@ const SubGhzProtocol subghz_protocol_legrand = {
 
 void* subghz_protocol_encoder_legrand_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderLegrand* instance = malloc(sizeof(SubGhzProtocolEncoderLegrand));
-
-    instance->base.protocol = &subghz_protocol_legrand;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = subghz_protocol_legrand_const.min_count_bit_for_found * 2 + 1;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderLegrand),
+        &subghz_protocol_legrand,
+        3,
+        subghz_protocol_legrand_const.min_count_bit_for_found * 2 + 1);
 }
 
 /**
@@ -166,10 +162,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_legrand_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderLegrand* instance = malloc(sizeof(SubGhzProtocolDecoderLegrand));
-    instance->base.protocol = &subghz_protocol_legrand;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderLegrand), &subghz_protocol_legrand);
 }
 
 void subghz_protocol_decoder_legrand_reset(void* context) {

--- a/lib/subghz/protocols/legrand.c
+++ b/lib/subghz/protocols/legrand.c
@@ -274,30 +274,8 @@ void subghz_protocol_decoder_legrand_feed(void* context, bool level, uint32_t du
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_legrand_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolDecoderLegrand* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_legrand_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        if(!flipper_format_rewind(flipper_format)) {
-            FURI_LOG_E(TAG, "Rewind error");
-            ret = SubGhzProtocolStatusErrorParserOthers;
-            break;
-        }
-        if(!flipper_format_read_uint32(flipper_format, "TE", (uint32_t*)&instance->te, 1)) {
-            FURI_LOG_E(TAG, "Missing TE");
-            ret = SubGhzProtocolStatusErrorParserTe;
-            break;
-        }
-    } while(false);
-
-    return ret;
+    return subghz_protocol_decoder_common_deserialize_te(
+        context, flipper_format, subghz_protocol_legrand_const.min_count_bit_for_found);
 }
 
 void subghz_protocol_decoder_legrand_get_string(void* context, FuriString* output) {

--- a/lib/subghz/protocols/legrand.h
+++ b/lib/subghz/protocols/legrand.h
@@ -53,18 +53,6 @@ void subghz_protocol_decoder_legrand_reset(void* context);
 void subghz_protocol_decoder_legrand_feed(void* context, bool level, uint32_t duration);
 
 /**
- * Serialize data SubGhzProtocolDecoderLegrand.
- * @param context Pointer to a SubGhzProtocolDecoderLegrand instance
- * @param flipper_format Pointer to a FlipperFormat instance
- * @param preset The modulation on which the signal was received, SubGhzRadioPreset
- * @return status
- */
-SubGhzProtocolStatus subghz_protocol_decoder_legrand_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset);
-
-/**
  * Deserialize data SubGhzProtocolDecoderLegrand.
  * @param context Pointer to a SubGhzProtocolDecoderLegrand instance
  * @param flipper_format Pointer to a FlipperFormat instance

--- a/lib/subghz/protocols/linear.c
+++ b/lib/subghz/protocols/linear.c
@@ -91,7 +91,8 @@ void* subghz_protocol_encoder_linear_alloc(SubGhzEnvironment* environment) {
  * @param instance Pointer to a SubGhzProtocolEncoderLinear instance
  * @return true On success
  */
-static bool subghz_protocol_encoder_linear_get_upload(SubGhzProtocolEncoderLinear* instance) {
+static bool subghz_protocol_encoder_linear_get_upload(void* context) {
+    SubGhzProtocolEncoderLinear* instance = context;
     furi_assert(instance);
     size_t index = 0;
     size_t size_upload = (instance->generic.data_count_bit * 2);
@@ -140,29 +141,11 @@ static bool subghz_protocol_encoder_linear_get_upload(SubGhzProtocolEncoderLinea
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_linear_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderLinear* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_linear_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        if(!subghz_protocol_encoder_linear_get_upload(instance)) {
-            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
-            break;
-        }
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_linear_const.min_count_bit_for_found,
+        subghz_protocol_encoder_linear_get_upload);
 }
 
 void* subghz_protocol_decoder_linear_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/linear.c
+++ b/lib/subghz/protocols/linear.c
@@ -29,6 +29,7 @@ struct SubGhzProtocolDecoderLinear {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderLinear);
 
 struct SubGhzProtocolEncoderLinear {
     SubGhzProtocolEncoderBase base;
@@ -36,6 +37,7 @@ struct SubGhzProtocolEncoderLinear {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderLinear);
 
 typedef enum {
     LinearDecoderStepReset = 0,
@@ -77,16 +79,11 @@ const SubGhzProtocol subghz_protocol_linear = {
 
 void* subghz_protocol_encoder_linear_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderLinear* instance = malloc(sizeof(SubGhzProtocolEncoderLinear));
-
-    instance->base.protocol = &subghz_protocol_linear;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 28; //max 10bit*2 + 2 (start, stop)
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderLinear),
+        &subghz_protocol_linear,
+        3,
+        28); //max 10bit*2 + 2 (start, stop)
 }
 
 /**
@@ -170,10 +167,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_linear_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderLinear* instance = malloc(sizeof(SubGhzProtocolDecoderLinear));
-    instance->base.protocol = &subghz_protocol_linear;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderLinear), &subghz_protocol_linear);
 }
 
 void subghz_protocol_decoder_linear_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/linear.c
+++ b/lib/subghz/protocols/linear.c
@@ -89,7 +89,7 @@ void* subghz_protocol_encoder_linear_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderLinear instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_linear_get_upload(void* context) {
     SubGhzProtocolEncoderLinear* instance = context;

--- a/lib/subghz/protocols/linear_delta3.c
+++ b/lib/subghz/protocols/linear_delta3.c
@@ -89,8 +89,8 @@ void* subghz_protocol_encoder_linear_delta3_alloc(SubGhzEnvironment* environment
  * @param instance Pointer to a SubGhzProtocolEncoderLinearDelta3 instance
  * @return true On success
  */
-static bool
-    subghz_protocol_encoder_linear_delta3_get_upload(SubGhzProtocolEncoderLinearDelta3* instance) {
+static bool subghz_protocol_encoder_linear_delta3_get_upload(void* context) {
+    SubGhzProtocolEncoderLinearDelta3* instance = context;
     furi_assert(instance);
     size_t index = 0;
     size_t size_upload = (instance->generic.data_count_bit * 2);
@@ -140,29 +140,11 @@ static bool
 SubGhzProtocolStatus subghz_protocol_encoder_linear_delta3_deserialize(
     void* context,
     FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderLinearDelta3* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_linear_delta3_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        if(!subghz_protocol_encoder_linear_delta3_get_upload(instance)) {
-            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
-            break;
-        }
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_linear_delta3_const.min_count_bit_for_found,
+        subghz_protocol_encoder_linear_delta3_get_upload);
 }
 
 void* subghz_protocol_decoder_linear_delta3_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/linear_delta3.c
+++ b/lib/subghz/protocols/linear_delta3.c
@@ -30,6 +30,7 @@ struct SubGhzProtocolDecoderLinearDelta3 {
 
     uint32_t last_data;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderLinearDelta3);
 
 struct SubGhzProtocolEncoderLinearDelta3 {
     SubGhzProtocolEncoderBase base;
@@ -37,6 +38,7 @@ struct SubGhzProtocolEncoderLinearDelta3 {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderLinearDelta3);
 
 typedef enum {
     LinearDecoderStepReset = 0,
@@ -78,17 +80,8 @@ const SubGhzProtocol subghz_protocol_linear_delta3 = {
 
 void* subghz_protocol_encoder_linear_delta3_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderLinearDelta3* instance =
-        malloc(sizeof(SubGhzProtocolEncoderLinearDelta3));
-
-    instance->base.protocol = &subghz_protocol_linear_delta3;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 16;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderLinearDelta3), &subghz_protocol_linear_delta3, 3, 16);
 }
 
 /**
@@ -174,11 +167,8 @@ SubGhzProtocolStatus subghz_protocol_encoder_linear_delta3_deserialize(
 
 void* subghz_protocol_decoder_linear_delta3_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderLinearDelta3* instance =
-        malloc(sizeof(SubGhzProtocolDecoderLinearDelta3));
-    instance->base.protocol = &subghz_protocol_linear_delta3;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderLinearDelta3), &subghz_protocol_linear_delta3);
 }
 
 void subghz_protocol_decoder_linear_delta3_reset(void* context) {

--- a/lib/subghz/protocols/linear_delta3.c
+++ b/lib/subghz/protocols/linear_delta3.c
@@ -87,7 +87,7 @@ void* subghz_protocol_encoder_linear_delta3_alloc(SubGhzEnvironment* environment
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderLinearDelta3 instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_linear_delta3_get_upload(void* context) {
     SubGhzProtocolEncoderLinearDelta3* instance = context;

--- a/lib/subghz/protocols/magellan.c
+++ b/lib/subghz/protocols/magellan.c
@@ -23,6 +23,7 @@ struct SubGhzProtocolDecoderMagellan {
     SubGhzBlockGeneric generic;
     uint16_t header_count;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderMagellan);
 
 struct SubGhzProtocolEncoderMagellan {
     SubGhzProtocolEncoderBase base;
@@ -30,6 +31,7 @@ struct SubGhzProtocolEncoderMagellan {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderMagellan);
 
 typedef enum {
     MagellanDecoderStepReset = 0,
@@ -74,16 +76,8 @@ const SubGhzProtocol subghz_protocol_magellan = {
 
 void* subghz_protocol_encoder_magellan_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderMagellan* instance = malloc(sizeof(SubGhzProtocolEncoderMagellan));
-
-    instance->base.protocol = &subghz_protocol_magellan;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderMagellan), &subghz_protocol_magellan, 3, 256);
 }
 
 /**
@@ -181,10 +175,8 @@ void subghz_protocol_encoder_magellan_stop(void* context) {
 
 void* subghz_protocol_decoder_magellan_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderMagellan* instance = malloc(sizeof(SubGhzProtocolDecoderMagellan));
-    instance->base.protocol = &subghz_protocol_magellan;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderMagellan), &subghz_protocol_magellan);
 }
 
 uint8_t subghz_protocol_magellan_crc8(uint8_t* data, size_t len) {

--- a/lib/subghz/protocols/magellan.c
+++ b/lib/subghz/protocols/magellan.c
@@ -83,7 +83,7 @@ void* subghz_protocol_encoder_magellan_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderMagellan instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_magellan_get_upload(SubGhzProtocolEncoderMagellan* instance) {
     furi_assert(instance);

--- a/lib/subghz/protocols/marantec.c
+++ b/lib/subghz/protocols/marantec.c
@@ -25,6 +25,7 @@ struct SubGhzProtocolDecoderMarantec {
     ManchesterState manchester_saved_state;
     uint16_t header_count;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderMarantec);
 
 struct SubGhzProtocolEncoderMarantec {
     SubGhzProtocolEncoderBase base;
@@ -32,6 +33,7 @@ struct SubGhzProtocolEncoderMarantec {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderMarantec);
 
 typedef enum {
     MarantecDecoderStepReset = 0,
@@ -73,16 +75,8 @@ const SubGhzProtocol subghz_protocol_marantec = {
 
 void* subghz_protocol_encoder_marantec_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderMarantec* instance = malloc(sizeof(SubGhzProtocolEncoderMarantec));
-
-    instance->base.protocol = &subghz_protocol_marantec;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderMarantec), &subghz_protocol_marantec, 3, 256);
 }
 
 static LevelDuration
@@ -228,10 +222,8 @@ void subghz_protocol_encoder_marantec_stop(void* context) {
 
 void* subghz_protocol_decoder_marantec_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderMarantec* instance = malloc(sizeof(SubGhzProtocolDecoderMarantec));
-    instance->base.protocol = &subghz_protocol_marantec;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderMarantec), &subghz_protocol_marantec);
 }
 
 void subghz_protocol_decoder_marantec_reset(void* context) {

--- a/lib/subghz/protocols/marantec24.c
+++ b/lib/subghz/protocols/marantec24.c
@@ -21,6 +21,7 @@ struct SubGhzProtocolDecoderMarantec24 {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderMarantec24);
 
 struct SubGhzProtocolEncoderMarantec24 {
     SubGhzProtocolEncoderBase base;
@@ -28,6 +29,7 @@ struct SubGhzProtocolEncoderMarantec24 {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderMarantec24);
 
 typedef enum {
     Marantec24DecoderStepReset = 0,
@@ -69,16 +71,8 @@ const SubGhzProtocol subghz_protocol_marantec24 = {
 
 void* subghz_protocol_encoder_marantec24_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderMarantec24* instance = malloc(sizeof(SubGhzProtocolEncoderMarantec24));
-
-    instance->base.protocol = &subghz_protocol_marantec24;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderMarantec24), &subghz_protocol_marantec24, 3, 256);
 }
 
 /**
@@ -163,10 +157,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_marantec24_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderMarantec24* instance = malloc(sizeof(SubGhzProtocolDecoderMarantec24));
-    instance->base.protocol = &subghz_protocol_marantec24;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderMarantec24), &subghz_protocol_marantec24);
 }
 
 void subghz_protocol_decoder_marantec24_feed(void* context, bool level, volatile uint32_t duration) {

--- a/lib/subghz/protocols/marantec24.c
+++ b/lib/subghz/protocols/marantec24.c
@@ -75,13 +75,18 @@ void* subghz_protocol_encoder_marantec24_alloc(SubGhzEnvironment* environment) {
         sizeof(SubGhzProtocolEncoderMarantec24), &subghz_protocol_marantec24, 3, 256);
 }
 
+static void subghz_protocol_marantec24_check_remote_controller(SubGhzBlockGeneric* instance);
+
 /**
  * Generating an upload from data.
- * @param instance Pointer to a SubGhzProtocolEncoderMarantec24 instance
+ * @param context Pointer to a SubGhzProtocolEncoderMarantec24 instance
+ * @return true Always; this encoder has no failure path
  */
-static void
-    subghz_protocol_encoder_marantec24_get_upload(SubGhzProtocolEncoderMarantec24* instance) {
+static bool subghz_protocol_encoder_marantec24_get_upload(void* context) {
+    SubGhzProtocolEncoderMarantec24* instance = context;
     furi_assert(instance);
+
+    subghz_protocol_marantec24_check_remote_controller(&instance->generic);
     size_t index = 0;
 
     // Send key and GAP
@@ -118,7 +123,7 @@ static void
     }
 
     instance->encoder.size_upload = index;
-    return;
+    return true;
 }
 
 /** 
@@ -132,27 +137,11 @@ static void subghz_protocol_marantec24_check_remote_controller(SubGhzBlockGeneri
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_marantec24_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderMarantec24* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_marantec24_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        subghz_protocol_marantec24_check_remote_controller(&instance->generic);
-        subghz_protocol_encoder_marantec24_get_upload(instance);
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_marantec24_const.min_count_bit_for_found,
+        subghz_protocol_encoder_marantec24_get_upload);
 }
 
 void* subghz_protocol_decoder_marantec24_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/mastercode.c
+++ b/lib/subghz/protocols/mastercode.c
@@ -96,8 +96,8 @@ void* subghz_protocol_encoder_mastercode_alloc(SubGhzEnvironment* environment) {
  * @param instance Pointer to a SubGhzProtocolEncoderMastercode instance
  * @return true On success
  */
-static bool
-    subghz_protocol_encoder_mastercode_get_upload(SubGhzProtocolEncoderMastercode* instance) {
+static bool subghz_protocol_encoder_mastercode_get_upload(void* context) {
+    SubGhzProtocolEncoderMastercode* instance = context;
     furi_assert(instance);
     size_t index = 0;
     size_t size_upload = (instance->generic.data_count_bit * 2);
@@ -145,30 +145,11 @@ static bool
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_mastercode_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderMastercode* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_mastercode_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        if(!subghz_protocol_encoder_mastercode_get_upload(instance)) {
-            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
-            break;
-        }
-        instance->encoder.is_running = true;
-
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_mastercode_const.min_count_bit_for_found,
+        subghz_protocol_encoder_mastercode_get_upload);
 }
 
 void* subghz_protocol_decoder_mastercode_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/mastercode.c
+++ b/lib/subghz/protocols/mastercode.c
@@ -38,12 +38,14 @@ struct SubGhzProtocolDecoderMastercode {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderMastercode);
 
 struct SubGhzProtocolEncoderMastercode {
     SubGhzProtocolEncoderBase base;
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderMastercode);
 
 typedef enum {
     MastercodeDecoderStepReset = 0,
@@ -85,16 +87,8 @@ const SubGhzProtocol subghz_protocol_mastercode = {
 
 void* subghz_protocol_encoder_mastercode_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderMastercode* instance = malloc(sizeof(SubGhzProtocolEncoderMastercode));
-
-    instance->base.protocol = &subghz_protocol_mastercode;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 72;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderMastercode), &subghz_protocol_mastercode, 3, 72);
 }
 
 /**
@@ -179,10 +173,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_mastercode_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderMastercode* instance = malloc(sizeof(SubGhzProtocolDecoderMastercode));
-    instance->base.protocol = &subghz_protocol_mastercode;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderMastercode), &subghz_protocol_mastercode);
 }
 
 void subghz_protocol_decoder_mastercode_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/mastercode.c
+++ b/lib/subghz/protocols/mastercode.c
@@ -94,7 +94,7 @@ void* subghz_protocol_encoder_mastercode_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderMastercode instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_mastercode_get_upload(void* context) {
     SubGhzProtocolEncoderMastercode* instance = context;

--- a/lib/subghz/protocols/megacode.c
+++ b/lib/subghz/protocols/megacode.c
@@ -92,7 +92,7 @@ void* subghz_protocol_encoder_megacode_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderMegaCode instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_megacode_get_upload(void* context) {
     SubGhzProtocolEncoderMegaCode* instance = context;

--- a/lib/subghz/protocols/megacode.c
+++ b/lib/subghz/protocols/megacode.c
@@ -34,6 +34,7 @@ struct SubGhzProtocolDecoderMegaCode {
     SubGhzBlockGeneric generic;
     uint8_t last_bit;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderMegaCode);
 
 struct SubGhzProtocolEncoderMegaCode {
     SubGhzProtocolEncoderBase base;
@@ -41,6 +42,7 @@ struct SubGhzProtocolEncoderMegaCode {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderMegaCode);
 
 typedef enum {
     MegaCodeDecoderStepReset = 0,
@@ -83,16 +85,8 @@ const SubGhzProtocol subghz_protocol_megacode = {
 
 void* subghz_protocol_encoder_megacode_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderMegaCode* instance = malloc(sizeof(SubGhzProtocolEncoderMegaCode));
-
-    instance->base.protocol = &subghz_protocol_megacode;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 52;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderMegaCode), &subghz_protocol_megacode, 3, 52);
 }
 
 /**
@@ -198,10 +192,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_megacode_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderMegaCode* instance = malloc(sizeof(SubGhzProtocolDecoderMegaCode));
-    instance->base.protocol = &subghz_protocol_megacode;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderMegaCode), &subghz_protocol_megacode);
 }
 
 void subghz_protocol_decoder_megacode_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/megacode.c
+++ b/lib/subghz/protocols/megacode.c
@@ -94,7 +94,8 @@ void* subghz_protocol_encoder_megacode_alloc(SubGhzEnvironment* environment) {
  * @param instance Pointer to a SubGhzProtocolEncoderMegaCode instance
  * @return true On success
  */
-static bool subghz_protocol_encoder_megacode_get_upload(SubGhzProtocolEncoderMegaCode* instance) {
+static bool subghz_protocol_encoder_megacode_get_upload(void* context) {
+    SubGhzProtocolEncoderMegaCode* instance = context;
     furi_assert(instance);
     uint8_t last_bit = 0;
     size_t size_upload = (instance->generic.data_count_bit * 2);
@@ -165,29 +166,11 @@ static bool subghz_protocol_encoder_megacode_get_upload(SubGhzProtocolEncoderMeg
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_megacode_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderMegaCode* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_megacode_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        if(!subghz_protocol_encoder_megacode_get_upload(instance)) {
-            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
-            break;
-        }
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_megacode_const.min_count_bit_for_found,
+        subghz_protocol_encoder_megacode_get_upload);
 }
 
 void* subghz_protocol_decoder_megacode_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/nero_radio.c
+++ b/lib/subghz/protocols/nero_radio.c
@@ -24,6 +24,7 @@ struct SubGhzProtocolDecoderNeroRadio {
 
     uint16_t header_count;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderNeroRadio);
 
 struct SubGhzProtocolEncoderNeroRadio {
     SubGhzProtocolEncoderBase base;
@@ -31,6 +32,7 @@ struct SubGhzProtocolEncoderNeroRadio {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderNeroRadio);
 
 typedef enum {
     NeroRadioDecoderStepReset = 0,
@@ -73,16 +75,8 @@ const SubGhzProtocol subghz_protocol_nero_radio = {
 
 void* subghz_protocol_encoder_nero_radio_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderNeroRadio* instance = malloc(sizeof(SubGhzProtocolEncoderNeroRadio));
-
-    instance->base.protocol = &subghz_protocol_nero_radio;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderNeroRadio), &subghz_protocol_nero_radio, 3, 256);
 }
 
 /**
@@ -190,10 +184,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_nero_radio_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderNeroRadio* instance = malloc(sizeof(SubGhzProtocolDecoderNeroRadio));
-    instance->base.protocol = &subghz_protocol_nero_radio;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderNeroRadio), &subghz_protocol_nero_radio);
 }
 
 void subghz_protocol_decoder_nero_radio_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/nero_sketch.c
+++ b/lib/subghz/protocols/nero_sketch.c
@@ -83,8 +83,8 @@ void* subghz_protocol_encoder_nero_sketch_alloc(SubGhzEnvironment* environment) 
  * @param instance Pointer to a SubGhzProtocolEncoderNeroSketch instance
  * @return true On success
  */
-static bool
-    subghz_protocol_encoder_nero_sketch_get_upload(SubGhzProtocolEncoderNeroSketch* instance) {
+static bool subghz_protocol_encoder_nero_sketch_get_upload(void* context) {
+    SubGhzProtocolEncoderNeroSketch* instance = context;
     furi_assert(instance);
 
     size_t index = 0;
@@ -138,29 +138,11 @@ static bool
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_nero_sketch_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderNeroSketch* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_nero_sketch_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        if(!subghz_protocol_encoder_nero_sketch_get_upload(instance)) {
-            ret = SubGhzProtocolStatusErrorEncoderGetUpload;
-            break;
-        }
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_nero_sketch_const.min_count_bit_for_found,
+        subghz_protocol_encoder_nero_sketch_get_upload);
 }
 
 void* subghz_protocol_decoder_nero_sketch_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/nero_sketch.c
+++ b/lib/subghz/protocols/nero_sketch.c
@@ -81,7 +81,7 @@ void* subghz_protocol_encoder_nero_sketch_alloc(SubGhzEnvironment* environment) 
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderNeroSketch instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_nero_sketch_get_upload(void* context) {
     SubGhzProtocolEncoderNeroSketch* instance = context;

--- a/lib/subghz/protocols/nero_sketch.c
+++ b/lib/subghz/protocols/nero_sketch.c
@@ -23,6 +23,7 @@ struct SubGhzProtocolDecoderNeroSketch {
     SubGhzBlockGeneric generic;
     uint16_t header_count;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderNeroSketch);
 
 struct SubGhzProtocolEncoderNeroSketch {
     SubGhzProtocolEncoderBase base;
@@ -30,6 +31,7 @@ struct SubGhzProtocolEncoderNeroSketch {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderNeroSketch);
 
 typedef enum {
     NeroSketchDecoderStepReset = 0,
@@ -72,16 +74,8 @@ const SubGhzProtocol subghz_protocol_nero_sketch = {
 
 void* subghz_protocol_encoder_nero_sketch_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderNeroSketch* instance = malloc(sizeof(SubGhzProtocolEncoderNeroSketch));
-
-    instance->base.protocol = &subghz_protocol_nero_sketch;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderNeroSketch), &subghz_protocol_nero_sketch, 3, 256);
 }
 
 /**
@@ -171,10 +165,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_nero_sketch_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderNeroSketch* instance = malloc(sizeof(SubGhzProtocolDecoderNeroSketch));
-    instance->base.protocol = &subghz_protocol_nero_sketch;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderNeroSketch), &subghz_protocol_nero_sketch);
 }
 
 void subghz_protocol_decoder_nero_sketch_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/nice_flo.c
+++ b/lib/subghz/protocols/nice_flo.c
@@ -83,7 +83,7 @@ void* subghz_protocol_encoder_nice_flo_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderNiceFlo instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_nice_flo_get_upload(SubGhzProtocolEncoderNiceFlo* instance) {
     furi_assert(instance);

--- a/lib/subghz/protocols/nice_flo.c
+++ b/lib/subghz/protocols/nice_flo.c
@@ -21,6 +21,7 @@ struct SubGhzProtocolDecoderNiceFlo {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderNiceFlo);
 
 struct SubGhzProtocolEncoderNiceFlo {
     SubGhzProtocolEncoderBase base;
@@ -28,6 +29,7 @@ struct SubGhzProtocolEncoderNiceFlo {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderNiceFlo);
 
 typedef enum {
     NiceFloDecoderStepReset = 0,
@@ -71,16 +73,11 @@ const SubGhzProtocol subghz_protocol_nice_flo = {
 
 void* subghz_protocol_encoder_nice_flo_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderNiceFlo* instance = malloc(sizeof(SubGhzProtocolEncoderNiceFlo));
-
-    instance->base.protocol = &subghz_protocol_nice_flo;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 52; //max 24bit*2 + 2 (start, stop)
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderNiceFlo),
+        &subghz_protocol_nice_flo,
+        3,
+        52); //max 24bit*2 + 2 (start, stop)
 }
 
 /**
@@ -157,10 +154,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_nice_flo_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderNiceFlo* instance = malloc(sizeof(SubGhzProtocolDecoderNiceFlo));
-    instance->base.protocol = &subghz_protocol_nice_flo;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderNiceFlo), &subghz_protocol_nice_flo);
 }
 
 void subghz_protocol_decoder_nice_flo_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/nice_flor_s.c
+++ b/lib/subghz/protocols/nice_flor_s.c
@@ -558,9 +558,8 @@ bool subghz_protocol_nice_flor_s_create_data(
 }
 
 void* subghz_protocol_decoder_nice_flor_s_alloc(SubGhzEnvironment* environment) {
-    SubGhzProtocolDecoderNiceFlorS* instance = malloc(sizeof(SubGhzProtocolDecoderNiceFlorS));
-    instance->base.protocol = &subghz_protocol_nice_flor_s;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolDecoderNiceFlorS* instance = subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderNiceFlorS), &subghz_protocol_nice_flor_s);
     instance->nice_flor_s_rainbow_table_file_name =
         subghz_environment_get_nice_flor_s_rainbow_table_file_name(environment);
     if(instance->nice_flor_s_rainbow_table_file_name) {

--- a/lib/subghz/protocols/nice_flor_s.c
+++ b/lib/subghz/protocols/nice_flor_s.c
@@ -40,6 +40,7 @@ struct SubGhzProtocolDecoderNiceFlorS {
 
     const char* nice_flor_s_rainbow_table_file_name;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderNiceFlorS);
 
 struct SubGhzProtocolEncoderNiceFlorS {
     SubGhzProtocolEncoderBase base;
@@ -49,6 +50,7 @@ struct SubGhzProtocolEncoderNiceFlorS {
 
     const char* nice_flor_s_rainbow_table_file_name;
 };
+SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderNiceFlorS);
 
 typedef enum {
     NiceFlorSDecoderStepReset = 0,

--- a/lib/subghz/protocols/nord_ice.c
+++ b/lib/subghz/protocols/nord_ice.c
@@ -21,6 +21,7 @@ struct SubGhzProtocolDecoderNord_Ice {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderNord_Ice);
 
 struct SubGhzProtocolEncoderNord_Ice {
     SubGhzProtocolEncoderBase base;
@@ -28,6 +29,7 @@ struct SubGhzProtocolEncoderNord_Ice {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderNord_Ice);
 
 typedef enum {
     Nord_IceDecoderStepReset = 0,
@@ -69,16 +71,8 @@ const SubGhzProtocol subghz_protocol_nord_ice = {
 
 void* subghz_protocol_encoder_nord_ice_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderNord_Ice* instance = malloc(sizeof(SubGhzProtocolEncoderNord_Ice));
-
-    instance->base.protocol = &subghz_protocol_nord_ice;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderNord_Ice), &subghz_protocol_nord_ice, 3, 128);
 }
 
 /**
@@ -159,10 +153,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_nord_ice_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderNord_Ice* instance = malloc(sizeof(SubGhzProtocolDecoderNord_Ice));
-    instance->base.protocol = &subghz_protocol_nord_ice;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderNord_Ice), &subghz_protocol_nord_ice);
 }
 
 void subghz_protocol_decoder_nord_ice_feed(void* context, bool level, volatile uint32_t duration) {

--- a/lib/subghz/protocols/nord_ice.c
+++ b/lib/subghz/protocols/nord_ice.c
@@ -75,12 +75,18 @@ void* subghz_protocol_encoder_nord_ice_alloc(SubGhzEnvironment* environment) {
         sizeof(SubGhzProtocolEncoderNord_Ice), &subghz_protocol_nord_ice, 3, 128);
 }
 
+static void subghz_protocol_nord_ice_check_remote_controller(SubGhzBlockGeneric* instance);
+
 /**
  * Generating an upload from data.
- * @param instance Pointer to a SubGhzProtocolEncoderNord_Ice instance
+ * @param context Pointer to a SubGhzProtocolEncoderNord_Ice instance
+ * @return true Always; this encoder has no failure path
  */
-static void subghz_protocol_encoder_nord_ice_get_upload(SubGhzProtocolEncoderNord_Ice* instance) {
+static bool subghz_protocol_encoder_nord_ice_get_upload(void* context) {
+    SubGhzProtocolEncoderNord_Ice* instance = context;
     furi_assert(instance);
+
+    subghz_protocol_nord_ice_check_remote_controller(&instance->generic);
     size_t index = 0;
 
     // Send key and GAP
@@ -113,7 +119,7 @@ static void subghz_protocol_encoder_nord_ice_get_upload(SubGhzProtocolEncoderNor
     }
 
     instance->encoder.size_upload = index;
-    return;
+    return true;
 }
 
 /** 
@@ -128,27 +134,11 @@ static void subghz_protocol_nord_ice_check_remote_controller(SubGhzBlockGeneric*
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_nord_ice_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderNord_Ice* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_nord_ice_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        subghz_protocol_nord_ice_check_remote_controller(&instance->generic);
-        subghz_protocol_encoder_nord_ice_get_upload(instance);
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_nord_ice_const.min_count_bit_for_found,
+        subghz_protocol_encoder_nord_ice_get_upload);
 }
 
 void* subghz_protocol_decoder_nord_ice_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/phoenix_v2.c
+++ b/lib/subghz/protocols/phoenix_v2.c
@@ -27,6 +27,7 @@ struct SubGhzProtocolDecoderPhoenix_V2 {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderPhoenix_V2);
 
 struct SubGhzProtocolEncoderPhoenix_V2 {
     SubGhzProtocolEncoderBase base;
@@ -34,6 +35,7 @@ struct SubGhzProtocolEncoderPhoenix_V2 {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderPhoenix_V2);
 
 typedef enum {
     Phoenix_V2DecoderStepReset = 0,
@@ -76,16 +78,8 @@ const SubGhzProtocol subghz_protocol_phoenix_v2 = {
 
 void* subghz_protocol_encoder_phoenix_v2_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderPhoenix_V2* instance = malloc(sizeof(SubGhzProtocolEncoderPhoenix_V2));
-
-    instance->base.protocol = &subghz_protocol_phoenix_v2;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderPhoenix_V2), &subghz_protocol_phoenix_v2, 3, 128);
 }
 
 static uint8_t v2_phoenix_counter_mode = 0;
@@ -398,10 +392,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_phoenix_v2_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderPhoenix_V2* instance = malloc(sizeof(SubGhzProtocolDecoderPhoenix_V2));
-    instance->base.protocol = &subghz_protocol_phoenix_v2;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderPhoenix_V2), &subghz_protocol_phoenix_v2);
 }
 
 void subghz_protocol_decoder_phoenix_v2_feed(void* context, bool level, uint32_t duration) {

--- a/lib/subghz/protocols/power_smart.c
+++ b/lib/subghz/protocols/power_smart.c
@@ -33,6 +33,7 @@ struct SubGhzProtocolDecoderPowerSmart {
     ManchesterState manchester_saved_state;
     uint16_t header_count;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderPowerSmart);
 
 struct SubGhzProtocolEncoderPowerSmart {
     SubGhzProtocolEncoderBase base;
@@ -40,6 +41,7 @@ struct SubGhzProtocolEncoderPowerSmart {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderPowerSmart);
 
 typedef enum {
     PowerSmartDecoderStepReset = 0,
@@ -81,16 +83,8 @@ const SubGhzProtocol subghz_protocol_power_smart = {
 
 void* subghz_protocol_encoder_power_smart_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderPowerSmart* instance = malloc(sizeof(SubGhzProtocolEncoderPowerSmart));
-
-    instance->base.protocol = &subghz_protocol_power_smart;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 1024;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderPowerSmart), &subghz_protocol_power_smart, 3, 1024);
 }
 
 static LevelDuration
@@ -221,10 +215,8 @@ void subghz_protocol_encoder_power_smart_stop(void* context) {
 
 void* subghz_protocol_decoder_power_smart_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderPowerSmart* instance = malloc(sizeof(SubGhzProtocolDecoderPowerSmart));
-    instance->base.protocol = &subghz_protocol_power_smart;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderPowerSmart), &subghz_protocol_power_smart);
 }
 
 void subghz_protocol_decoder_power_smart_reset(void* context) {

--- a/lib/subghz/protocols/princeton.c
+++ b/lib/subghz/protocols/princeton.c
@@ -37,6 +37,7 @@ struct SubGhzProtocolDecoderPrinceton {
     uint32_t last_data;
     uint32_t guard_time;
 };
+SUBGHZ_ASSERT_DECODER_TE_LAYOUT(SubGhzProtocolDecoderPrinceton);
 
 struct SubGhzProtocolEncoderPrinceton {
     SubGhzProtocolEncoderBase base;
@@ -490,15 +491,9 @@ SubGhzProtocolStatus subghz_protocol_decoder_princeton_serialize(
     void* context,
     FlipperFormat* flipper_format,
     SubGhzRadioPreset* preset) {
-    furi_assert(context);
     SubGhzProtocolDecoderPrinceton* instance = context;
     SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
-    if((ret == SubGhzProtocolStatusOk) &&
-       !flipper_format_write_uint32(flipper_format, "TE", &instance->te, 1)) {
-        FURI_LOG_E(TAG, "Unable to add TE");
-        ret = SubGhzProtocolStatusErrorParserTe;
-    }
+        subghz_protocol_decoder_common_serialize_te(context, flipper_format, preset);
     if((ret == SubGhzProtocolStatusOk) &&
        !flipper_format_write_uint32(flipper_format, "Guard_time", &instance->guard_time, 1)) {
         FURI_LOG_E(TAG, "Unable to add Guard_time");

--- a/lib/subghz/protocols/princeton.c
+++ b/lib/subghz/protocols/princeton.c
@@ -48,6 +48,7 @@ struct SubGhzProtocolEncoderPrinceton {
     uint32_t te;
     uint32_t guard_time;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderPrinceton);
 
 typedef enum {
     PrincetonDecoderStepReset = 0,
@@ -90,16 +91,11 @@ const SubGhzProtocol subghz_protocol_princeton = {
 
 void* subghz_protocol_encoder_princeton_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderPrinceton* instance = malloc(sizeof(SubGhzProtocolEncoderPrinceton));
-
-    instance->base.protocol = &subghz_protocol_princeton;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 52; //max 24bit*2 + 2 (start, stop)
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderPrinceton),
+        &subghz_protocol_princeton,
+        3,
+        52); //max 24bit*2 + 2 (start, stop)
 }
 
 // Get custom button code
@@ -396,10 +392,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_princeton_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderPrinceton* instance = malloc(sizeof(SubGhzProtocolDecoderPrinceton));
-    instance->base.protocol = &subghz_protocol_princeton;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderPrinceton), &subghz_protocol_princeton);
 }
 
 void subghz_protocol_decoder_princeton_reset(void* context) {

--- a/lib/subghz/protocols/revers_rb2.c
+++ b/lib/subghz/protocols/revers_rb2.c
@@ -110,11 +110,16 @@ static LevelDuration
 
 /**
  * Generating an upload from data.
- * @param instance Pointer to a SubGhzProtocolEncoderRevers_RB2 instance
+ * @param context Pointer to a SubGhzProtocolEncoderRevers_RB2 instance
+ * @return true On success
  */
-static void
-    subghz_protocol_encoder_revers_rb2_get_upload(SubGhzProtocolEncoderRevers_RB2* instance) {
+static void subghz_protocol_revers_rb2_remote_controller(SubGhzBlockGeneric* instance);
+
+static bool subghz_protocol_encoder_revers_rb2_get_upload(void* context) {
+    SubGhzProtocolEncoderRevers_RB2* instance = context;
     furi_assert(instance);
+
+    subghz_protocol_revers_rb2_remote_controller(&instance->generic);
     size_t index = 0;
 
     ManchesterEncoderState enc_state;
@@ -139,6 +144,8 @@ static void
     }
     instance->encoder.upload[index++] = level_duration_make(false, (uint32_t)320);
     instance->encoder.size_upload = index;
+
+    return true;
 }
 
 /** 
@@ -153,27 +160,11 @@ static void subghz_protocol_revers_rb2_remote_controller(SubGhzBlockGeneric* ins
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_revers_rb2_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderRevers_RB2* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_revers_rb2_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        subghz_protocol_revers_rb2_remote_controller(&instance->generic);
-        subghz_protocol_encoder_revers_rb2_get_upload(instance);
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_revers_rb2_const.min_count_bit_for_found,
+        subghz_protocol_encoder_revers_rb2_get_upload);
 }
 
 void* subghz_protocol_decoder_revers_rb2_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/revers_rb2.c
+++ b/lib/subghz/protocols/revers_rb2.c
@@ -25,6 +25,7 @@ struct SubGhzProtocolDecoderRevers_RB2 {
     ManchesterState manchester_saved_state;
     uint16_t header_count;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderRevers_RB2);
 
 struct SubGhzProtocolEncoderRevers_RB2 {
     SubGhzProtocolEncoderBase base;
@@ -32,6 +33,7 @@ struct SubGhzProtocolEncoderRevers_RB2 {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderRevers_RB2);
 
 typedef enum {
     Revers_RB2DecoderStepReset = 0,
@@ -74,16 +76,8 @@ const SubGhzProtocol subghz_protocol_revers_rb2 = {
 
 void* subghz_protocol_encoder_revers_rb2_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderRevers_RB2* instance = malloc(sizeof(SubGhzProtocolEncoderRevers_RB2));
-
-    instance->base.protocol = &subghz_protocol_revers_rb2;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderRevers_RB2), &subghz_protocol_revers_rb2, 3, 256);
 }
 
 static LevelDuration
@@ -184,10 +178,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_revers_rb2_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderRevers_RB2* instance = malloc(sizeof(SubGhzProtocolDecoderRevers_RB2));
-    instance->base.protocol = &subghz_protocol_revers_rb2;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderRevers_RB2), &subghz_protocol_revers_rb2);
 }
 
 void subghz_protocol_decoder_revers_rb2_reset(void* context) {

--- a/lib/subghz/protocols/roger.c
+++ b/lib/subghz/protocols/roger.c
@@ -23,6 +23,7 @@ struct SubGhzProtocolDecoderRoger {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderRoger);
 
 struct SubGhzProtocolEncoderRoger {
     SubGhzProtocolEncoderBase base;
@@ -30,6 +31,7 @@ struct SubGhzProtocolEncoderRoger {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderRoger);
 
 typedef enum {
     RogerDecoderStepReset = 0,
@@ -72,16 +74,8 @@ const SubGhzProtocol subghz_protocol_roger = {
 
 void* subghz_protocol_encoder_roger_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderRoger* instance = malloc(sizeof(SubGhzProtocolEncoderRoger));
-
-    instance->base.protocol = &subghz_protocol_roger;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderRoger), &subghz_protocol_roger, 3, 128);
 }
 
 // Get custom button code
@@ -288,10 +282,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_roger_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderRoger* instance = malloc(sizeof(SubGhzProtocolDecoderRoger));
-    instance->base.protocol = &subghz_protocol_roger;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderRoger), &subghz_protocol_roger);
 }
 
 void subghz_protocol_decoder_roger_feed(void* context, bool level, volatile uint32_t duration) {

--- a/lib/subghz/protocols/secplus_v1.c
+++ b/lib/subghz/protocols/secplus_v1.c
@@ -43,6 +43,7 @@ struct SubGhzProtocolDecoderSecPlus_v1 {
     uint8_t base_packet_index;
     uint8_t data_array[44];
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderSecPlus_v1);
 
 struct SubGhzProtocolEncoderSecPlus_v1 {
     SubGhzProtocolEncoderBase base;
@@ -52,6 +53,7 @@ struct SubGhzProtocolEncoderSecPlus_v1 {
 
     uint8_t data_array[44];
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderSecPlus_v1);
 
 typedef enum {
     SecPlus_v1DecoderStepReset = 0,
@@ -94,16 +96,8 @@ const SubGhzProtocol subghz_protocol_secplus_v1 = {
 
 void* subghz_protocol_encoder_secplus_v1_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderSecPlus_v1* instance = malloc(sizeof(SubGhzProtocolEncoderSecPlus_v1));
-
-    instance->base.protocol = &subghz_protocol_secplus_v1;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderSecPlus_v1), &subghz_protocol_secplus_v1, 3, 128);
 }
 
 /**
@@ -324,11 +318,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_secplus_v1_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderSecPlus_v1* instance = malloc(sizeof(SubGhzProtocolDecoderSecPlus_v1));
-    instance->base.protocol = &subghz_protocol_secplus_v1;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderSecPlus_v1), &subghz_protocol_secplus_v1);
 }
 
 void subghz_protocol_decoder_secplus_v1_reset(void* context) {

--- a/lib/subghz/protocols/secplus_v2.c
+++ b/lib/subghz/protocols/secplus_v2.c
@@ -40,6 +40,7 @@ struct SubGhzProtocolDecoderSecPlus_v2 {
     ManchesterState manchester_saved_state;
     uint64_t secplus_packet_1;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderSecPlus_v2);
 
 struct SubGhzProtocolEncoderSecPlus_v2 {
     SubGhzProtocolEncoderBase base;
@@ -48,6 +49,7 @@ struct SubGhzProtocolEncoderSecPlus_v2 {
     SubGhzBlockGeneric generic;
     uint64_t secplus_packet_1;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderSecPlus_v2);
 
 typedef enum {
     SecPlus_v2DecoderStepReset = 0,
@@ -88,16 +90,8 @@ const SubGhzProtocol subghz_protocol_secplus_v2 = {
 
 void* subghz_protocol_encoder_secplus_v2_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderSecPlus_v2* instance = malloc(sizeof(SubGhzProtocolEncoderSecPlus_v2));
-
-    instance->base.protocol = &subghz_protocol_secplus_v2;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 256;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderSecPlus_v2), &subghz_protocol_secplus_v2, 3, 256);
 }
 
 static bool subghz_protocol_secplus_v2_mix_invet(uint8_t invert, uint16_t p[]) {
@@ -645,11 +639,8 @@ bool subghz_protocol_secplus_v2_create_data(
 
 void* subghz_protocol_decoder_secplus_v2_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderSecPlus_v2* instance = malloc(sizeof(SubGhzProtocolDecoderSecPlus_v2));
-    instance->base.protocol = &subghz_protocol_secplus_v2;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderSecPlus_v2), &subghz_protocol_secplus_v2);
 }
 
 void subghz_protocol_decoder_secplus_v2_reset(void* context) {

--- a/lib/subghz/protocols/smc5326.c
+++ b/lib/subghz/protocols/smc5326.c
@@ -106,7 +106,7 @@ void* subghz_protocol_encoder_smc5326_alloc(SubGhzEnvironment* environment) {
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderSMC5326 instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_smc5326_get_upload(SubGhzProtocolEncoderSMC5326* instance) {
     furi_assert(instance);

--- a/lib/subghz/protocols/smc5326.c
+++ b/lib/subghz/protocols/smc5326.c
@@ -267,30 +267,8 @@ void subghz_protocol_decoder_smc5326_feed(void* context, bool level, uint32_t du
 
 SubGhzProtocolStatus
     subghz_protocol_decoder_smc5326_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolDecoderSMC5326* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_smc5326_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        if(!flipper_format_rewind(flipper_format)) {
-            FURI_LOG_E(TAG, "Rewind error");
-            ret = SubGhzProtocolStatusErrorParserOthers;
-            break;
-        }
-        if(!flipper_format_read_uint32(flipper_format, "TE", (uint32_t*)&instance->te, 1)) {
-            FURI_LOG_E(TAG, "Missing TE");
-            ret = SubGhzProtocolStatusErrorParserTe;
-            break;
-        }
-    } while(false);
-
-    return ret;
+    return subghz_protocol_decoder_common_deserialize_te(
+        context, flipper_format, subghz_protocol_smc5326_const.min_count_bit_for_found);
 }
 
 static void subghz_protocol_smc5326_get_event_serialize(uint8_t event, FuriString* output) {

--- a/lib/subghz/protocols/smc5326.c
+++ b/lib/subghz/protocols/smc5326.c
@@ -56,6 +56,7 @@ struct SubGhzProtocolEncoderSMC5326 {
 
     uint32_t te;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderSMC5326);
 
 typedef enum {
     SMC5326DecoderStepReset = 0,
@@ -98,16 +99,8 @@ const SubGhzProtocol subghz_protocol_smc5326 = {
 
 void* subghz_protocol_encoder_smc5326_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderSMC5326* instance = malloc(sizeof(SubGhzProtocolEncoderSMC5326));
-
-    instance->base.protocol = &subghz_protocol_smc5326;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderSMC5326), &subghz_protocol_smc5326, 3, 128);
 }
 
 /**
@@ -189,10 +182,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_smc5326_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderSMC5326* instance = malloc(sizeof(SubGhzProtocolDecoderSMC5326));
-    instance->base.protocol = &subghz_protocol_smc5326;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderSMC5326), &subghz_protocol_smc5326);
 }
 
 void subghz_protocol_decoder_smc5326_reset(void* context) {

--- a/lib/subghz/protocols/smc5326.c
+++ b/lib/subghz/protocols/smc5326.c
@@ -46,6 +46,7 @@ struct SubGhzProtocolDecoderSMC5326 {
     uint32_t te;
     uint32_t last_data;
 };
+SUBGHZ_ASSERT_DECODER_TE_LAYOUT(SubGhzProtocolDecoderSMC5326);
 
 struct SubGhzProtocolEncoderSMC5326 {
     SubGhzProtocolEncoderBase base;
@@ -70,7 +71,7 @@ const SubGhzProtocolDecoder subghz_protocol_smc5326_decoder = {
     .reset = subghz_protocol_decoder_smc5326_reset,
 
     .get_hash_data = subghz_protocol_decoder_common_get_hash_data,
-    .serialize = subghz_protocol_decoder_smc5326_serialize,
+    .serialize = subghz_protocol_decoder_common_serialize_te,
     .deserialize = subghz_protocol_decoder_smc5326_deserialize,
     .get_string = subghz_protocol_decoder_smc5326_get_string,
 };
@@ -271,22 +272,6 @@ void subghz_protocol_decoder_smc5326_feed(void* context, bool level, uint32_t du
         }
         break;
     }
-}
-
-SubGhzProtocolStatus subghz_protocol_decoder_smc5326_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset) {
-    furi_assert(context);
-    SubGhzProtocolDecoderSMC5326* instance = context;
-    SubGhzProtocolStatus ret =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
-    if((ret == SubGhzProtocolStatusOk) &&
-       !flipper_format_write_uint32(flipper_format, "TE", &instance->te, 1)) {
-        FURI_LOG_E(TAG, "Unable to add TE");
-        ret = SubGhzProtocolStatusErrorParserTe;
-    }
-    return ret;
 }
 
 SubGhzProtocolStatus

--- a/lib/subghz/protocols/smc5326.h
+++ b/lib/subghz/protocols/smc5326.h
@@ -49,18 +49,6 @@ void subghz_protocol_decoder_smc5326_reset(void* context);
 void subghz_protocol_decoder_smc5326_feed(void* context, bool level, uint32_t duration);
 
 /**
- * Serialize data SubGhzProtocolDecoderSMC5326.
- * @param context Pointer to a SubGhzProtocolDecoderSMC5326 instance
- * @param flipper_format Pointer to a FlipperFormat instance
- * @param preset The modulation on which the signal was received, SubGhzRadioPreset
- * @return status
- */
-SubGhzProtocolStatus subghz_protocol_decoder_smc5326_serialize(
-    void* context,
-    FlipperFormat* flipper_format,
-    SubGhzRadioPreset* preset);
-
-/**
  * Deserialize data SubGhzProtocolDecoderSMC5326.
  * @param context Pointer to a SubGhzProtocolDecoderSMC5326 instance
  * @param flipper_format Pointer to a FlipperFormat instance

--- a/lib/subghz/protocols/somfy_keytis.c
+++ b/lib/subghz/protocols/somfy_keytis.c
@@ -28,6 +28,7 @@ struct SubGhzProtocolDecoderSomfyKeytis {
     uint16_t header_count;
     ManchesterState manchester_saved_state;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderSomfyKeytis);
 
 struct SubGhzProtocolEncoderSomfyKeytis {
     SubGhzProtocolEncoderBase base;
@@ -35,6 +36,7 @@ struct SubGhzProtocolEncoderSomfyKeytis {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderSomfyKeytis);
 
 typedef enum {
     SomfyKeytisDecoderStepReset = 0,
@@ -78,26 +80,14 @@ const SubGhzProtocolEncoder subghz_protocol_somfy_keytis_encoder = {
 
 void* subghz_protocol_encoder_somfy_keytis_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderSomfyKeytis* instance = malloc(sizeof(SubGhzProtocolEncoderSomfyKeytis));
-
-    instance->base.protocol = &subghz_protocol_somfy_keytis;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 512;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderSomfyKeytis), &subghz_protocol_somfy_keytis, 3, 512);
 }
 
 void* subghz_protocol_decoder_somfy_keytis_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderSomfyKeytis* instance = malloc(sizeof(SubGhzProtocolDecoderSomfyKeytis));
-    instance->base.protocol = &subghz_protocol_somfy_keytis;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderSomfyKeytis), &subghz_protocol_somfy_keytis);
 }
 
 void subghz_protocol_decoder_somfy_keytis_reset(void* context) {

--- a/lib/subghz/protocols/somfy_keytis.c
+++ b/lib/subghz/protocols/somfy_keytis.c
@@ -241,7 +241,7 @@ bool subghz_protocol_somfy_keytis_create_data(
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderSomfyKeytis instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_somfy_keytis_get_upload(
     SubGhzProtocolEncoderSomfyKeytis* instance,

--- a/lib/subghz/protocols/somfy_telis.c
+++ b/lib/subghz/protocols/somfy_telis.c
@@ -28,6 +28,7 @@ struct SubGhzProtocolDecoderSomfyTelis {
     uint16_t header_count;
     ManchesterState manchester_saved_state;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderSomfyTelis);
 
 struct SubGhzProtocolEncoderSomfyTelis {
     SubGhzProtocolEncoderBase base;
@@ -35,6 +36,7 @@ struct SubGhzProtocolEncoderSomfyTelis {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderSomfyTelis);
 
 typedef enum {
     SomfyTelisDecoderStepReset = 0,
@@ -78,17 +80,8 @@ const SubGhzProtocol subghz_protocol_somfy_telis = {
 
 void* subghz_protocol_encoder_somfy_telis_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderSomfyTelis* instance = malloc(sizeof(SubGhzProtocolEncoderSomfyTelis));
-
-    instance->base.protocol = &subghz_protocol_somfy_telis;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 512;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderSomfyTelis), &subghz_protocol_somfy_telis, 3, 512);
 }
 
 /**
@@ -369,11 +362,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_somfy_telis_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderSomfyTelis* instance = malloc(sizeof(SubGhzProtocolDecoderSomfyTelis));
-    instance->base.protocol = &subghz_protocol_somfy_telis;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderSomfyTelis), &subghz_protocol_somfy_telis);
 }
 
 void subghz_protocol_decoder_somfy_telis_reset(void* context) {

--- a/lib/subghz/protocols/somfy_telis.c
+++ b/lib/subghz/protocols/somfy_telis.c
@@ -193,7 +193,7 @@ bool subghz_protocol_somfy_telis_create_data(
 /**
  * Generating an upload from data.
  * @param instance Pointer to a SubGhzProtocolEncoderSomfyTelis instance
- * @return true On success
+ * @return true Always; this encoder has no failure path
  */
 static bool subghz_protocol_encoder_somfy_telis_get_upload(
     SubGhzProtocolEncoderSomfyTelis* instance,

--- a/lib/subghz/protocols/telcoma_edge.c
+++ b/lib/subghz/protocols/telcoma_edge.c
@@ -74,9 +74,8 @@ const SubGhzProtocol subghz_protocol_telcoma_edge = {
 
 void* subghz_protocol_decoder_telcoma_edge_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderTelcomaEdge* instance = malloc(sizeof(SubGhzProtocolDecoderTelcomaEdge));
-    instance->base.protocol = &subghz_protocol_telcoma_edge;
-    instance->generic.protocol_name = instance->base.protocol->name;
+    SubGhzProtocolDecoderTelcomaEdge* instance = subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderTelcomaEdge), &subghz_protocol_telcoma_edge);
     instance->half_pending = false;
     return instance;
 }

--- a/lib/subghz/protocols/telcoma_edge.c
+++ b/lib/subghz/protocols/telcoma_edge.c
@@ -33,12 +33,14 @@ struct SubGhzProtocolDecoderTelcomaEdge {
     bool half_pending; /* a half-bit sample is buffered, awaiting its pair */
     bool half_level; /* level of the buffered half-bit */
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderTelcomaEdge);
 
 struct SubGhzProtocolEncoderTelcomaEdge {
     SubGhzProtocolEncoderBase base;
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_COMMON_LAYOUT(SubGhzProtocolEncoderTelcomaEdge);
 
 const SubGhzProtocolDecoder subghz_protocol_telcoma_edge_decoder = {
     .alloc = subghz_protocol_decoder_telcoma_edge_alloc,

--- a/lib/subghz/protocols/treadmill37.c
+++ b/lib/subghz/protocols/treadmill37.c
@@ -21,6 +21,7 @@ struct SubGhzProtocolDecoderTreadmill37 {
     SubGhzBlockDecoder decoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_DECODER_COMMON_LAYOUT(SubGhzProtocolDecoderTreadmill37);
 
 struct SubGhzProtocolEncoderTreadmill37 {
     SubGhzProtocolEncoderBase base;
@@ -28,6 +29,7 @@ struct SubGhzProtocolEncoderTreadmill37 {
     SubGhzProtocolBlockEncoder encoder;
     SubGhzBlockGeneric generic;
 };
+SUBGHZ_ASSERT_ENCODER_GENERIC_LAYOUT(SubGhzProtocolEncoderTreadmill37);
 
 typedef enum {
     Treadmill37DecoderStepReset = 0,
@@ -69,16 +71,8 @@ const SubGhzProtocol subghz_protocol_treadmill37 = {
 
 void* subghz_protocol_encoder_treadmill37_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolEncoderTreadmill37* instance = malloc(sizeof(SubGhzProtocolEncoderTreadmill37));
-
-    instance->base.protocol = &subghz_protocol_treadmill37;
-    instance->generic.protocol_name = instance->base.protocol->name;
-
-    instance->encoder.repeat = 3;
-    instance->encoder.size_upload = 128;
-    instance->encoder.upload = malloc(instance->encoder.size_upload * sizeof(LevelDuration));
-    instance->encoder.is_running = false;
-    return instance;
+    return subghz_protocol_encoder_common_alloc(
+        sizeof(SubGhzProtocolEncoderTreadmill37), &subghz_protocol_treadmill37, 3, 128);
 }
 
 /**
@@ -159,10 +153,8 @@ SubGhzProtocolStatus
 
 void* subghz_protocol_decoder_treadmill37_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
-    SubGhzProtocolDecoderTreadmill37* instance = malloc(sizeof(SubGhzProtocolDecoderTreadmill37));
-    instance->base.protocol = &subghz_protocol_treadmill37;
-    instance->generic.protocol_name = instance->base.protocol->name;
-    return instance;
+    return subghz_protocol_decoder_common_alloc(
+        sizeof(SubGhzProtocolDecoderTreadmill37), &subghz_protocol_treadmill37);
 }
 
 void subghz_protocol_decoder_treadmill37_feed(

--- a/lib/subghz/protocols/treadmill37.c
+++ b/lib/subghz/protocols/treadmill37.c
@@ -75,13 +75,18 @@ void* subghz_protocol_encoder_treadmill37_alloc(SubGhzEnvironment* environment) 
         sizeof(SubGhzProtocolEncoderTreadmill37), &subghz_protocol_treadmill37, 3, 128);
 }
 
+static void subghz_protocol_treadmill37_check_remote_controller(SubGhzBlockGeneric* instance);
+
 /**
  * Generating an upload from data.
- * @param instance Pointer to a SubGhzProtocolEncoderTreadmill37 instance
+ * @param context Pointer to a SubGhzProtocolEncoderTreadmill37 instance
+ * @return true Always; this encoder has no failure path
  */
-static void
-    subghz_protocol_encoder_treadmill37_get_upload(SubGhzProtocolEncoderTreadmill37* instance) {
+static bool subghz_protocol_encoder_treadmill37_get_upload(void* context) {
+    SubGhzProtocolEncoderTreadmill37* instance = context;
     furi_assert(instance);
+
+    subghz_protocol_treadmill37_check_remote_controller(&instance->generic);
     size_t index = 0;
 
     // Send key and GAP
@@ -114,7 +119,7 @@ static void
     }
 
     instance->encoder.size_upload = index;
-    return;
+    return true;
 }
 
 /** 
@@ -128,27 +133,11 @@ static void subghz_protocol_treadmill37_check_remote_controller(SubGhzBlockGener
 
 SubGhzProtocolStatus
     subghz_protocol_encoder_treadmill37_deserialize(void* context, FlipperFormat* flipper_format) {
-    furi_assert(context);
-    SubGhzProtocolEncoderTreadmill37* instance = context;
-    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    do {
-        ret = subghz_block_generic_deserialize_check_count_bit(
-            &instance->generic,
-            flipper_format,
-            subghz_protocol_treadmill37_const.min_count_bit_for_found);
-        if(ret != SubGhzProtocolStatusOk) {
-            break;
-        }
-        // Optional value
-        flipper_format_read_uint32(
-            flipper_format, "Repeat", (uint32_t*)&instance->encoder.repeat, 1);
-
-        subghz_protocol_treadmill37_check_remote_controller(&instance->generic);
-        subghz_protocol_encoder_treadmill37_get_upload(instance);
-        instance->encoder.is_running = true;
-    } while(false);
-
-    return ret;
+    return subghz_protocol_encoder_common_deserialize(
+        context,
+        flipper_format,
+        subghz_protocol_treadmill37_const.min_count_bit_for_found,
+        subghz_protocol_encoder_treadmill37_get_upload);
 }
 
 void* subghz_protocol_decoder_treadmill37_alloc(SubGhzEnvironment* environment) {


### PR DESCRIPTION
# What's new

Follow-up to af2370573 ("free space"). Five commits sharing more duplicated bodies, measured against a release build each time.

**`.text` 696,740 → 691,848 = −4,892 B.** Free flash 175.3 → 180.1 KiB. `.rodata` and `.data` unchanged, `api_symbols.csv` untouched, no API version bump.

| commit | what | measured |
|---|---|---|
| `7e530e583` | SubGhz: the `serialize` handlers af2370573 left behind, plus honeywell | −912 B |
| `84aca75eb` | SubGhz: 96 `alloc` bodies | −2,432 B |
| `5f4f4cc2b` | SubGhz: 14 `deserialize` bodies | −496 B |
| `bf5db36cd` | Storage: 12 command-dispatch bodies | −604 B |
| `06738435d` | SubGhz: the allocs and deserializes the first reviews listed as skipped | −448 B |

Two mechanics, chosen per symbol. Where the clone is reached only through a function-pointer table and is not exported, the table entry points at the shared implementation and the function is deleted — exactly what af2370573 did. Where the symbol is exported (all of the Storage ones, some NFC/ibutton), the body moves but the symbol stays as a small tail-call thunk, so nothing changes for FAPs.

Some things worth calling out:

**honeywell's structs were reordered.** `generic` and `decoder` were the wrong way round, which was the only reason af2370853 could not fold six of its handlers. Swapping two members folds them. The structs are opaque outside the `.c`, so nothing else sees it.

**`SUBGHZ_ASSERT_*_LAYOUT` now guards all 114 structs a shared helper punts through** — 14 of those were already being punned by `free`/`stop`/`yield`/`reset`/`serialize` with no guard at all, before this branch. The asserts cost no flash. Pinning only a tail member is not enough: `SubGhzBlockDecoder` (24 B) and `SubGhzBlockGeneric` (48 B) are both multiples of 8, so swapping them leaves later members at the same offset. Verified by restoring honeywell's old order and watching the build fail.

**`min_count_bit` widened from `uint8_t` to `uint16_t`** in the two deserialize helpers — the function it feeds compares against a `uint16_t`, so the narrower parameter would have silently truncated any protocol above 255 bits. None exists today (largest is 128).

## Deliberately not done

- **SubGhz `feed`** — the bodies differ by timing multipliers and a helper needs 5-6 arguments, which spill to the stack on the per-RF-edge hot path. A wrong multiplier breaks decoding silently.
- **35 decoders whose `deserialize` is a single tail call** — they compile to 8 bytes each and a thunk is 6, so folding gains ~70 B for touching 35 files. Poor trade, not a loss.
- **`flipper_format_insert_or_update_*`, canvas draw family** — need 6-argument helpers plus function-pointer casts between incompatible types, for 80-160 B.
- **lfrfid / nfc / furi_hal / ibutton** — SubGhz is foldable because every protocol struct shares a leading member sequence by convention. These do not: each protocol sizes its own buffers, so source-identical bodies compile to different offsets. What is left there is either sub-thunk-sized or differs by *which function it calls* rather than by data, which needs an enum switch that costs more than it saves.

## Known follow-ups (not in this PR)

- The 8 encoders converted in `06738435d` have no upload bound check, unlike the 11 converted in `5f4f4cc2b`. They cannot overrun today — `subghz_block_generic_deserialize_check_count_bit` pins `data_count_bit` by equality before `get_upload` runs — but `keyfinder` has 4 spare entries in a 60-entry buffer. Their doc says "true Always; this encoder has no failure path" rather than claiming a success check they do not perform. Adding the guards wants its own commit.
- Five `check_remote_controller` calls moved into `get_upload` write only `serial`/`btn`/`cnt` on the encoder instance, which nothing reads. They could be deleted rather than moved — a behaviour change, so not here.
- Adding `encoder.front = 0` to the shared `stop` would delete 8 near-duplicate `_stop` bodies and unblock 5 more encoders (~112 B plus). Also a behaviour change for ~50 protocols.

# Verification

Not hardware tested. I have no Flipper to hand for this branch, and that is the main thing a reviewer should close.

What was verified:

- Every commit builds clean at `COMPACT=1 DEBUG=0`, `fbt format` and `scripts/lint.py check` clean.
- `git diff dev..HEAD -- targets/f7/api_symbols.csv` is empty. Every folded symbol either stays as a thunk or was never exported.
- Each of the 96 alloc thunks was compared mechanically against the body it replaced — same `sizeof(type)`, same `&protocol`, same `repeat`/`size_upload`. Zero mismatches.
- Storage: each folded call's return macro was checked against the union member `storage_processing.c` actually writes, since a mismatched `S_RETURN_*` would silently read the wrong member.
- The layout asserts were negative-tested: restoring honeywell's pre-fix member order fails the build with a readable message.

Worth exercising on hardware, in rough priority order:

1. SubGhz save/load for a protocol from each folded family — receive, save, reload, transmit. `beninca_arc`, `jarolift`, `kinggates_stylo_4k` (Data field), `holtek_ht12x`, `legrand`, `smc5326`, `princeton` (TE + Guard_time), `honeywell`.
2. SubGhz "Add manually" for `alutech_at_4n`, `jarolift`, `kinggates_stylo_4k`, `beninca_arc` — those are the `create_data` paths that now share the Data-writing helper.
3. Transmit on the 19 encoders now going through the shared deserialize, especially `keyfinder`, `feron`, `treadmill37`, `revers_rb2`.
4. Anything touching storage: SD info/format/unmount, file browser, app that writes files.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

All five commits were written by Claude (Opus 5) in Claude Code, directed by me.

What the generated code does: it moves duplicated function bodies into shared helpers and leaves either nothing (where a vtable entry can point straight at the shared copy) or a small tail-call thunk (where the symbol is exported and must survive) at each site. New shared code lives in `lib/subghz/protocols/common.{c,h}` — alloc, deserialize, and two serialize helpers, plus the `SUBGHZ_ASSERT_*_LAYOUT` macros that pin the struct prefixes those helpers reach through — and four static dispatch helpers in `applications/services/storage/storage_external_api.c`. Behaviour is intended to be identical, with three documented exceptions, all diagnostics-only: converted paths log under the protocol's user-facing name (`generic.protocol_name`) instead of each file's `TAG`; the encoder `create_data` "Unable to add Data2" message merges with the serialize one; and `beninca_arc`'s `stop`/`yield` lose a debug-only `furi_assert` by adopting the shared versions, matching ~60 other protocols.

Each commit went through a multi-agent review before landing (`/simplify` and `/pr-review-toolkit:review-pr`). That caught real defects in the generated code, which are fixed in the commits as pushed — most seriously a 2 KB-per-transmit heap leak in `alutech_at_4n` where a scripted edit left the old `encoder.upload` malloc in place alongside the helper's, and a dropped `remote_controller` call in `revers_rb2` where the sweep keyed on a function name that file spells differently. Both were invisible to the compiler. I am flagging this because "AI generated, reviewed by more AI" is not the same as human review, and the hardware testing above is genuinely outstanding.
