### PR TITLE
NFC: Save recovered MIFARE Classic keys to the user dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - NFC: **Save recovered MIFARE Classic keys to the user dictionary** - new "Save Keys to Dictionary" action on a read or saved card, so keys found by any attack (including the per-UID dictionary used for static-encrypted-nonce cards) become available to future reads and to NFC Magic; keys the system or user dictionary already holds are skipped (by @mishamyte | PR #1118 | Closes #1117)
 - Apps: Build tag (**1sep2026**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes
+- NFC: Adding a key to a user dictionary no longer rewrites the whole file - it is appended instead of inserted at the end, which also speeds up MFKey32 writing back a batch of recovered keys (by @mishamyte | PR #1118)
 - SubGHz: Fixed a one-past-the-end write when building a transmission (just in case) - the final level duration was stored without a bounds check (by @MNeroba | PR #1105)
 - SubGHz: The free/stop/yield/reset/hash/serialize handlers that were byte-identical across 57 protocols now share one implementation instead of 346 copies, freeing ~6 KB of flash (thanks @apfxtech !)
 - SubGHz & Storage: A further ~4.8 KB of flash freed - the alloc, deserialize and remaining serialize bodies still duplicated across SubGHz protocols, and the twelve Storage API calls that differed only in the command they send, now share one implementation each (by @mishamyte | PR #1116)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - SubGHz: **Read no longer adds a copy of the last received signal a few seconds after it arrived** - the duplicate filter now measures the gap between the signals themselves instead of the time they reached the app, so the last repeat of a burst is recognised as a repeat no matter how late the receiver reports it
 - Desktop: **Second page in the up-button menu** - press left or right there for screen brightness, volume and vibro
 - Infrared: **Save a signal straight from the Universal Remote** - pause the brute force and press down to keep the signal that just worked, as a new remote or appended to an existing one
+- NFC: **Save recovered MIFARE Classic keys to the user dictionary** - new "Save Keys to Dictionary" action on a read or saved card, so keys found by any attack (including the per-UID dictionary used for static-encrypted-nonce cards) become available to future reads and to NFC Magic; keys the system or user dictionary already holds are skipped (by @mishamyte | PR #1118 | Closes #1117)
 - Apps: Build tag (**1sep2026**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes
 - SubGHz: Fixed a one-past-the-end write when building a transmission (just in case) - the final level duration was stored without a bounds check (by @MNeroba | PR #1105)

--- a/applications/main/nfc/helpers/nfc_key_dict.c
+++ b/applications/main/nfc/helpers/nfc_key_dict.c
@@ -115,6 +115,10 @@ size_t nfc_key_dict_collect_from_device(
 
     size_t key_count = 0;
     if(type == NfcKeyDictTypeMfClassic) {
+        // The loaded device and the dictionary type are chosen independently, so check them
+        // against each other here rather than leaving it to nfc_device_get_data(), which crashes
+        // several frames deeper with nothing pointing back at the mismatched pair.
+        furi_check(nfc_device_get_protocol(device) == NfcProtocolMfClassic);
         key_count = nfc_key_dict_collect_mf_classic(device, keys, keys_max, dict->key_size);
     } else {
         // Only the Classic dictionary has a card-side key store to read back. The other three
@@ -137,8 +141,8 @@ static void nfc_key_dict_mark_present(
     size_t key_size,
     bool* known,
     size_t* known_count) {
-    // Covers a dictionary file that is missing or empty: keys_dict_alloc() leaves the stream
-    // closed in that case, and there is nothing to compare against either way.
+    // A missing or empty dictionary reports no keys either way, and there is nothing to
+    // compare against - the missing one also leaves keys_dict_alloc()'s stream closed.
     if(keys_dict_get_total_keys(dict) == 0) return;
 
     uint8_t* dict_key = malloc(key_size);
@@ -150,7 +154,7 @@ static void nfc_key_dict_mark_present(
 
             known[i] = true;
             (*known_count)++;
-            break; // The candidate list is already deduplicated, so one match settles this key.
+            break; // Candidates are deduplicated, so one match settles this dictionary line.
         }
     }
 
@@ -167,28 +171,31 @@ void nfc_key_dict_import(
     furi_check(stats);
 
     const NfcKeyDict* dict = nfc_key_dict(type);
+    const size_t key_size = dict->key_size;
     memset(stats, 0, sizeof(NfcKeyDictImportStats));
+    stats->candidates = key_count;
     if(key_count == 0) return;
 
     bool known[NFC_KEY_DICT_DEVICE_KEYS_MAX] = {};
 
-    // The system dictionary first: it is the larger of the two and holds the factory keys, so
-    // filtering against it is what stops a default-keyed card from doubling the user dictionary.
-    KeysDict* system_dict =
-        keys_dict_alloc(dict->system_path, KeysDictModeOpenExisting, dict->key_size);
-    nfc_key_dict_mark_present(
-        system_dict, keys, key_count, dict->key_size, known, &stats->known_system);
+    // Filtering against the system dictionary is what stops a default-keyed card from doubling
+    // the user dictionary, so a missing one is worth a word: it is not fatal, but it means a
+    // broken install, and every factory key on the card is about to look new.
+    if(!keys_dict_check_presence(dict->system_path)) {
+        FURI_LOG_W(TAG, "System dictionary %s is missing", dict->system_path);
+    }
+    KeysDict* system_dict = keys_dict_alloc(dict->system_path, KeysDictModeOpenExisting, key_size);
+    nfc_key_dict_mark_present(system_dict, keys, key_count, key_size, known, &stats->known);
     keys_dict_free(system_dict);
 
     // One handle for both the read and the append, so the file is not walked a third time.
-    KeysDict* user_dict = keys_dict_alloc(dict->user_path, KeysDictModeOpenAlways, dict->key_size);
-    nfc_key_dict_mark_present(
-        user_dict, keys, key_count, dict->key_size, known, &stats->known_user);
+    KeysDict* user_dict = keys_dict_alloc(dict->user_path, KeysDictModeOpenAlways, key_size);
+    nfc_key_dict_mark_present(user_dict, keys, key_count, key_size, known, &stats->known);
 
     for(size_t i = 0; i < key_count; i++) {
         if(known[i]) continue;
 
-        if(!keys_dict_add_key(user_dict, keys + i * dict->key_size, dict->key_size)) {
+        if(!keys_dict_add_key(user_dict, keys + i * key_size, key_size)) {
             // Stop at the first failure: the cause (full SD, read-only card) applies to the
             // rest as well, and the count already written stays accurate.
             FURI_LOG_E(TAG, "Failed to add a key to %s", dict->user_path);

--- a/applications/main/nfc/helpers/nfc_key_dict.c
+++ b/applications/main/nfc/helpers/nfc_key_dict.c
@@ -2,9 +2,18 @@
 
 #include "../nfc_app_i.h"
 
+#include <furi.h>
+#include <toolbox/keys_dict.h>
+
 #include <nfc/protocols/mf_classic/mf_classic.h>
 #include <nfc/protocols/mf_plus/mf_plus.h>
 #include <nfc/protocols/mf_ultralight/mf_ultralight.h>
+
+#define TAG "NfcKeyDict"
+
+_Static_assert(
+    NFC_KEY_DICT_DEVICE_KEYS_MAX >= MF_CLASSIC_TOTAL_SECTORS_MAX * 2,
+    "A 4K card can hand over two keys per sector");
 
 static const NfcKeyDict nfc_key_dicts[NfcKeyDictTypeNum] = {
     [NfcKeyDictTypeMfClassic] =
@@ -47,4 +56,147 @@ const NfcKeyDict* nfc_key_dict(NfcKeyDictType type) {
     furi_check(dict->key_size > 0 && dict->key_size <= NFC_BYTE_INPUT_STORE_SIZE);
 
     return dict;
+}
+
+/** Append `key` unless the buffer already holds it. Returns the new count. */
+static size_t nfc_key_dict_push_unique(
+    uint8_t* keys,
+    size_t key_count,
+    size_t keys_max,
+    size_t key_size,
+    const uint8_t* key) {
+    if(key_count == keys_max) return key_count;
+
+    for(size_t i = 0; i < key_count; i++) {
+        if(memcmp(keys + i * key_size, key, key_size) == 0) return key_count;
+    }
+
+    memcpy(keys + key_count * key_size, key, key_size);
+    return key_count + 1;
+}
+
+static size_t nfc_key_dict_collect_mf_classic(
+    const NfcDevice* device,
+    uint8_t* keys,
+    size_t keys_max,
+    size_t key_size) {
+    const MfClassicData* data = nfc_device_get_data(device, NfcProtocolMfClassic);
+    const uint8_t sector_num = mf_classic_get_total_sectors_num(data->type);
+
+    size_t key_count = 0;
+    for(uint8_t sector = 0; sector < sector_num; sector++) {
+        const MfClassicSectorTrailer* sec_tr =
+            mf_classic_get_sector_trailer_by_sector(data, sector);
+        // Gated on the found masks, not on the bytes: an unrecovered slot is zero fill, while a
+        // key that genuinely is all zeroes is a real key and has its mask bit set.
+        if(FURI_BIT(data->key_a_mask, sector)) {
+            key_count =
+                nfc_key_dict_push_unique(keys, key_count, keys_max, key_size, sec_tr->key_a.data);
+        }
+        if(FURI_BIT(data->key_b_mask, sector)) {
+            key_count =
+                nfc_key_dict_push_unique(keys, key_count, keys_max, key_size, sec_tr->key_b.data);
+        }
+    }
+
+    return key_count;
+}
+
+size_t nfc_key_dict_collect_from_device(
+    NfcKeyDictType type,
+    const NfcDevice* device,
+    uint8_t* keys,
+    size_t keys_max) {
+    furi_check(device);
+    furi_check(keys);
+    furi_check(keys_max > 0 && keys_max <= NFC_KEY_DICT_DEVICE_KEYS_MAX);
+
+    const NfcKeyDict* dict = nfc_key_dict(type);
+
+    size_t key_count = 0;
+    if(type == NfcKeyDictTypeMfClassic) {
+        key_count = nfc_key_dict_collect_mf_classic(device, keys, keys_max, dict->key_size);
+    } else {
+        // Only the Classic dictionary has a card-side key store to read back. The other three
+        // are fed by hand, so there is nothing to collect until a protocol grows one.
+        FURI_LOG_W(TAG, "No key collector for %s", dict->title);
+    }
+
+    return key_count;
+}
+
+/**
+ * Walk `dict` once, marking every candidate it already holds. Comparing the parsed bytes rather
+ * than keys_dict_is_key_present()'s formatted strings also means a hand-edited lowercase-hex
+ * line still counts as present.
+ */
+static void nfc_key_dict_mark_present(
+    KeysDict* dict,
+    const uint8_t* keys,
+    size_t key_count,
+    size_t key_size,
+    bool* known,
+    size_t* known_count) {
+    // Covers a dictionary file that is missing or empty: keys_dict_alloc() leaves the stream
+    // closed in that case, and there is nothing to compare against either way.
+    if(keys_dict_get_total_keys(dict) == 0) return;
+
+    uint8_t* dict_key = malloc(key_size);
+
+    while(keys_dict_get_next_key(dict, dict_key, key_size)) {
+        for(size_t i = 0; i < key_count; i++) {
+            if(known[i]) continue;
+            if(memcmp(keys + i * key_size, dict_key, key_size) != 0) continue;
+
+            known[i] = true;
+            (*known_count)++;
+            break; // The candidate list is already deduplicated, so one match settles this key.
+        }
+    }
+
+    free(dict_key);
+}
+
+void nfc_key_dict_import(
+    NfcKeyDictType type,
+    const uint8_t* keys,
+    size_t key_count,
+    NfcKeyDictImportStats* stats) {
+    furi_check(keys);
+    furi_check(key_count <= NFC_KEY_DICT_DEVICE_KEYS_MAX);
+    furi_check(stats);
+
+    const NfcKeyDict* dict = nfc_key_dict(type);
+    memset(stats, 0, sizeof(NfcKeyDictImportStats));
+    if(key_count == 0) return;
+
+    bool known[NFC_KEY_DICT_DEVICE_KEYS_MAX] = {};
+
+    // The system dictionary first: it is the larger of the two and holds the factory keys, so
+    // filtering against it is what stops a default-keyed card from doubling the user dictionary.
+    KeysDict* system_dict =
+        keys_dict_alloc(dict->system_path, KeysDictModeOpenExisting, dict->key_size);
+    nfc_key_dict_mark_present(
+        system_dict, keys, key_count, dict->key_size, known, &stats->known_system);
+    keys_dict_free(system_dict);
+
+    // One handle for both the read and the append, so the file is not walked a third time.
+    KeysDict* user_dict = keys_dict_alloc(dict->user_path, KeysDictModeOpenAlways, dict->key_size);
+    nfc_key_dict_mark_present(
+        user_dict, keys, key_count, dict->key_size, known, &stats->known_user);
+
+    for(size_t i = 0; i < key_count; i++) {
+        if(known[i]) continue;
+
+        if(!keys_dict_add_key(user_dict, keys + i * dict->key_size, dict->key_size)) {
+            // Stop at the first failure: the cause (full SD, read-only card) applies to the
+            // rest as well, and the count already written stays accurate.
+            FURI_LOG_E(TAG, "Failed to add a key to %s", dict->user_path);
+            stats->write_failed = true;
+            break;
+        }
+        stats->added++;
+    }
+
+    keys_dict_free(user_dict);
 }

--- a/applications/main/nfc/helpers/nfc_key_dict.h
+++ b/applications/main/nfc/helpers/nfc_key_dict.h
@@ -53,11 +53,16 @@ typedef struct {
 
 const NfcKeyDict* nfc_key_dict(NfcKeyDictType type);
 
-/** @brief Outcome of nfc_key_dict_import(), for the screen that reports it. */
+/**
+ * @brief Outcome of nfc_key_dict_import(), for the screen that reports it.
+ *
+ * added + known == candidates, unless write_failed - the append loop stops at the first
+ * failure, leaving the rest counted nowhere.
+ */
 typedef struct {
+    size_t candidates; /**< Keys offered, i.e. the key_count passed in. */
     size_t added; /**< Keys appended to the user dictionary. */
-    size_t known_system; /**< Keys skipped: already in the system dictionary. */
-    size_t known_user; /**< Keys skipped: already in the user dictionary. */
+    size_t known; /**< Keys skipped: either dictionary already held them. */
     bool write_failed; /**< An append failed (full SD, missing folder, read-only card). */
 } NfcKeyDictImportStats;
 
@@ -68,7 +73,7 @@ typedef struct {
  * not a key. Duplicates are dropped here, because sectors commonly share a key and every
  * duplicate would otherwise cost a full dictionary comparison downstream.
  *
- * @param type      Dictionary the keys belong to; the device must hold that protocol.
+ * @param type      Dictionary the keys belong to; the device must hold that protocol (checked).
  * @param device    Loaded device to read the keys from.
  * @param keys      Output buffer of at least keys_max * nfc_key_dict(type)->key_size bytes.
  * @param keys_max  Capacity of the buffer in keys, at most NFC_KEY_DICT_DEVICE_KEYS_MAX.
@@ -89,7 +94,8 @@ size_t nfc_key_dict_collect_from_device(
  * view first.
  *
  * @param type       Dictionary to import into.
- * @param keys       Keys to import, packed at nfc_key_dict(type)->key_size bytes each.
+ * @param keys       Keys to import, packed at nfc_key_dict(type)->key_size bytes each and
+ *                   free of duplicates - a repeated key would be appended twice.
  * @param key_count  Number of keys, at most NFC_KEY_DICT_DEVICE_KEYS_MAX.
  * @param stats      Filled in with what happened; never NULL.
  */

--- a/applications/main/nfc/helpers/nfc_key_dict.h
+++ b/applications/main/nfc/helpers/nfc_key_dict.h
@@ -8,11 +8,23 @@
  */
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
+
+#include <nfc/nfc_device.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Upper bound on the keys one card can hand to the user dictionary.
+ *
+ * MIFARE Classic 4K: 40 sectors, key A and key B each. Checked against the protocol's own
+ * maximum in nfc_key_dict.c so this cannot drift.
+ */
+#define NFC_KEY_DICT_DEVICE_KEYS_MAX (80)
 
 typedef enum {
     /**
@@ -40,6 +52,52 @@ typedef struct {
 } NfcKeyDict;
 
 const NfcKeyDict* nfc_key_dict(NfcKeyDictType type);
+
+/** @brief Outcome of nfc_key_dict_import(), for the screen that reports it. */
+typedef struct {
+    size_t added; /**< Keys appended to the user dictionary. */
+    size_t known_system; /**< Keys skipped: already in the system dictionary. */
+    size_t known_user; /**< Keys skipped: already in the user dictionary. */
+    bool write_failed; /**< An append failed (full SD, missing folder, read-only card). */
+} NfcKeyDictImportStats;
+
+/**
+ * @brief Collect the distinct keys a loaded device actually recovered.
+ *
+ * Only keys the device reports as found are collected - an unrecovered slot holds zero fill,
+ * not a key. Duplicates are dropped here, because sectors commonly share a key and every
+ * duplicate would otherwise cost a full dictionary comparison downstream.
+ *
+ * @param type      Dictionary the keys belong to; the device must hold that protocol.
+ * @param device    Loaded device to read the keys from.
+ * @param keys      Output buffer of at least keys_max * nfc_key_dict(type)->key_size bytes.
+ * @param keys_max  Capacity of the buffer in keys, at most NFC_KEY_DICT_DEVICE_KEYS_MAX.
+ *
+ * @return Number of keys written to the buffer.
+ */
+size_t nfc_key_dict_collect_from_device(
+    NfcKeyDictType type,
+    const NfcDevice* device,
+    uint8_t* keys,
+    size_t keys_max);
+
+/**
+ * @brief Append the keys that neither dictionary already holds to the user dictionary.
+ *
+ * One pass per dictionary rather than keys_dict_is_key_present() per key, which rescans the
+ * whole file every time. Both files are read in full, so callers should put up the loading
+ * view first.
+ *
+ * @param type       Dictionary to import into.
+ * @param keys       Keys to import, packed at nfc_key_dict(type)->key_size bytes each.
+ * @param key_count  Number of keys, at most NFC_KEY_DICT_DEVICE_KEYS_MAX.
+ * @param stats      Filled in with what happened; never NULL.
+ */
+void nfc_key_dict_import(
+    NfcKeyDictType type,
+    const uint8_t* keys,
+    size_t key_count,
+    NfcKeyDictImportStats* stats);
 
 #ifdef __cplusplus
 }

--- a/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic.c
@@ -17,7 +17,30 @@ enum {
     SubmenuIndexCrackNonces,
     SubmenuIndexUpdate,
     SubmenuIndexShowKeys,
+    SubmenuIndexSaveKeys,
 };
+
+// The keys the card gave up are only reachable from this card until they reach the shared user
+// dictionary - the CUID dictionary in particular is per-UID and invisible to everything else.
+static void nfc_scene_menu_add_save_keys_mf_classic(NfcApp* instance, const MfClassicData* data) {
+    if((data->key_a_mask | data->key_b_mask) == 0) return;
+
+    submenu_add_item(
+        instance->submenu,
+        "Save Keys to Dictionary",
+        SubmenuIndexSaveKeys,
+        nfc_protocol_support_common_submenu_callback,
+        instance);
+}
+
+static bool nfc_scene_menu_on_event_save_keys_mf_classic(NfcApp* instance, uint32_t event) {
+    if(event != SubmenuIndexSaveKeys) return false;
+
+    instance->key_dict_type = NfcKeyDictTypeMfClassic;
+    scene_manager_next_scene(instance->scene_manager, NfcSceneKeyDictImport);
+
+    return true;
+}
 
 static void nfc_scene_info_on_enter_mf_classic(NfcApp* instance) {
     const NfcDevice* device = instance->nfc_device;
@@ -148,6 +171,8 @@ static void nfc_scene_read_menu_on_enter_mf_classic(NfcApp* instance) {
         SubmenuIndexShowKeys,
         nfc_protocol_support_common_submenu_callback,
         instance);
+
+    nfc_scene_menu_add_save_keys_mf_classic(instance, data);
 }
 
 static void nfc_scene_read_success_on_enter_mf_classic(NfcApp* instance) { //-V524
@@ -202,6 +227,8 @@ static void nfc_scene_saved_menu_on_enter_mf_classic(NfcApp* instance) {
         SubmenuIndexShowKeys,
         nfc_protocol_support_common_submenu_callback,
         instance);
+
+    nfc_scene_menu_add_save_keys_mf_classic(instance, data);
 }
 
 static void nfc_scene_emulate_on_enter_mf_classic(NfcApp* instance) {
@@ -237,6 +264,8 @@ static bool nfc_scene_read_menu_on_event_mf_classic(NfcApp* instance, SceneManag
         } else if(event.event == SubmenuIndexShowKeys) {
             scene_manager_next_scene(instance->scene_manager, NfcSceneMfClassicShowKeys);
             consumed = true;
+        } else {
+            consumed = nfc_scene_menu_on_event_save_keys_mf_classic(instance, event.event);
         }
     }
 
@@ -262,6 +291,8 @@ static bool nfc_scene_saved_menu_on_event_mf_classic(NfcApp* instance, SceneMana
         } else if(event.event == SubmenuIndexShowKeys) {
             scene_manager_next_scene(instance->scene_manager, NfcSceneMfClassicShowKeys);
             consumed = true;
+        } else {
+            consumed = nfc_scene_menu_on_event_save_keys_mf_classic(instance, event.event);
         }
     }
 

--- a/applications/main/nfc/scenes/nfc_scene_config.h
+++ b/applications/main/nfc/scenes/nfc_scene_config.h
@@ -53,6 +53,7 @@ ADD_SCENE(nfc, key_dict_list, KeyDictList)
 ADD_SCENE(nfc, key_dict_delete, KeyDictDelete)
 ADD_SCENE(nfc, key_dict_add, KeyDictAdd)
 ADD_SCENE(nfc, key_dict_warn_duplicate, KeyDictWarnDuplicate)
+ADD_SCENE(nfc, key_dict_import, KeyDictImport)
 
 ADD_SCENE(nfc, mf_plus_dict_attack, MfPlusDictAttack)
 ADD_SCENE(nfc, mf_plus_show_keys, MfPlusShowKeys)

--- a/applications/main/nfc/scenes/nfc_scene_key_dict_import.c
+++ b/applications/main/nfc/scenes/nfc_scene_key_dict_import.c
@@ -1,0 +1,83 @@
+#include "../nfc_app_i.h"
+
+#include <dolphin/dolphin.h>
+
+#define TAG "NfcKeyDictImport"
+
+static void nfc_scene_key_dict_import_show_result(
+    NfcApp* instance,
+    const NfcKeyDictImportStats* stats,
+    size_t key_count) {
+    Popup* popup = instance->popup;
+
+    if(stats->write_failed) {
+        notification_message(instance->notifications, &sequence_error);
+        popup_set_icon(popup, 83, 22, &I_WarningDolphinFlip_45x42);
+        popup_set_header(popup, "Save Failed", 64, 3, AlignCenter, AlignTop);
+        nfc_text_store_set(instance, "SD card full\nor read-only");
+    } else {
+        // The two counts are the point of the screen: they say whether this card's keys were
+        // worth carrying in a dictionary every future attack has to walk.
+        popup_set_header(
+            popup,
+            stats->added > 0 ? "Keys Saved" : "Nothing to Add",
+            64,
+            3,
+            AlignCenter,
+            AlignTop);
+        nfc_text_store_set(
+            instance,
+            "New keys: %u\nAlready known: %u",
+            (unsigned)stats->added,
+            (unsigned)(key_count - stats->added));
+    }
+
+    popup_set_text(popup, instance->text_store, 4, 26, AlignLeft, AlignTop);
+    view_dispatcher_switch_to_view(instance->view_dispatcher, NfcViewPopup);
+}
+
+void nfc_scene_key_dict_import_on_enter(void* context) {
+    NfcApp* instance = context;
+    const NfcKeyDict* dict = nfc_key_dict(instance->key_dict_type);
+
+    // Both dictionaries are read in full, and keys_dict_alloc() walks each one once more just to
+    // count - the Classic system dictionary alone is ~67 KB read twice. Put the animated view up
+    // first so the wait is not a frozen copy of the menu we came from.
+    nfc_show_loading_label_popup(instance, "Saving keys to\nuser dictionary", true);
+
+    uint8_t* keys = malloc(NFC_KEY_DICT_DEVICE_KEYS_MAX * dict->key_size);
+    const size_t key_count = nfc_key_dict_collect_from_device(
+        instance->key_dict_type, instance->nfc_device, keys, NFC_KEY_DICT_DEVICE_KEYS_MAX);
+
+    NfcKeyDictImportStats stats = {};
+    nfc_key_dict_import(instance->key_dict_type, keys, key_count, &stats);
+    free(keys);
+
+    nfc_show_loading_label_popup(instance, NULL, false);
+
+    FURI_LOG_I(
+        TAG,
+        "%s: %u of %u keys added (%u in system dict, %u in user dict)",
+        dict->title,
+        (unsigned)stats.added,
+        (unsigned)key_count,
+        (unsigned)stats.known_system,
+        (unsigned)stats.known_user);
+
+    if(stats.added > 0) dolphin_deed(DolphinDeedNfcKeyAdd);
+    nfc_scene_key_dict_import_show_result(instance, &stats, key_count);
+}
+
+bool nfc_scene_key_dict_import_on_event(void* context, SceneManagerEvent event) {
+    UNUSED(context);
+    UNUSED(event);
+
+    // Nothing to consume: the work is done on enter, and Back returns to the menu that sent us.
+    return false;
+}
+
+void nfc_scene_key_dict_import_on_exit(void* context) {
+    NfcApp* instance = context;
+
+    popup_reset(instance->popup);
+}

--- a/applications/main/nfc/scenes/nfc_scene_key_dict_import.c
+++ b/applications/main/nfc/scenes/nfc_scene_key_dict_import.c
@@ -4,17 +4,21 @@
 
 #define TAG "NfcKeyDictImport"
 
-static void nfc_scene_key_dict_import_show_result(
-    NfcApp* instance,
-    const NfcKeyDictImportStats* stats,
-    size_t key_count) {
+static void
+    nfc_scene_key_dict_import_show_result(NfcApp* instance, const NfcKeyDictImportStats* stats) {
     Popup* popup = instance->popup;
 
     if(stats->write_failed) {
+        // The append stops at the first failure, so earlier keys are already on the card. Say how
+        // many, or a partial save is indistinguishable from nothing having happened at all.
         notification_message(instance->notifications, &sequence_error);
         popup_set_icon(popup, 83, 22, &I_WarningDolphinFlip_45x42);
         popup_set_header(popup, "Save Failed", 64, 3, AlignCenter, AlignTop);
-        nfc_text_store_set(instance, "SD card full\nor read-only");
+        nfc_text_store_set(
+            instance,
+            "Saved %u of %u\nSD card full\nor read-only",
+            (unsigned)stats->added,
+            (unsigned)(stats->candidates - stats->known));
     } else {
         // The two counts are the point of the screen: they say whether this card's keys were
         // worth carrying in a dictionary every future attack has to walk.
@@ -29,7 +33,7 @@ static void nfc_scene_key_dict_import_show_result(
             instance,
             "New keys: %u\nAlready known: %u",
             (unsigned)stats->added,
-            (unsigned)(key_count - stats->added));
+            (unsigned)stats->known);
     }
 
     popup_set_text(popup, instance->text_store, 4, 26, AlignLeft, AlignTop);
@@ -41,8 +45,8 @@ void nfc_scene_key_dict_import_on_enter(void* context) {
     const NfcKeyDict* dict = nfc_key_dict(instance->key_dict_type);
 
     // Both dictionaries are read in full, and keys_dict_alloc() walks each one once more just to
-    // count - the Classic system dictionary alone is ~67 KB read twice. Put the animated view up
-    // first so the wait is not a frozen copy of the menu we came from.
+    // count - the Classic system dictionary alone is 4,082 keys over ~67 KB, read twice. Put the
+    // animated view up first so the wait is not a frozen copy of the menu we came from.
     nfc_show_loading_label_popup(instance, "Saving keys to\nuser dictionary", true);
 
     uint8_t* keys = malloc(NFC_KEY_DICT_DEVICE_KEYS_MAX * dict->key_size);
@@ -57,15 +61,14 @@ void nfc_scene_key_dict_import_on_enter(void* context) {
 
     FURI_LOG_I(
         TAG,
-        "%s: %u of %u keys added (%u in system dict, %u in user dict)",
+        "%s: added %u of %u keys, %u already known",
         dict->title,
         (unsigned)stats.added,
-        (unsigned)key_count,
-        (unsigned)stats.known_system,
-        (unsigned)stats.known_user);
+        (unsigned)stats.candidates,
+        (unsigned)stats.known);
 
     if(stats.added > 0) dolphin_deed(DolphinDeedNfcKeyAdd);
-    nfc_scene_key_dict_import_show_result(instance, &stats, key_count);
+    nfc_scene_key_dict_import_show_result(instance, &stats);
 }
 
 bool nfc_scene_key_dict_import_on_event(void* context, SceneManagerEvent event) {

--- a/lib/toolbox/keys_dict.c
+++ b/lib/toolbox/keys_dict.c
@@ -251,8 +251,11 @@ static bool keys_dict_add_key_str(KeysDict* instance, FuriString* key) {
 
     uint32_t actual_pos = stream_tell(instance->stream);
 
+    // Written, not inserted: an insert copies the whole file into a scratch file and back again
+    // (file_stream_delete_and_insert) even with nothing to shift, which at end of file is pure
+    // waste - and quadratic for a caller adding keys in a loop.
     if(stream_seek(instance->stream, 0, StreamOffsetFromEnd) &&
-       stream_insert_string(instance->stream, key)) {
+       stream_write_string(instance->stream, key) == furi_string_size(key)) {
         instance->total_keys++;
         key_added = true;
     }


### PR DESCRIPTION
# What's new

Closes #1117.

Keys the NFC app recovers for a MIFARE Classic card had no way out of that card. They reach `MfClassicData`, the saved dump and the per-UID `/ext/nfc/.cache/<UID>.keys` cache — but never `nfc/assets/mf_classic_dict_user.nfc`, which is the only place other consumers look.

The per-UID (CUID) dictionary is the worst case, since it's the path used for static-encrypted-nonce cards (FM11RF08S) and those keys are visible to nothing else. Read such a card, clone it to a Gen2 magic tag, then try to wipe the clone: NFC Magic runs the user dictionary then the system dictionary, neither has the keys, and it dead-ends at "no keys found".

This adds a **Save Keys to Dictionary** action to the MIFARE Classic read-result and saved-card menus, next to **Show Keys**, shown only when the card actually holds a key. It appends every key the card recovered that neither dictionary already holds.

Because it works from `key_a_mask` / `key_b_mask` rather than from whichever attack filled them, one code path covers keys from the CUID dictionary, nested, MFKey32, a hand-entered key, or a dump imported from Proxmark.

The screen reports both counts (`New keys: 12` / `Already known: 68`), since that is what tells you whether this card's keys were worth carrying in a file every future attack has to walk.

### Implementation notes

- **Batch dedup, not the per-key one.** `keys_dict_is_key_present()` rewinds and rescans the whole file per key, so 80 keys against a 1000-key dictionary would be 80 full walks with the screen frozen. `nfc_key_dict_import()` instead marks candidates during a single `keys_dict_get_next_key()` pass per dictionary. Comparing the parsed bytes rather than the formatted strings also means a hand-edited lowercase-hex line correctly counts as present.
- **Filtering against the system dictionary earns its cost.** Without it, a fully-read factory-key card would append 80 already-known keys and slow every future attack. MFKey32 filters the same way before it adds.
- **Loading view.** Both dictionaries are read in full, and `keys_dict_alloc()` walks each one again just to count — the Classic system dictionary alone is 4,082 keys over ~67 KB, read twice. The scene puts up the animated `loading_label` view via `nfc_show_loading_label_popup()` first, the same treatment the CUID dictionary load got in #1022. Unconditionally, unlike the CUID case, because these passes always happen.
- **No API surface change.** `mf_classic.c` lives in the `nfc_mf_classic` plugin and is dead-stripped from the app, so anything it calls app-side would need a row in `nfc_app_api_table_i.h` — including icons. Putting the work in a generic app-side scene next to the existing `nfc_scene_key_dict*.c` family avoids that: the plugin only sets `key_dict_type` and pushes the scene. No `api_symbols.csv` change.
- Scope is MIFARE Classic. The scene and helper are generic over `NfcKeyDictType`, so MIFARE Plus SL1 can reuse them later.
- **One shared-code fix rides along**, in its own commit: `keys_dict_add_key()` sought to end of file and then *inserted*, which routes through `file_stream_delete_and_insert()` — scratch file created, whole dictionary copied in, one line appended, everything copied back, original truncated, scratch deleted, **per key**. At EOF with nothing to shift that is pure waste, and quadratic for a caller adding keys in a loop. It now writes instead. Every caller already seeks to EOF first, so the result is identical — and MFKey32 gets the same speedup when it writes back a batch of recovered keys (`mfkey.c:508-509`).

A companion change on the apps side covers the other half of the same scenario — NFC Magic reading the per-UID `.keys` cache before falling back to the dictionaries, which fixes clone-then-wipe with no dictionary growth at all: xMasterX/all-the-plugins#257.

### Review pass

Ran the repo's review and simplify toolkits over the branch. Fixes applied in follow-up commits:

- A missing system dictionary silently defeated the filter the feature rests on — every factory key would be appended while the screen still read `Already known: 0`. Now logged, the way `mf_plus_extra_scenes.c:181-184` already does it.
- A partial write reported as a total failure. The counts up to the failure are accurate, so the screen now reads `Saved N of M`.
- Added a protocol check at the boundary: the loaded device and the dictionary type are picked independently, so a mismatch would have crashed inside `nfc_device_get_data()` with nothing pointing at the pair that caused it.
- Collapsed the two "already known" counters into one and moved the candidate total onto the stats struct — nothing branched on the split, both display sites summed it, and only a log line read them apart.
- Corrected two of my own comments: `keys_dict_alloc()` leaves the stream closed for a *missing* file, not an empty one, and the system dictionary is 4,082 keys rather than the ~1,200 I first wrote (fixed above too).

Deliberately not taken, for the record: routing the key collection through `MfClassicKeyCache` (it is dead-stripped from the app image today — `nfc_d.elf.map:1730-1738` — so reusing it would pull it back into the always-resident FAP, against what #1073 bought), and promoting the menu item into the shared `get_features`/`SubmenuIndexCommon*` mechanism (every existing feature flag is a capability several protocols share; this one is Classic-only, so it would put single-consumer surface into infrastructure every protocol runs through).

# Verification

Builds clean (`./fbt fap_nfc`, APPCHK passes) and `scripts/lint.py check` is clean on all touched files. **Not yet verified on hardware** — needs a card with non-default keys to exercise the filter counts.

Manual QA to run:

| # | Steps | Expected |
|---|---|---|
| 1 | Read an MFC card with default keys only, then **Save Keys to Dictionary** | Spinner, then `Nothing to Add` with `New keys: 0`; user dictionary unchanged |
| 2 | Read a card with at least one non-default key, then the same action | `Keys Saved`, `New keys: N` matching the non-default keys; the new keys appear in Extra Actions → MIFARE Classic Keys → List |
| 3 | Repeat step 2 immediately | `Nothing to Add`, `Already known` equals the card's key count; user dictionary size unchanged (no duplicates) |
| 4 | Load a saved dump from the file browser and run the action from the saved-card menu | Same behaviour as from the read menu |
| 5 | Load a UID-only MFC dump with no recovered keys | Menu item is absent |
| 6 | Hand-edit `mf_classic_dict_user.nfc` to hold one of the card's keys in lowercase hex, then run the action | That key counts as `Already known`, not appended again |
| 7 | Run with the SD card removed or write-protected | `Save Failed`, error tone, user dictionary untouched |
| 8 | With a large imported user dictionary, watch the transition into the action | The spinner animates rather than the menu freezing |

The FM11RF08S end-to-end case (read with the CUID dictionary → save keys → clone to Gen2 → wipe the clone) needs the apps-side change as well and will be verified together with it.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

Written with Claude Code, from a problem statement and a design reviewed and adjusted by me before any code was produced. All of it is AI generated:

- `helpers/nfc_key_dict.{h,c}` — `nfc_key_dict_collect_from_device()` walks a loaded card's sector trailers and collects the distinct keys whose found-mask bit is set (mask-gated, because an unrecovered slot holds zero fill while a key that genuinely is all zeroes is real and has its bit set); intra-card duplicates are dropped there, since sectors commonly share a key. `nfc_key_dict_import()` then makes one pass over the system dictionary and one over the user dictionary, marking candidates either already holds, and appends the remainder through the user-dictionary handle it already has open — stopping at the first append failure, because a full or read-only SD applies to the rest too. It reports counts back through `NfcKeyDictImportStats`.
- `scenes/nfc_scene_key_dict_import.c` — raises the loading view, runs collect + import, then renders the result popup (`Keys Saved` / `Nothing to Add` / `Save Failed`) with the two counts, and fires `DolphinDeedNfcKeyAdd` once when something was added.
- `helpers/protocol_support/mf_classic/mf_classic.c` — the menu item in both MFC menus, gated on the found masks, plus its handler.
- Scene registration and the CHANGELOG entry.

Reviewed by me before pushing; the loading-view treatment, the choice to filter against the system dictionary, and the decision to keep the helper app-side rather than exporting through the plugin API table were all deliberate calls made during review.

