### PR TITLE
Plugin loader: skip what it cannot load, and let a scan filter by file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Main changes
-- Current API: 88.6
+- Current API: 88.7
 - SubGHz: **Add Superrollo (GW60) roller-shutter protocol** (KeeLoq HCS361) (67bit rolling code, with CRC) (with add manually support) (PR #1068 | by @rollorentner)
 - SubGHz: **Read no longer adds a copy of the last received signal a few seconds after it arrived** - the duplicate filter now measures the gap between the signals themselves instead of the time they reached the app, so the last repeat of a burst is recognised as a repeat no matter how late the receiver reports it
 - Desktop: **Second page in the up-button menu** - press left or right there for screen brightness, volume and vibro
@@ -8,6 +8,7 @@
 - NFC: **Save recovered MIFARE Classic keys to the user dictionary** - new "Save Keys to Dictionary" action on a read or saved card, so keys found by any attack (including the per-UID dictionary used for static-encrypted-nonce cards) become available to future reads and to NFC Magic; keys the system or user dictionary already holds are skipped (by @mishamyte | PR #1118 | Closes #1117)
 - Apps: Build tag (**8sep2026**) - **Check out more Apps updates and fixes by following** [this link](https://github.com/xMasterX/all-the-plugins/commits/dev)
 ## Other changes
+- SubGHz & System: A stray plugin file in apps_data/subghz/plugins no longer takes external CC1101 support with it - the radio device registry now picks its drivers out of that folder by file name (radio_device_*.fal) rather than mapping every .fal there in full to find out what it is, and the shared plugin loader skips a file it cannot load instead of abandoning the scan, which dropped every plugin listed after it while still reporting success (by @mishamyte | PR #1133 | Closes #1130)
 - Power: Boot no longer reports "Init OK" when the fuel gauge or the charger failed to come up - the result is latched for the whole session, and a gauge that fails there leaves an error battery in the status bar with the low battery shutdown disabled behind it, so a log claiming success sent anyone reading it the wrong way (by @mishamyte | PR #1132)
 - GUI: File browser keeps only the file name of each listed entry instead of its whole path, and rebuilds the full path from the folder it is showing when one is picked - a folder of long names no longer costs a few KB of RAM to display (ported from [Momentum Firmware](https://github.com/Next-Flip/Momentum-Firmware) | by @WillyJL)
 - NFC: Type 4 Tag - selecting a file by EF id now sends P1 = 0x00 rather than 0x02, so cards that reject the "select EF under the current DF" mode can be read (ported from [Momentum Firmware](https://github.com/Next-Flip/Momentum-Firmware) | by @WillyJL)

--- a/applications/debug/unit_tests/tests/subghz/subghz_test.c
+++ b/applications/debug/unit_tests/tests/subghz/subghz_test.c
@@ -9,6 +9,7 @@
 #include <flipper_format/flipper_format_i.h>
 #include <lib/subghz/devices/devices.h>
 #include <lib/subghz/devices/cc1101_configs.h>
+#include <applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h>
 
 #define TAG "SubGhzTest"
 
@@ -948,8 +949,18 @@ MU_TEST(subghz_random_test) {
     mu_assert(subghz_decode_random_test(TEST_RANDOM_DIR_NAME), "Random test error\r\n");
 }
 
+MU_TEST(subghz_device_registry_test) {
+    // subghz_test_init() ran the registry scan, which picks drivers out of a shared folder by
+    // file name - a driver that stops matching disappears with no other symptom.
+    mu_assert(
+        subghz_devices_get_by_name(SUBGHZ_DEVICE_CC1101_EXT_NAME) != NULL,
+        "No " SUBGHZ_DEVICE_CC1101_EXT_NAME " device: is radio_device_cc1101_ext.fal on the "
+        "card, in apps_data/subghz/plugins?\r\n");
+}
+
 MU_TEST_SUITE(subghz) {
     subghz_test_init();
+    MU_RUN_TEST(subghz_device_registry_test);
     MU_RUN_TEST(subghz_keystore_test);
 
     MU_RUN_TEST(subghz_hal_async_tx_test);

--- a/applications/examples/example_plugins/example_plugins_multi.c
+++ b/applications/examples/example_plugins/example_plugins_multi.c
@@ -23,9 +23,10 @@ int32_t example_plugins_multi_app(void* p) {
     PluginManager* manager =
         plugin_manager_alloc(PLUGIN_APP_ID, PLUGIN_API_VERSION, firmware_api_interface);
 
-    if(plugin_manager_load_all(manager, APP_DATA_PATH("plugins")) != PluginManagerErrorNone) {
-        FURI_LOG_E(TAG, "Failed to load all libs");
-        return 0;
+    PluginManagerError error = plugin_manager_load_all(manager, APP_DATA_PATH("plugins"));
+    if(error != PluginManagerErrorNone) {
+        // Not fatal - the plugins that did load are still usable.
+        FURI_LOG_E(TAG, "Failed to load all libs, error %d", error);
     }
 
     uint32_t plugin_count = plugin_manager_get_count(manager);

--- a/applications/examples/example_plugins_advanced/example_advanced_plugins.c
+++ b/applications/examples/example_plugins_advanced/example_advanced_plugins.c
@@ -22,26 +22,24 @@ int32_t example_advanced_plugins_app(void* p) {
     PluginManager* manager = plugin_manager_alloc(
         PLUGIN_APP_ID, PLUGIN_API_VERSION, composite_api_resolver_get(resolver));
 
-    do {
-        // For built-in .fals (fal_embedded==True), use APP_ASSETS_PATH
-        // Otherwise, use APP_DATA_PATH
-        if(plugin_manager_load_all(manager, APP_ASSETS_PATH("plugins")) !=
-           PluginManagerErrorNone) {
-            FURI_LOG_E(TAG, "Failed to load all libs");
-            break;
-        }
+    // For built-in .fals (fal_embedded==True), use APP_ASSETS_PATH
+    // Otherwise, use APP_DATA_PATH
+    PluginManagerError error = plugin_manager_load_all(manager, APP_ASSETS_PATH("plugins"));
+    if(error != PluginManagerErrorNone) {
+        // Not fatal - the plugins that did load are still usable.
+        FURI_LOG_E(TAG, "Failed to load all libs, error %d", error);
+    }
 
-        uint32_t plugin_count = plugin_manager_get_count(manager);
-        FURI_LOG_I(TAG, "Loaded libs: %lu", plugin_count);
+    uint32_t plugin_count = plugin_manager_get_count(manager);
+    FURI_LOG_I(TAG, "Loaded libs: %lu", plugin_count);
 
-        for(uint32_t i = 0; i < plugin_count; i++) {
-            const AdvancedPlugin* plugin = plugin_manager_get_ep(manager, i);
-            FURI_LOG_I(TAG, "plugin name: %s. Calling methods", plugin->name);
-            plugin->method1(228);
-            plugin->method2();
-            FURI_LOG_I(TAG, "Accumulator: %lu", app_api_accumulator_get());
-        }
-    } while(0);
+    for(uint32_t i = 0; i < plugin_count; i++) {
+        const AdvancedPlugin* plugin = plugin_manager_get_ep(manager, i);
+        FURI_LOG_I(TAG, "plugin name: %s. Calling methods", plugin->name);
+        plugin->method1(228);
+        plugin->method2();
+        FURI_LOG_I(TAG, "Accumulator: %lu", app_api_accumulator_get());
+    }
 
     plugin_manager_free(manager);
     composite_api_resolver_free(resolver);

--- a/applications/main/subghz/helpers/subghz_frequency_analyzer_plugin.c
+++ b/applications/main/subghz/helpers/subghz_frequency_analyzer_plugin.c
@@ -8,9 +8,8 @@
 
 #define TAG "SubGhzFrequencyAnalyzer"
 
-/** Not apps_data/subghz/plugins - see the fal_path comment in the plugin's application.fam. */
 #define SUBGHZ_FREQUENCY_ANALYZER_PLUGIN_PATH \
-    EXT_PATH("apps_data/subghz/plugins/features/subghz_frequency_analyzer.fal")
+    EXT_PATH("apps_data/subghz/plugins/subghz_frequency_analyzer.fal")
 
 bool subghz_frequency_analyzer_plugin_load(SubGhz* subghz) {
     furi_assert(!subghz->freq_analyzer_plugin_manager);

--- a/applications/main/subghz_frequency_analyzer/application.fam
+++ b/applications/main/subghz_frequency_analyzer/application.fam
@@ -4,12 +4,6 @@ App(
     targets=["f7"],
     entry_point="subghz_frequency_analyzer_ep",
     requires=["subghz"],
-    # Not the default apps_data/subghz/plugins. The radio device registry scans that folder on
-    # every Sub-GHz start and has to map each .fal before it can tell one is not a radio driver -
-    # and plugin_manager_load_all aborts the scan on the first mismatch, so a foreign file there
-    # drops any radio driver listed after it, external CC1101 support included.
-    # Keep in sync with SUBGHZ_FREQUENCY_ANALYZER_PLUGIN_PATH.
-    fal_path="apps_data/subghz/plugins/features",
     sources=["*.c"],
     # The worker drives the CC1101 registers directly, so hwdrivers puts a second copy of those
     # 320 bytes in the .fal. Exporting them from the firmware instead would trade SD/RAM bytes

--- a/lib/flipper_application/plugins/plugin_manager.c
+++ b/lib/flipper_application/plugins/plugin_manager.c
@@ -47,8 +47,8 @@ void plugin_manager_free(PluginManager* manager) {
     free(manager);
 }
 
-PluginManagerError plugin_manager_load_single(PluginManager* manager, const char* path) {
-    furi_check(manager);
+static PluginManagerError
+    plugin_manager_load_file(PluginManager* manager, const char* path, bool scanning) {
     FlipperApplication* lib = flipper_application_alloc(manager->storage, manager->api_interface);
 
     PluginManagerError error = PluginManagerErrorNone;
@@ -84,7 +84,13 @@ PluginManagerError plugin_manager_load_single(PluginManager* manager, const char
         }
 
         if(strcmp(app_descriptor->appid, manager->application_id) != 0) {
-            FURI_LOG_E(TAG, "Application id mismatch %s", path);
+            // Somebody else's plugin. Naming one file and getting this is a mistake; meeting it
+            // while scanning a directory is just how a shared directory looks.
+            if(scanning) {
+                FURI_LOG_D(TAG, "Not ours, skipping %s", path);
+            } else {
+                FURI_LOG_E(TAG, "Application id mismatch %s", path);
+            }
             error = PluginManagerErrorApplicationIdMismatch;
             break;
         }
@@ -105,21 +111,23 @@ PluginManagerError plugin_manager_load_single(PluginManager* manager, const char
     return error;
 }
 
+PluginManagerError plugin_manager_load_single(PluginManager* manager, const char* path) {
+    furi_check(manager);
+    return plugin_manager_load_file(manager, path, false);
+}
+
 PluginManagerError plugin_manager_load_all(PluginManager* manager, const char* path) {
     furi_check(manager);
     File* directory = storage_file_alloc(manager->storage);
     char file_name_buffer[256];
     FuriString* file_name = furi_string_alloc();
+    PluginManagerError result = PluginManagerErrorNone;
     do {
         if(!storage_dir_open(directory, path)) {
             FURI_LOG_E(TAG, "Failed to open directory %s", path);
             break;
         }
-        while(true) {
-            if(!storage_dir_read(directory, NULL, file_name_buffer, sizeof(file_name_buffer))) {
-                break;
-            }
-
+        while(storage_dir_read(directory, NULL, file_name_buffer, sizeof(file_name_buffer))) {
             furi_string_set(file_name, file_name_buffer);
             if(!furi_string_end_with_str(file_name, ".fal")) {
                 continue;
@@ -128,18 +136,20 @@ PluginManagerError plugin_manager_load_all(PluginManager* manager, const char* p
             path_concat(path, file_name_buffer, file_name);
             FURI_LOG_D(TAG, "Loading %s", furi_string_get_cstr(file_name));
             PluginManagerError error =
-                plugin_manager_load_single(manager, furi_string_get_cstr(file_name));
+                plugin_manager_load_file(manager, furi_string_get_cstr(file_name), true);
 
-            if(error != PluginManagerErrorNone) {
-                FURI_LOG_E(TAG, "Failed to load %s", furi_string_get_cstr(file_name));
-                break;
+            // Keep the first real error and keep scanning, so one unusable file does not cost us
+            // the plugins listed after it. Somebody else's plugin is not one of those errors.
+            if(error != PluginManagerErrorApplicationIdMismatch &&
+               result == PluginManagerErrorNone) {
+                result = error;
             }
         }
     } while(false);
     storage_dir_close(directory);
     storage_file_free(directory);
     furi_string_free(file_name);
-    return PluginManagerErrorNone;
+    return result;
 }
 
 uint32_t plugin_manager_get_count(PluginManager* manager) {

--- a/lib/flipper_application/plugins/plugin_manager.c
+++ b/lib/flipper_application/plugins/plugin_manager.c
@@ -145,6 +145,18 @@ PluginManagerError plugin_manager_load_all(PluginManager* manager, const char* p
                 result = error;
             }
         }
+
+        // storage_dir_read() ends the loop the same way whether it ran out of entries or failed.
+        if(storage_file_get_error(directory) != FSE_NOT_EXIST) {
+            FURI_LOG_E(
+                TAG,
+                "Failed to read directory %s: %s",
+                path,
+                storage_file_get_error_desc(directory));
+            if(result == PluginManagerErrorNone) {
+                result = PluginManagerErrorLoaderError;
+            }
+        }
     } while(false);
     storage_dir_close(directory);
     storage_file_free(directory);

--- a/lib/flipper_application/plugins/plugin_manager.c
+++ b/lib/flipper_application/plugins/plugin_manager.c
@@ -116,7 +116,10 @@ PluginManagerError plugin_manager_load_single(PluginManager* manager, const char
     return plugin_manager_load_file(manager, path, false);
 }
 
-PluginManagerError plugin_manager_load_all(PluginManager* manager, const char* path) {
+PluginManagerError plugin_manager_load_all_prefixed(
+    PluginManager* manager,
+    const char* path,
+    const char* fal_prefix) {
     furi_check(manager);
     File* directory = storage_file_alloc(manager->storage);
     char file_name_buffer[256];
@@ -130,6 +133,12 @@ PluginManagerError plugin_manager_load_all(PluginManager* manager, const char* p
         while(storage_dir_read(directory, NULL, file_name_buffer, sizeof(file_name_buffer))) {
             furi_string_set(file_name, file_name_buffer);
             if(!furi_string_end_with_str(file_name, ".fal")) {
+                continue;
+            }
+
+            // Cheap pre-check: reading an app id costs a full load.
+            if(fal_prefix && !furi_string_start_with_str(file_name, fal_prefix)) {
+                FURI_LOG_D(TAG, "Not ours, skipping %s", file_name_buffer);
                 continue;
             }
 
@@ -162,6 +171,10 @@ PluginManagerError plugin_manager_load_all(PluginManager* manager, const char* p
     storage_file_free(directory);
     furi_string_free(file_name);
     return result;
+}
+
+PluginManagerError plugin_manager_load_all(PluginManager* manager, const char* path) {
+    return plugin_manager_load_all_prefixed(manager, path, NULL);
 }
 
 uint32_t plugin_manager_get_count(PluginManager* manager) {

--- a/lib/flipper_application/plugins/plugin_manager.h
+++ b/lib/flipper_application/plugins/plugin_manager.h
@@ -62,6 +62,24 @@ PluginManagerError plugin_manager_load_single(PluginManager* manager, const char
 PluginManagerError plugin_manager_load_all(PluginManager* manager, const char* path);
 
 /**
+ * @brief Loads all plugins from specified directory whose file name starts with a prefix
+ *
+ * Use this when the directory is shared with plugins of another kind. An app id mismatch is only
+ * visible once the image has been mapped, relocated and its init run, all of which a file name
+ * check costs nothing to avoid.
+ *
+ * @param manager PluginManager instance
+ * @param path Path to directory
+ * @param fal_prefix Prefix the file name must start with, compared case-sensitively, or NULL to
+ *  consider every *.fal
+ * @return As plugin_manager_load_all(), over the files whose name matches the prefix
+ */
+PluginManagerError plugin_manager_load_all_prefixed(
+    PluginManager* manager,
+    const char* path,
+    const char* fal_prefix);
+
+/**
  * @brief Returns number of loaded plugins
  * @param manager PluginManager instance
  * @return Number of loaded plugins

--- a/lib/flipper_application/plugins/plugin_manager.h
+++ b/lib/flipper_application/plugins/plugin_manager.h
@@ -48,9 +48,16 @@ PluginManagerError plugin_manager_load_single(PluginManager* manager, const char
 
 /**
  * @brief Loads all plugins from specified directory
+ *
+ * A file that cannot be loaded is skipped, so it does not cost the plugins listed after it, and
+ * a plugin belonging to another application is passed over rather than reported as a failure.
+ *
  * @param manager PluginManager instance
  * @param path Path to directory
- * @return Error code
+ * @return PluginManagerErrorNone if the whole directory was read and every plugin of this
+ *  application in it loaded - a directory that cannot be opened holds none, and so counts as
+ *  success. Otherwise the error of one that did not; use plugin_manager_get_count() for how many
+ *  did.
  */
 PluginManagerError plugin_manager_load_all(PluginManager* manager, const char* path);
 

--- a/lib/subghz/devices/registry.c
+++ b/lib/subghz/devices/registry.c
@@ -22,15 +22,21 @@ void subghz_device_registry_init(void) {
         SUBGHZ_RADIO_DEVICE_PLUGIN_API_VERSION,
         firmware_api_interface);
 
-    //TODO FL-3556: fix path to plugins
-    //if(plugin_manager_load_all(subghz_device->manager, APP_DATA_PATH("plugins")) !=
-    //
-    if(plugin_manager_load_all(subghz_device->manager, EXT_PATH("apps_data/subghz/plugins")) !=
-       PluginManagerErrorNone) {
-        FURI_LOG_E(TAG, "Failed to load all libs");
+    //TODO FL-3556: should be APP_DATA_PATH("plugins"), not a hardcoded /ext path
+    PluginManagerError error = plugin_manager_load_all_prefixed(
+        subghz_device->manager,
+        EXT_PATH("apps_data/subghz/plugins"),
+        SUBGHZ_RADIO_DEVICE_PLUGIN_FAL_PREFIX);
+    uint32_t plugin_count = plugin_manager_get_count(subghz_device->manager);
+    if(error != PluginManagerErrorNone) {
+        FURI_LOG_E(TAG, "Failed to load a radio device plugin, error %d", error);
+    } else if(plugin_count == 0) {
+        // A driver skipped over its name is only logged at debug level, and a missing one shows
+        // up as nothing more than the external module no longer being offered.
+        FURI_LOG_W(TAG, "No " SUBGHZ_RADIO_DEVICE_PLUGIN_FAL_PREFIX "*.fal loaded");
     }
 
-    subghz_device->size = plugin_manager_get_count(subghz_device->manager) + 1;
+    subghz_device->size = plugin_count + 1;
     subghz_device->items =
         (const SubGhzDevice**)malloc(sizeof(SubGhzDevice*) * subghz_device->size);
     subghz_device->items[0] = &subghz_device_cc1101_int;

--- a/lib/subghz/devices/types.h
+++ b/lib/subghz/devices/types.h
@@ -14,6 +14,10 @@
 #define SUBGHZ_RADIO_DEVICE_PLUGIN_APP_ID      "subghz_radio_device"
 #define SUBGHZ_RADIO_DEVICE_PLUGIN_API_VERSION 2
 
+/** A radio device plugin's appid, and so its .fal file name, has to start with this - the
+ * registry skips everything else sharing its folder rather than loading it to find out. */
+#define SUBGHZ_RADIO_DEVICE_PLUGIN_FAL_PREFIX "radio_device_"
+
 typedef struct SubGhzDeviceRegistry SubGhzDeviceRegistry;
 typedef struct SubGhzDevice SubGhzDevice;
 typedef struct SubGhzDeviceConf SubGhzDeviceConf;

--- a/scripts/fbt/appmanifest.py
+++ b/scripts/fbt/appmanifest.py
@@ -87,11 +87,6 @@ class FlipperApplication:
     fap_private_libs: List[Library] = field(default_factory=list)
     fap_file_assets: Optional[str] = None
     fal_embedded: bool = False
-    # Directory a plugin is deployed to, relative to the resources root. Defaults to
-    # apps_data/<parent appid>/plugins - override when the parent scans that folder for
-    # plugins of a different kind and must not be handed this one. One value for all of
-    # `requires`, and ignored entirely when fal_embedded is set.
-    fal_path: Optional[str] = None
     # Internally used by fbt
     _appmanager: Optional["AppManager"] = None
     _appdir: Optional[object] = None

--- a/scripts/fbt_tools/fbt_extapps.py
+++ b/scripts/fbt_tools/fbt_extapps.py
@@ -208,8 +208,7 @@ class AppBuilder:
                         source=app_artifacts.compact,
                     )
                 else:
-                    fal_dir = self.app.fal_path or f"apps_data/{parent_app_id}/plugins"
-                    fal_path = f"{fal_dir}/{app_artifacts.compact.name}"
+                    fal_path = f"apps_data/{parent_app_id}/plugins/{app_artifacts.compact.name}"
                     deployable = True
                     # If it's a plugin for a non-deployable app, don't include it in the resources
                     if parent_app := self.app._appmanager.get(parent_app_id):

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,88.6,,
+Version,+,88.7,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/applications.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
@@ -3272,6 +3272,7 @@ Function,+,plugin_manager_get,const FlipperAppPluginDescriptor*,"PluginManager*,
 Function,+,plugin_manager_get_count,uint32_t,PluginManager*
 Function,+,plugin_manager_get_ep,const void*,"PluginManager*, uint32_t"
 Function,+,plugin_manager_load_all,PluginManagerError,"PluginManager*, const char*"
+Function,+,plugin_manager_load_all_prefixed,PluginManagerError,"PluginManager*, const char*, const char*"
 Function,+,plugin_manager_load_single,PluginManagerError,"PluginManager*, const char*"
 Function,-,popen,FILE*,"const char*, const char*"
 Function,+,popup_alloc,Popup*,


### PR DESCRIPTION
# What's new

Closes #1130.

`plugin_manager_load_all()` had two properties that together made a plugin directory unsafe to share between two kinds of plugin:

1. **It mapped and *ran* every `.fal` before it could reject one.** The app id lives in the plugin descriptor, and `flipper_application_plugin_get_descriptor()` only hands that back after `flipper_application_map_to_memory()` has allocated and relocated the whole image, `elf_file_call_init()` has run the plugin's preinit/init arrays, and its entry point has been called. So "is this mine?" was answered only after another app's plugin had already had its constructors and entry point executed, against an API interface it was not built for.
2. **It aborted the whole scan on the first failure.** Any per-file error `break`ed out of the directory loop instead of skipping that file, and the function then returned `PluginManagerErrorNone` unconditionally — so every caller's error check was dead by construction, the `FURI_LOG_E(TAG, "Failed to load all libs")` in the Sub-GHz radio device registry among them.

`subghz_device_registry_init()` scans `apps_data/subghz/plugins` on every `subghz_devices_init()`, which runs on every Sub-GHz app start and from the Sub-GHz CLI and JS module. `apps_data/<parent appid>/plugins` is fbt's own default location for any plugin of an app, so a second kind of Sub-GHz plugin landing there cost a full map, relocate and init on every start — and silently dropped any radio driver enumerated after it. `radio_device_cc1101_ext.fal` sorts late, so in practice that meant external CC1101 support disappearing with no error anywhere the user could see.

Five commits, one change each:

- **Skip a plugin that fails to load instead of ending the scan.** `continue` rather than `break`, and return the first error the scan hit so a caller can tell a complete load from a partial one. An app id mismatch is *not* folded into that result: a scan selects, and a plugin belonging to another app is the case the prefix filter below exists to make cheap, not a failure. That verdict is decided once, inside the loader — the shared body of `plugin_manager_load_single()` moves into a static helper that takes whether it is scanning, so naming one file and getting a mismatch still logs an error while meeting one mid-scan logs at debug. A directory that cannot be opened holds no plugins and still returns success, as before — only its existing `FURI_LOG_E` reports it. Both plugin examples are updated to log and carry on rather than discard the plugins that did load, since that branch was unreachable until now and they are what third-party hosts get copied from.
- **Tell a failed directory read from the end of the directory.** `storage_dir_read()` returns false for both, with the difference only in `storage_file_get_error()`, so a card pulled mid-scan used to leave a half-populated manager reporting success. Now it reports `PluginManagerErrorLoaderError`.
- **Let a directory scan filter by file name prefix.** New `plugin_manager_load_all_prefixed()`, which passes over any `.fal` not starting with the given prefix for the cost of a string compare. Same idea as `CliCommandExternalConfig::fal_prefix`, which is why the CLI registry has its own loader. `plugin_manager_load_all()` keeps its signature and becomes the NULL-prefix case, so nothing already built has to change. **API 88.6 → 88.7** (one added symbol, minor bump).
- **The radio device registry passes `radio_device_`.** Every radio driver is named that way already, so nothing is renamed. It now logs *which* error the scan returned, and warns when the scan yielded no driver at all — otherwise the external module simply stops being offered with nothing said. A unit test in the existing Sub-GHz suite asserts the driver is still found, since that is the one regression this commit could introduce.
- **The Frequency Analyzer plugin moves back to `apps_data/subghz/plugins/`** and the `fal_path` manifest field added by #1131 to keep it out of that folder is deleted, along with its two-line fbt change. Nothing else used it, and it never shipped in a release, so no SDK consumer can be relying on it.

What it costs: about **+137 B of flash** — +94 B `.text` and +35 B `.rodata` in `plugin_manager.o`, measured at the `-Og` this library is pinned to, plus 8 B of API table for the added symbol. What it buys, on every `subghz_devices_init()`: the ~5.1 KB transient heap allocation, ~7 KB of SD reads, several hundred relocations and the entry-point call that mapping `subghz_frequency_analyzer.fal` costs before its app id can be read. The two new `FURI_LOG_D` lines are free — `lib/flipper_application` is built with `-DLOGS_RELEASE_BUILD`, so they preprocess away.

Things worth flagging:

- **A third-party radio driver named something other than `radio_device_*.fal` would stop being picked up.** The only driver in the tree — and the only naming an out-of-tree one could have copied — is `radio_device_cc1101_ext.fal`. This is why the prefix is a parameter of the loader rather than a rule baked into it, why `SUBGHZ_RADIO_DEVICE_PLUGIN_FAL_PREFIX` documents the requirement, and why the registry warns when it ends up with no driver. Note that the `count == 0` warning cannot see "one of two drivers vanished" — if a second radio driver is ever added, the unit test asserting `cc1101_ext` by name is the guard that still covers naming drift.
- **Why not put the plugin app id in the `.fapmeta` manifest** so `flipper_application_preload()` could read it without loading anything: every `.fal` already on a card would carry an empty field, so the load-and-check fallback would have to stay and the hazard would only shrink; reading the manifest still costs an `elf_file_open` plus a section-table walk per foreign file, against zero for a compare on a directory entry already in hand, so the name gate would be wanted in front of it anyway; and it would mean either a manifest version bump touching every `.fap` and `.fal` on every SD card, or overloading the existing UI `name` field with a matching key.
- **The filter is prefix-only, deliberately.** NFC picks its plugins out of a shared folder by *suffix* (`_parser.fal`), so it cannot use this and keeps its own scan. Generalising to both was more API than this fix needs.

Known follow-ups, all pre-existing and out of scope here: `registry.c` stores `plugin_manager_get_ep()` into its array with no NULL check, where `loader.c:662` guards exactly that; there is no unit test for `lib/flipper_application` itself, which would want a small fixture-copying suite of its own; and this same `.fal` directory scan now exists in four places (`plugin_manager.c`, `cli_registry.c`, `test_runner.c`, `desktop_settings_app.c`), of which `cli_registry.c` still has no end-of-scan error check at all — the same gap the second commit closes here, so a truncated read there silently drops external CLI commands. Extracting one shared walker wants a home decision this PR should not be making.

# Verification

Release build (`COMPACT=1 DEBUG=0`), `flash_usb_full` to a Flipper Zero, hw ver 12. Device reports the branch commit and `firmware_api_minor: 7`. The resource update also removed the now-unused `apps_data/subghz/plugins/features/` directory, so no stale copy of the analyzer plugin is left behind.

**Deployment.** `storage list /ext/apps_data/subghz/plugins` afterwards:

```
[F] radio_device_cc1101_ext.fal 15948b
[F] subghz_frequency_analyzer.fal 15564b
```

Both plugins now share the folder — the situation this PR makes safe.

**1. The foreign plugin is never loaded.** On a fresh boot, opening Sub-GHz takes free heap 133,568 → 73,272 B, and the *minimum* heap watermark bottoms at 73,200 B — 72 B below the steady state. Mapping `subghz_frequency_analyzer.fal` costs ~5.1 KB, so the watermark shows it was rejected on its name without being loaded at all.

**2. A plugin that fails to load no longer takes the driver with it.** `subghz_frequency_analyzer.fal` was copied to `radio_device_bad.fal` — a valid plugin with the right file name prefix but the wrong app id — and placed so the directory enumerates it *before* `radio_device_cc1101_ext.fal`:

```
[F] radio_device_bad.fal 15564b
[F] subghz_frequency_analyzer.fal 15564b
[F] radio_device_cc1101_ext.fal 15948b
```

Free heap with Sub-GHz open, all three states measured within one boot so the figures are comparable:

| state | free heap, Sub-GHz open |
| --- | --- |
| `radio_device_bad.fal` present, enumerated first | 73,296 B |
| bad file renamed away | 72,960 B |
| bad file *and* `radio_device_cc1101_ext.fal` renamed away | 78,784 B |

The third row is the control: the driver holds 5,824 B while loaded, so its absence shows up as that much more free heap. The first row sits within 336 B of the second, i.e. the driver is loaded in both — the bad file in front of it costs nothing. Before this change the scan stopped at that mismatch and never reached the driver, which is what the third row looks like.

**3. The analyzer still loads, from its new path.** Sub-GHz → Frequency Analyzer: free heap 72,984 → 64,304 B on entering (−8,680 B, matching the −8,984 B measured in #1131), back to 72,632 B on leaving.

**4. Unit test — built, not executed.** `fap_test_subghz` builds, links and passes `APPCHK` with the new assertion. I could not run the suite: `./fbt FIRMWARE_APP_SET=unit_tests` does not link on `dev` as it stands, with `unit_test_api_table.o` leaving `js_value_buffer_size`, `js_thread_stop` and `js_value_parse` undefined — pre-existing and unrelated to anything here (happy to file it separately). The test's one environmental precondition is settled statically instead: `radio_device_cc1101_ext.fal` deploys to `apps_data/subghz/plugins/` in every app set, since `fbt_extapps.py` derives that path from the plugin's `requires=["subghz"]` and `subghz` is `is_default_deployable`. What the assertion checks — that the driver is present in the registry after the scan — is what row two of the table above measures directly.

Build and checks: firmware, `fap_radio_device_cc1101_ext`, `fap_subghz_frequency_analyzer`, `fap_example_plugins_multi`, `fap_example_advanced_plugins` and `fap_test_subghz` all build clean; `fbt lint` clean; `scripts/lint.py` clean on `lib/flipper_application/plugins` (which `fbt lint` does not cover); `fbt lint_py` reports only four pre-existing files, none of them touched here.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

Written with Claude Code, reviewed and hardware-tested by me before opening.

The generated code is: the rewrite of `plugin_manager_load_all()` in `lib/flipper_application/plugins/plugin_manager.c` into `plugin_manager_load_all_prefixed()` — same directory walk, but it skips a file whose name does not match the caller's prefix, skips rather than aborts on a file that fails to load, treats an app id mismatch as a selection rather than an error, checks `storage_file_get_error()` for a read that ended the loop early, and returns the first error it hit instead of a hardcoded success; the one-line `plugin_manager_load_all()` wrapper that passes a NULL prefix; the doc comments for both and the new `SUBGHZ_RADIO_DEVICE_PLUGIN_FAL_PREFIX` constant; the `plugin_manager_load_all_prefixed` call and the two log lines in `subghz_device_registry_init()`; the `subghz_device_registry_test` assertion in the existing Sub-GHz unit test suite; the "log and carry on" change in both plugin examples; and the reverts of the `fal_path` manifest field and the Frequency Analyzer plugin's deploy path.

# Checklist (For Reviewer) (Don't fill this out!):

- [ ] PR has proper description of new feature/bugfix
- [ ] Description contains actions to verify feature/bugfix on the hardware
- [ ] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
