### PR TITLE
SubGHz: correct the radio poll comments after the split in #1139

### DIFF
--- a/applications/main/subghz/helpers/subghz_txrx.c
+++ b/applications/main/subghz/helpers/subghz_txrx.c
@@ -236,8 +236,8 @@ void subghz_txrx_get_frequency_and_modulation(
 //Common tail of both polls: re-run set(), which is the only thing that actually
 //self-tests a module, and report whether that moved us to a different radio
 static bool subghz_txrx_radio_device_probe(SubGhzTxRx* instance) {
-    //stamped before the probe, not after a failure, so the re-entry from
-    //rx_start() below cannot immediately pay for a second one
+    //Stamped on every probe, cheap path included, so a module that just dropped out
+    //is not hunted for again on the next trip through the menu
     instance->radio_device_probe_tick = furi_get_tick();
     const SubGhzRadioDeviceType was = instance->radio_device_type;
     if(subghz_txrx_radio_device_set(instance, SubGhzRadioDeviceTypeExternalCC1101) == was) {

--- a/applications/main/subghz/helpers/subghz_txrx.h
+++ b/applications/main/subghz/helpers/subghz_txrx.h
@@ -132,6 +132,11 @@ void subghz_txrx_sleep(SubGhzTxRx* instance);
 
 /**
  * Update frequency CC1101 in automatic mode (hopper)
+ *
+ * Hopping does not check the radio itself - a hop is the hot path, and paying for
+ * it once per hop is what that check would cost. Callers must run
+ * subghz_txrx_radio_device_poll_active() earlier in the same tick, or an external
+ * module that was unplugged will keep being hopped on a dead bus
  * 
  * @param instance Pointer to a SubGhzTxRx
  * @param stay_threshold RSSI theshold over which to stay before hopping

--- a/applications/main/subghz/helpers/subghz_txrx_i.h
+++ b/applications/main/subghz/helpers/subghz_txrx_i.h
@@ -26,7 +26,7 @@ struct SubGhzTxRx {
     //An external module was asked for and answered; radio_device_type is what is
     //actually driving right now, and the two part company when one is unplugged
     bool radio_device_external_wanted;
-    //When the last search for a missing module ran, see the probe period
+    //When the last probe of any kind ran, see the probe period
     uint32_t radio_device_probe_tick;
 
     SubGhzTxRxNeedSaveCallback need_save_callback;


### PR DESCRIPTION
# What's new

Comment-only follow-up to #1139. Splitting the radio poll into a cheap check (`subghz_txrx_radio_device_poll()`) and a rate-limited search (`subghz_txrx_radio_device_poll_reacquire()`) was the right call — it made the cost visible at the call site instead of hiding a ~290 ms branch inside a function that was usually ~20 µs. It left three comments describing the shape the code had before the split.

**`subghz_txrx_radio_device_probe()`** still claimed the probe tick was stamped early so *"the re-entry from `rx_start()` below cannot immediately pay for a second one"*. There is no `rx_start()` below it any more, and that re-entry now returns at the top of `poll()`, since by then `radio_device_type` is `Internal`. What the early stamp actually buys after the split is that a module which just dropped out is not hunted for again on the next trip through the menu — worth keeping, worth describing correctly.

**`radio_device_probe_tick`** said it recorded when the last search for a *missing* module ran. `probe()` stamps it on the cheap path too, so it records the last probe of any kind.

**`subghz_txrx_hopper_update()`** is public, and after the split it depends on its callers having run `subghz_txrx_radio_device_poll_active()` earlier in the same tick. That holds for both callers today (`subghz_scene_receiver.c`, `subghz_scene_receiver_info.c`) and is exactly why a hop pays nothing for the check — but it was only written down at the call sites, which is not where someone adding a third caller would look. Documented on the declaration.

No functional change; the diff is three comments.

Considered and rejected: a `furi_assert` on the hopper precondition. A module can genuinely be unplugged in the window between the tick's poll and the hop, so it would crash debug builds on a legitimate race — and any check that actually works at runtime is the per-hop poll that #1139 deliberately removed for cost.

# Verification

`./fbt firmware_all` and `./fbt lint` clean. Nothing to verify on hardware — no instruction changes.

# Author Checklist (Fill this out):

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if it exists)

# AI usage disclosure (Fill this out):

Tick exactly one - leaving all three blank reads as "not filled out" rather than "no AI".

- [ ] No AI assistance.
- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

Written with Claude Code. The change is three comments, no code: a corrected rationale on the probe-tick stamp in `subghz_txrx_radio_device_probe()`, a corrected description of what `radio_device_probe_tick` records, and a new paragraph on `subghz_txrx_hopper_update()`'s declaration stating the poll-before-hop precondition its two callers satisfy. Found by re-reading the merged result of #1139 against the state the comments were originally written for.

# Checklist (For Reviewer) (Don't fill this out!):

- [ ] PR has proper description of new feature/bugfix
- [ ] Description contains actions to verify feature/bugfix on the hardware
- [ ] No obvious issues with the code was found
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
